### PR TITLE
amended typo in link from htpp to http

### DIFF
--- a/app/views/session_invitation_mailer/invite_coach.html.haml
+++ b/app/views/session_invitation_mailer/invite_coach.html.haml
@@ -20,7 +20,7 @@
 
                 %p You can find all of our tutorials at #{link_to "http://codebar.github.io/tutorials", "http://codebar.github.io/tutorials/"}. If you would like to improve any of the existing content, you can issue a pull request to our #{link_to "github repository", "https://github.com/codebar/tutorials"}
 
-                %p Before attending, make sure you read and understand our #{link_to "code of conduct", "http://codebar.io/code-of-conduct"} as we have a zero tolerance policy and expect everyone to behave appropriately. You should also go through our #{link_to "How to be an effective teacher", "htpp://codebar.io/effective-teacher-guide"}. If you have anything to add to it, please open a pull request or an issue.
+                %p Before attending, make sure you read and understand our #{link_to "code of conduct", "http://codebar.io/code-of-conduct"} as we have a zero tolerance policy and expect everyone to behave appropriately. You should also go through our #{link_to "How to be an effective teacher", "http://codebar.io/effective-teacher-guide"}. If you have anything to add to it, please open a pull request or an issue.
 
                 %p.callout It would be awesome if you could also #{link_to "join the chat on gitter", "https://gitter.im/codebar/tutorials"} to offer help and guidance outside the workshops.
 


### PR DESCRIPTION
There is a typo in the coach invitation ("htpp" rather than "http").

It stops the link from working automatically from the mail client (mine, anyway).

Please note: I've read the guidelines for contributing and my fork is installed on a machine running rails, and the code has been viewed and changed in Aptana as a Rails project. However, I'm not a rails programmer and certainly do not know how to test the mailer.

So, this pull request has NOT BEEN TESTED. Apologies if this is annoying or wastes somebody's time. I perfectly understand if this pull request is rejected.
