### PR TITLE
csv response on workshop invitation page - suitable for name badge use.

### DIFF
--- a/app/views/invitation/show.csv.haml
+++ b/app/views/invitation/show.csv.haml
@@ -1,0 +1,6 @@
+- csv_string = CSV.generate do |csv|
+  - @invitation.sessions.attending_students.each do |invitation|
+    - csv << [invitation.member.full_name, 'STUDENT ' + truncate(invitation.note, length: 100 ) ]
+  - @invitation.sessions.attending_coaches.each do |invitation|
+    - csv << [ invitation.member.full_name, 'COACH' ]
+= csv_string

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,3 +27,5 @@ module Planner
     config.i18n.enforce_available_locales = false
   end
 end
+
+require 'csv' # the standard library CSV Class


### PR DESCRIPTION
Hi, this makes it easy to get a CSV list of students and coaches by just adding .csv to the end of the invitation page. All of the data is already in the regular .html version. 
