### PR TITLE
Don't html encode csv output

### DIFF
--- a/app/views/invitation/show.csv.haml
+++ b/app/views/invitation/show.csv.haml
@@ -3,4 +3,4 @@
     - csv << [invitation.member.full_name, 'STUDENT ' + truncate(invitation.note, length: 100 ) ]
   - @invitation.sessions.attending_coaches.each do |invitation|
     - csv << [ invitation.member.full_name, 'COACH' ]
-= csv_string
+= raw csv_string


### PR DESCRIPTION
The CSV library already does it's own required escaping and encoding. 
