### PR TITLE
replace pry-debugger with pry-byebug for ruby2.1.2 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem 'sqlite3'
   gem 'coveralls', require: false
   gem 'launchy'
-  gem 'pry-debugger'
+  gem 'pry-byebug'
   gem 'dotenv-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,9 @@ GEM
     arel (4.0.1)
     atomic (1.1.14)
     builder (3.1.4)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     capybara (2.2.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -43,19 +46,14 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.3)
-    columnize (0.3.6)
+    columnize (0.8.9)
     coveralls (0.7.0)
       multi_json (~> 1.3)
       rest-client
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    debugger (1.6.5)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.1)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.1)
     diff-lcs (1.2.5)
     docile (1.1.2)
     dotenv (0.9.0)
@@ -118,13 +116,13 @@ GEM
       omniauth (~> 1.0)
     pg (0.17.1)
     polyglot (0.3.3)
-    pry (0.9.12.4)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-debugger (0.2.2)
-      debugger (~> 1.3)
-      pry (~> 0.9.10)
+    pry-byebug (1.3.3)
+      byebug (~> 2.7)
+      pry (~> 0.10)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -180,7 +178,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    slop (3.4.7)
+    slop (3.6.0)
     sprockets (2.10.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -228,7 +226,7 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
-  pry-debugger
+  pry-byebug
   rails (= 4.0.2)
   rails_12factor
   rspec-rails


### PR DESCRIPTION
`pry-debugger` depends on `debugger` which does not work with Ruby 2.X. Replaced it with `pry-byebug` which uses `byebug`.
