### PR TITLE
Some copy changes for events.

### DIFF
--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -1,4 +1,10 @@
 = render partial: 'shared/title', locals: { title: @chapter.name, date: nil }
+.row
+  .large-7.medium-6-small-12.columns
+    Our workshops are open to anyone under-represented in the tech industry, but places are limited.
+    =link_to "Sign up", new_member_path
+    to receive invitations to our upcoming workshops.
+
 %section#chapter
   .row
     .large-7.medium-6.small-12.columns

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -1,18 +1,20 @@
 %li.workshop
   .row
     .large-4.medium-4.small-4.columns
-      .date{ class: event.class_string }
-        .month
-          = event.month
-        .day
-          =l(event.date_and_time, format: :day)
-        .time
-          at #{event.time}
+      =link_to event.path do
+        .date{ class: event.class_string }
+          .month
+            = event.month
+          .day
+            =l(event.date_and_time, format: :day)
+          .time
+            at #{event.time}
     .large-5.medium-5.small-5.columns
       .title
         =link_to event.to_s, event.path
       %small= event.description
       - if event.venue.present?
+        Kindly hosted by
         = link_to event.venue.name, event.venue.website
         %br
         = AddressDecorator.decorate(event.venue.address).to_html


### PR DESCRIPTION
There's been some emails this week from people who weren't sure how to sign up. I'd like to make some improvements to workshop display on the site, but for now we can add some text telling people how to sign up for invites on each chapter. 

This changeset also makes the big date link through to the chapter, as I always want to click it. 
