### PR TITLE
Fix dead link to "How to be an effective teacher"

### DIFF
--- a/app/views/session_invitation_mailer/invite_coach.html.haml
+++ b/app/views/session_invitation_mailer/invite_coach.html.haml
@@ -20,7 +20,7 @@
 
                 %p You can find all our tutorials at #{link_to "http://codebar.github.io/tutorials", "http://codebar.github.io/tutorials/"}. If you would like to improve any of the existing content, you can issue a pull request to our #{link_to "GitHub repository", "https://github.com/codebar/tutorials"}
 
-                %p Before attending, make sure you read and understand our #{link_to "code of conduct", "http://codebar.io/code-of-conduct"}. We have a zero tolerance policy and expect everyone to behave appropriately. You should also go through our #{link_to "How to be an effective teacher", "htpp://codebar.io/effective-teacher-guide"}. If you have anything to add to it, please open a pull request or an issue.
+                %p Before attending, make sure you read and understand our #{link_to "code of conduct", "http://codebar.io/code-of-conduct"}. We have a zero tolerance policy and expect everyone to behave appropriately. You should also go through our #{link_to "How to be an effective teacher", "http://codebar.io/effective-teacher-guide"}. If you have anything to add to it, please open a pull request or an issue.
                 
                 %p.callout It would be awesome if you could also #{link_to "join the chat on gitter", "https://gitter.im/codebar/tutorials"} to offer help and guidance outside the workshops.
 


### PR DESCRIPTION
It had `htpp` instead of `http` so navigating to it in a browser failed.
