### PR TITLE
Improve the user signup experience

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require pickadate/picker.time
 //= require analytics
 //= require gosquared
+//= require subscriptions-toggle
 
 $(function(){
   $(document).foundation();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,5 +25,6 @@ $(function(){
   $(document).foundation();
   $('#sessions_date_and_time').pickadate();
   $('#sessions_time').pickatime();
+  $('body').removeClass('no-js');
 });
 

--- a/app/assets/javascripts/subscriptions-toggle.js.coffee
+++ b/app/assets/javascripts/subscriptions-toggle.js.coffee
@@ -1,0 +1,12 @@
+# Expand/collapse toggling for coach/student group subscriptions.
+# Used in the new user signup flow, to stop too many options being
+# presented.
+
+$ ->
+ $('.subscriptions .toggle').click (e) ->
+   $section = $(e.target).closest '.subscriptions'
+   $container = $ '.group-container', $section
+   $icon = $ '.toggle i', $section
+   $container.slideToggle 400, ->
+     $container.toggleClass('collapsed')
+   $icon.toggleClass('fa-chevron-right fa-chevron-down')

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -76,6 +76,20 @@ nav a.menu {
   background-color: #CCC;
 }
 
+
+.sign-up-wizard {
+  label.required abbr {
+    display: none;
+  }
+
+  .hint {
+    position: relative;
+    top: -1rem;
+    font-size: 65%;
+  }
+}
+
+
 .workshop.title {
   color: grey;
   font-style: italic;

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -82,6 +82,10 @@ nav a.menu {
     margin-bottom: 2rem;
   }
 
+  span.error {
+    margin-top: -17px;
+  }
+
   .toggle {
     cursor: pointer;
   }

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -78,6 +78,10 @@ nav a.menu {
 
 
 .sign-up-wizard {
+  .row.subscriptions {
+    margin-bottom: 2rem;
+  }
+
   label.required abbr {
     display: none;
   }

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -76,14 +76,10 @@ nav a.menu {
   background-color: #CCC;
 }
 
-
+/* The new user flow. */
 .sign-up-wizard {
   .row.subscriptions {
     margin-bottom: 2rem;
-  }
-
-  .subscriptions .collapsed {
-    display: none;
   }
 
   .toggle {
@@ -100,6 +96,11 @@ nav a.menu {
     font-size: 65%;
   }
 }
+
+/* Show/hide togglable elements are controlled by JavaScript. */
+.sign-up-wizard .collapsed { display: none; }
+.no-js .sign-up-wizard .collapsed { display: block; }
+
 
 
 .workshop.title {

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -82,6 +82,14 @@ nav a.menu {
     margin-bottom: 2rem;
   }
 
+  .subscriptions .collapsed {
+    display: none;
+  }
+
+  .toggle {
+    cursor: pointer;
+  }
+
   label.required abbr {
     display: none;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,9 +45,12 @@ class ApplicationController < ActionController::Base
 
   def finish_registration
     if current_user.requires_additional_details?
-      flash[:notice] = "We need to know a little more about you. Please finish the registration form below."
-      redirect_to edit_member_path
+      redirect_to step1_member_path unless providing_additional_details?
     end
+  end
+
+  def providing_additional_details?
+    [edit_member_path, step1_member_path].include? request.path
   end
 
   def logout!

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -41,7 +41,7 @@ class AuthServicesController < ApplicationController
         session[:oauth_token]        = omnihash[:credentials][:token]
         session[:oauth_token_secret] = omnihash[:credentials][:secret]
 
-        redirect_to edit_member_path, notice: 'Thanks for signing up. Please fill in your details to complete the registration process.'
+        redirect_to step1_member_path, notice: 'Thanks for signing up. Please fill in your details to complete the registration process.'
       end
     end
   end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -14,7 +14,14 @@ class MembersController < ApplicationController
   def step1
     @suppress_notices = true
     @member = current_user
+
+    if request.post? or request.put?
+      if @member.update_attributes(member_params)
+        redirect_to step2_member_path and return
+      end
+    end
   end
+
 
   # Second step of the new user flow. Choose mailing lists.
   def step2
@@ -35,11 +42,7 @@ class MembersController < ApplicationController
 
     if @member.update_attributes(member_params)
       notice = "Your details have been updated"
-      if params[:next_page]
-        redirect_to(params[:next_page], notice: notice) and return
-      else
-        redirect_to(:back, notice: notice) and return
-      end
+      redirect_to(:back, notice: notice) and return
     else
       @groups = Group.all
       render "edit"

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -12,11 +12,13 @@ class MembersController < ApplicationController
 
   # Show the first step of the new user flow. A custom edit form for the user.
   def step1
+    @suppress_notices = true
     @member = current_user
   end
 
   # Second step of the new user flow. Choose mailing lists.
   def step2
+    @suppress_notices = true
     @member = current_user
     @coach_groups = Group.coaches
     @student_groups = Group.students

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,5 +1,5 @@
 class MembersController < ApplicationController
-  before_action :logged_in?, only: [:edit, :show, :step1, :step2]
+  before_action :authenticate_member!, only: [:edit, :show, :step1, :step2]
 
   def new
     @page_title = "Sign up"

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,5 +1,5 @@
 class MembersController < ApplicationController
-  before_action :logged_in?, only: [:edit, :show]
+  before_action :logged_in?, only: [:edit, :show, :step1, :step2]
 
   def new
     @page_title = "Sign up"
@@ -8,6 +8,18 @@ class MembersController < ApplicationController
   def edit
     @groups = Group.all
     @member = current_user
+  end
+
+  # Show the first step of the new user flow. A custom edit form for the user.
+  def step1
+    @member = current_user
+  end
+
+  # Second step of the new user flow. Choose mailing lists.
+  def step2
+    @member = current_user
+    @coach_groups = Group.coaches
+    @student_groups = Group.students
   end
 
   def profile
@@ -20,7 +32,12 @@ class MembersController < ApplicationController
     @member = current_user
 
     if @member.update_attributes(member_params)
-      redirect_to :back, notice: "Your details have been updated"
+      notice = "Your details have been updated"
+      if params[:next_page]
+        redirect_to(params[:next_page], notice: notice) and return
+      else
+        redirect_to(:back, notice: notice) and return
+      end
     else
       @groups = Group.all
       render "edit"

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -22,12 +22,12 @@ class Member < ActiveRecord::Base
 
   # Is this user a student?
   def student?
-    groups.students.count > 0
+    groups.students.count > 0 || roles.where(name: 'student').any?
   end
 
   # Is this user a coach?
   def coach?
-    groups.coaches.count > 0
+    groups.coaches.count > 0 || roles.where(name: 'coach').any?
   end
 
   # Has this user ever attended a Codebar session?

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -4,7 +4,10 @@
       .row
         .small-8.medium-8.columns
           =link_to admin_member_path(invitation.member) do
-            =invitation.member.full_name
+            - if invitation.member.full_name.blank?
+              = invitation.member.email
+            - else
+              = invitation.member.full_name
           - if invitation.member.newbie?
             %p
               %em New attendee!

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -1,7 +1,8 @@
 - flash.each do |name, msg|
-  - if msg.is_a?(String)
-    - name = name.eql?("notice") ? "info" : name
-    %div{ "data-alert" => '', :class => "alert-box #{name}" }
-      =link_to "#", class: 'close' do
-        &times;
-      = content_tag :div, msg.html_safe
+  - unless (name.eql?("notice") && @suppress_notices) || (name.eql?("warning") && @suppress_warnings)
+    - if msg.is_a?(String)
+      - name = name.eql?("notice") ? "info" : name
+      %div{ "data-alert" => '', :class => "alert-box #{name}" }
+        =link_to "#", class: 'close' do
+          &times;
+        = content_tag :div, msg.html_safe

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     %link{ href: 'http://fonts.googleapis.com/css?family=Gabriela', rel: 'stylesheet', type: 'text/css' }
     %link{ href: 'http://fonts.googleapis.com/css?family=Cousine:400,700', rel:'stylesheet', type:'text/css'}
     = csrf_meta_tags
-  %body
+  %body.no-js
     .off-canvas-wrap{ "data-offcanvas" => true }
       .inner-wrap
         #top

--- a/app/views/members/_coach_invite_subscriptions.html.haml
+++ b/app/views/members/_coach_invite_subscriptions.html.haml
@@ -1,0 +1,21 @@
+.row.subscriptions
+  .large-6.large-offset-3.columns
+    %h2.toggle
+      Coaches
+      - if collapsed
+        %i.fa.fa-chevron-right
+      - else
+        %i.fa.fa-chevron-down
+    .group-container{class: collapsed ? "collapsed" : ""}
+      - groups.each do |g|
+        - if belongs_to_group? g
+          = simple_form_for :subscription, url: :destroy_subscriptions, method: :delete do |f|
+            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = button_tag type: :submit, class: 'button expand success round' do
+              %i.fa.fa-check.fa-lg
+              Subscribed to #{g.chapter.name} coach invites
+        - else
+          = simple_form_for :subscription, url: :subscriptions do |f|
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = f.submit "Subscribe to #{g.chapter.name} coach invites", class: 'button expand warn round'

--- a/app/views/members/_student_invite_subscriptions.html.haml
+++ b/app/views/members/_student_invite_subscriptions.html.haml
@@ -1,0 +1,21 @@
+.row.subscriptions
+  .large-6.large-offset-3.columns
+    %h2.toggle
+      Students
+      - if collapsed
+        %i.fa.fa-chevron-right
+      - else
+        %i.fa.fa-chevron-down
+    .group-container{class: collapsed ? "collapsed" : ""}
+      - groups.each do |g|
+        - if belongs_to_group? g
+          = simple_form_for :subscription, url: :destroy_subscriptions, method: :delete do |f|
+            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = button_tag type: :submit, class: 'button expand success round' do
+              %i.fa.fa-check.fa-lg
+              Subscribed to #{g.chapter.name} student invites
+        - else
+          = simple_form_for :subscription, url: :subscriptions do |f|
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = f.submit "Subscribe to #{g.chapter.name} student invites", class: 'button expand warn round'

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -6,7 +6,7 @@
         We need some more details from you to finish creating your account. We use these to help run our events &amp; match you
         with a suitable #{@member.coach? ? "student" : "coach"}.
 
-  = simple_form_for @member, method: :put, html: {class: "sign-up-wizard"} do |f|
+  = simple_form_for @member, method: :put, url: {action: :step1}, html: {class: "sign-up-wizard"} do |f|
     .row
       .large-6.large-offset-3.columns
         = f.input :name, label: "First name", required: true

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -25,4 +25,5 @@
 
     .row
       .large-6.large-offset-3.columns.text-right
+        = hidden_field_tag :next_page, step2_member_path
         = f.submit "Next", class: 'button round right'

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -2,7 +2,9 @@
   .row
     .medium-12.columns
       %h1 Almost there...
-      %p We need some more details from you to finish creating your account. We use these to help run our events &amp; match you with a suitable coach.
+      %p
+        We need some more details from you to finish creating your account. We use these to help run our events &amp; match you
+        with a suitable #{@member.coach? ? "student" : "coach"}.
 
   = simple_form_for @member, method: :put, html: {class: "sign-up-wizard"} do |f|
     .row
@@ -19,7 +21,7 @@
     .row
       .large-6.large-offset-3.columns
         - if @member.coach?
-          = f.input :about_you, as: :text, label: "What languages do you like to use? How do you spend your time? Tell us a little about yourself!", required: true
+          = f.input :about_you, as: :text, label: "What experience do you have? What languages do you like to use? Tell us a little about yourself!", required: true
         - else
           = f.input :about_you, as: :text, label: "What do you want to work on at Codebar? What have you done in the past? Tell us a little about yourself!", required: true
 

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -1,0 +1,28 @@
+%section#banner
+  .row
+    .medium-12.columns
+      %h1 Almost there...
+      %p We need some more details from you to finish creating your account. We use these to help run our events &amp; match you with a suitable coach.
+
+  = simple_form_for @member, method: :put, html: {class: "sign-up-wizard"} do |f|
+    .row
+      .large-6.large-offset-3.columns
+        = f.input :name, label: "First name", required: true
+    .row
+      .large-6.large-offset-3.columns
+        = f.input :surname, required: true
+
+    .row
+      .large-6.large-offset-3.columns
+        = f.input :email, label: "Email address", hint: "We send you invites to our events via email.", required: true
+
+    .row
+      .large-6.large-offset-3.columns
+        - if @member.coach?
+          = f.input :about_you, as: :text, label: "What languages do you like to use? How do you spend your time? Tell us a little about yourself!", required: true
+        - else
+          = f.input :about_you, as: :text, label: "What do you want to work on at Codebar? What have you done in the past? Tell us a little about yourself!", required: true
+
+    .row
+      .large-6.large-offset-3.columns.text-right
+        = f.submit "Next", class: 'button round right'

--- a/app/views/members/step2.html.haml
+++ b/app/views/members/step2.html.haml
@@ -3,42 +3,15 @@
     .medium-12.columns
       %h1 Pick an invite list
       %p
-        You can register for events on the Codebar site, but it's easier via email. You can
-        join an email list below to receive invites for that location.
+        You can register for events on the Codebar site, but it's easier via email.
+        Join an email list below to receive invites for that location.
 
-  .row.subscriptions
-    .large-6.large-offset-3.columns
-      %h2
-        Coaches
-      - @coach_groups.each do |g|
-        - if belongs_to_group? g
-          = simple_form_for :subscription, url: :destroy_subscriptions, method: :delete do |f|
-            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
-            = f.input :group_id, as: :hidden, input_html: { value: g.id }
-            = button_tag type: :submit, class: 'button expand success round' do
-              %i.fa.fa-check.fa-lg
-              Subscribed to #{g.chapter.name} coach invites
-        - else
-          = simple_form_for :subscription, url: :subscriptions do |f|
-            = f.input :group_id, as: :hidden, input_html: { value: g.id }
-            = f.submit "Subscribe to #{g.chapter.name} coach invites", class: 'button expand warn round'
-
-  .row.subscriptions
-    .large-6.large-offset-3.columns
-      %h2
-        Students
-      - @student_groups.each do |g|
-        - if belongs_to_group? g
-          = simple_form_for :subscription, url: :destroy_subscriptions, method: :delete do |f|
-            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
-            = f.input :group_id, as: :hidden, input_html: { value: g.id }
-            = button_tag type: :submit, class: 'button expand success round' do
-              %i.fa.fa-check.fa-lg
-              Subscribed to #{g.chapter.name} student invites
-        - else
-          = simple_form_for :subscription, url: :subscriptions do |f|
-            = f.input :group_id, as: :hidden, input_html: { value: g.id }
-            = f.submit "Subscribe to #{g.chapter.name} student invites", class: 'button expand warn round'
+  - if current_user.coach?
+    = render partial: 'coach_invite_subscriptions', locals: {groups: @coach_groups, collapsed: false}
+    = render partial: 'student_invite_subscriptions', locals: {groups: @student_groups, collapsed: true}
+  - else
+    = render partial: 'student_invite_subscriptions', locals: {groups: @student_groups, collapsed: false}
+    = render partial: 'coach_invite_subscriptions', locals: {groups: @coach_groups, collapsed: true}
 
   .row
     .large-6.large-offset-3.columns

--- a/app/views/members/step2.html.haml
+++ b/app/views/members/step2.html.haml
@@ -1,0 +1,46 @@
+%section#banner.sign-up-wizard
+  .row
+    .medium-12.columns
+      %h1 Pick an invite list
+      %p
+        You can register for events on the Codebar site, but it's easier via email. You can
+        join an email list below to receive invites for that location.
+
+  .row.subscriptions
+    .large-6.large-offset-3.columns
+      %h2
+        Coaches
+      - @coach_groups.each do |g|
+        - if belongs_to_group? g
+          = simple_form_for :subscription, url: :destroy_subscriptions, method: :delete do |f|
+            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = button_tag type: :submit, class: 'button expand success round' do
+              %i.fa.fa-check.fa-lg
+              Subscribed to #{g.chapter.name} coach invites
+        - else
+          = simple_form_for :subscription, url: :subscriptions do |f|
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = f.submit "Subscribe to #{g.chapter.name} coach invites", class: 'button expand warn round'
+
+  .row.subscriptions
+    .large-6.large-offset-3.columns
+      %h2
+        Students
+      - @student_groups.each do |g|
+        - if belongs_to_group? g
+          = simple_form_for :subscription, url: :destroy_subscriptions, method: :delete do |f|
+            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = button_tag type: :submit, class: 'button expand success round' do
+              %i.fa.fa-check.fa-lg
+              Subscribed to #{g.chapter.name} student invites
+        - else
+          = simple_form_for :subscription, url: :subscriptions do |f|
+            = f.input :group_id, as: :hidden, input_html: { value: g.id }
+            = f.submit "Subscribe to #{g.chapter.name} student invites", class: 'button expand warn round'
+
+  .row
+    .large-6.large-offset-3.columns
+      %p
+        = link_to "Done", root_path, class: "button round right"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Planner::Application.routes.draw do
     get 'attendance-policy', action: 'attendance_policy'
   end
 
-  resource :member, only: [:new, :edit, :update, :patch]
+  resource :member, only: [:new, :edit, :update, :patch] do
+    get 'step1'
+    get 'step2'
+  end
 
   get '/profile' => "members#profile", as: :profile
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Planner::Application.routes.draw do
 
   resource :member, only: [:new, :edit, :update, :patch] do
     get 'step1'
+    put 'step1'
     get 'step2'
   end
 

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -83,17 +83,64 @@ feature "A new student signs up", js: false do
     expect(member.about_you).to eq("I'm a test user created via the RSpec feature specs.")
   end
 
-  scenario "A student can sign up via the front page", pending: "Transform into test for edit page" do
-    visit root_path
-    click_on "Students"
-    expect(current_path).to eq(new_member_path)
+  scenario "Missing any detail on step 1 returns the user to step 1" do
+    member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil)
+    login member
+    member.update(can_log_in: true)
+    visit step1_member_path
 
-    click_on "Sign in with Github"
-    expect(current_path).to eq(edit_member_path)
-    expect(page).to have_selector("form")
-    fill_in 'member_about_you', with: "I'm a test user and am not actually real"
-    click_on "Save"
+    # Check for missing first name
+    fill_in "member_name", with: ""
+    fill_in "member_surname", with: "Smith"
+    fill_in "member_email", with: "someone@example.com"
+    fill_in "member_about_you", with: "Something"
+    click_on "Next"
+    expect(current_path).to eq(step1_member_path)
+    expect(page).to have_selector('.error')
 
-    expect(page).to have_text "Your details have been updated"
+    # Check for missing last name
+    fill_in "member_name", with: "Bob"
+    fill_in "member_surname", with: ""
+    fill_in "member_email", with: "someone@example.com"
+    fill_in "member_about_you", with: "Something"
+    click_on "Next"
+    expect(current_path).to eq(step1_member_path)
+    expect(page).to have_selector('.error')
+
+    # Check for missing email
+    fill_in "member_name", with: "Bob"
+    fill_in "member_surname", with: "Smith"
+    fill_in "member_email", with: ""
+    fill_in "member_about_you", with: "Something"
+    click_on "Next"
+    expect(current_path).to eq(step1_member_path)
+    expect(page).to have_selector('.error')
+
+    # Check for missing about you
+    fill_in "member_name", with: "Bob"
+    fill_in "member_surname", with: "Smith"
+    fill_in "member_email", with: "someone@example.com"
+    fill_in "member_about_you", with: ""
+    click_on "Next"
+    expect(current_path).to eq(step1_member_path)
+    expect(page).to have_selector('.error')
+  end
+
+  scenario "Picking a mailing list on step 2 subscribes you to that list" do
+    member = Fabricate(:member)
+    group = Fabricate(:group)
+    coach_group = Fabricate(:coaches)
+    expect(group.members.include? member).to be false
+    expect(coach_group.members.include? member).to be false
+
+    login member
+    member.update(can_log_in: true)
+    visit step2_member_path
+    expect(current_path).to eq(step2_member_path) # Make sure we didn't get redirected to step1 for missing details
+
+    expect(page).to have_selector('form')
+    click_button "Subscribe to #{group.chapter.name} student invites"
+    expect(group.members.include? member).to be true
+    expect(coach_group.members.include? member).to be false
   end
 end

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -57,7 +57,33 @@ feature "A new student signs up", js: false do
     [ "Student", "Coach", "Mentor", "Admin" ].each { |role| Role.create name: role }
   end
 
-  scenario "A student can sign up via the front page" do
+  scenario "A new student lands on step 1 after signing up via the front page" do
+    visit root_path
+    click_on "Students"
+    click_on "Sign in with Github"
+    expect(current_path).to eq(step1_member_path)
+  end
+
+  scenario "Filling in all the details on step 1 brings the user to step 2" do
+    visit root_path
+    click_on "Students"
+    click_on "Sign in with Github"
+    expect(page).to have_selector("form")
+    fill_in "member_name", with: "Bob"
+    fill_in "member_surname", with: "Smith"
+    fill_in "member_email", with: "someone@example.com"
+    fill_in "member_about_you", with: "I'm a test user created via the RSpec feature specs."
+    click_on "Next"
+    expect(current_path).to eq(step2_member_path)
+
+    member = Member.last
+    expect(member.name).to eq("Bob")
+    expect(member.surname).to eq("Smith")
+    expect(member.email).to eq("someone@example.com")
+    expect(member.about_you).to eq("I'm a test user created via the RSpec feature specs.")
+  end
+
+  scenario "A student can sign up via the front page", pending: "Transform into test for edit page" do
     visit root_path
     click_on "Students"
     expect(current_path).to eq(new_member_path)

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -20,6 +20,37 @@ feature 'member portal' do
       login(member)
       visit root_path
     end
+
+    it "should allow a user to edit their profile" do
+      login member
+      visit edit_member_path
+      expect(member.name).not_to eq "Bob"
+      fill_in "member_name", with: "Bob"
+      click_button "Save"
+      expect(member.name).to eq "Bob"
+    end
+
+    it "should allow a user to join new mailing lists" do
+      group = Fabricate(:group)
+      expect(group.members.include? member).to be false
+
+      login member
+      visit edit_member_path
+      click_button "Subscribe"
+      expect(group.members.include? member).to be true
+
+    end
+
+    it "should allow a user to leave a mailing list" do
+      group = Fabricate(:group)
+      group.members << member
+      expect(group.members.include? member).to be true
+
+      login member
+      visit edit_member_path
+      click_button "Subscribed"
+      expect(group.members.include? member).to be false
+    end
   end
 
   context "not signed in" do

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,1 @@
+Omniauth.config.test_mode = true


### PR DESCRIPTION
This changeset introduces a new flow for users who sign up to Codebar. 

The first couple of steps are the same. Click 'Students' from the front page, then 'Sign in with Github': 
<img src="https://cloud.githubusercontent.com/assets/244541/5696662/18cc5566-99d0-11e4-87c3-0e92b5d3b01b.png" width="400" alt="Front page of website" />
<img src="https://cloud.githubusercontent.com/assets/244541/5696661/18ca0824-99d0-11e4-8c2b-2334289650e3.png" width="400" alt="Second step" />

Once the user returns from Github, though, there's a new form with fewer fields. It should be friendlier, and have less chance the user gets lost. There's different copy for students and coaches on this page. 

<img src="https://cloud.githubusercontent.com/assets/244541/5696680/720d305a-99d0-11e4-9c37-165e49e21b06.png" alt="First step of the new wizard" width="400" />

After clicking 'Next', the user can pick which groups they'd like to subscribe to. If they're a student, then the coach groups are hidden by default and listed second. If they're a coach, then the student groups are hidden by default and listed second. 

<img src="https://cloud.githubusercontent.com/assets/244541/5696691/bb317dae-99d0-11e4-80a3-537a37acceff.png" alt="Second step allowing users to select lists to join" width="400" />
<img src="https://cloud.githubusercontent.com/assets/244541/5696692/bb3395a8-99d0-11e4-80e3-38143d43fd39.png" alt="Second step, with one list joined" width="400" />

There's feature tests for this flow, and also for the old edit page too. That one's kept around to let people edit things after they've signed up. 
