### PR TITLE
Don't allow people to RSVP to events that aren't marked as invitable.

### DIFF
--- a/app/views/workshops/_workshop_actions.html.haml
+++ b/app/views/workshops/_workshop_actions.html.haml
@@ -9,12 +9,14 @@
   - elsif @workshop.waitlisted? current_user
     You're on the waiting list for this event.
   - else
-    - if @workshop.spaces?
+    - if not @workshop.invitable
+      This workshop isn't open for registrations yet.
+    - elsif @workshop.spaces?
       Come along and join us!
     - else
       This workshop is full, but you can join the waiting list.
 
-- if logged_in? && @workshop.future?
+- if logged_in? && @workshop.future? && @workshop.invitable
   - if @workshop.attendee?(current_user)
     - if @workshop.imminent?
       You can't change your RSVP this close to the event. If you can no longer make it,
@@ -45,7 +47,7 @@
         = submit_tag "Attend as a coach", class: 'button round expand'
       - else
         = submit_tag "Join the coach waiting list", class: 'button round expand'
-- else
+- elsif not logged_in?
   = link_to "Sign up as a student", new_member_path(role: "student"), class: 'button round expand'
   = link_to "Sign up as a coach", new_member_path(role: "coach"), class: 'button round expand'
   = link_to "Log in with existing account", redirect_path, class: 'button round expand'

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -263,4 +263,14 @@ feature 'Viewing a workshop page' do
     expect(page).to have_content("As a coach")
     expect(page).not_to have_content("As a student")
   end
+
+  scenario "A logged-in user viewing a future event that's not invitable can't RSVP to that event" do
+    workshop.update(invitable: false)
+
+    login member
+    visit workshop_path workshop
+    expect(page).to have_content("This workshop isn't open for registrations yet")
+    expect(page).not_to have_button("Attend as a coach")
+    expect(page).not_to have_button("Attend as a student")
+  end
 end


### PR DESCRIPTION
This tripped us up with the upcoming Twitter workshop! If a workshop isn't marked as invitable, then people shouldn't be able to sign up to it from the planner website. It's also more fair to give people on the mailing list a first crack at the spaces. 


