### PR TITLE
Add "organiser" display to the CSV dump

### DIFF
--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -43,7 +43,7 @@ class WorkshopPresenter < EventPresenter
       if organisers.include? i.member
         [i.member.full_name, "ORGANISER"]
       else
-      [i.member.full_name, i.role.upcase]
+        [i.member.full_name, i.role.upcase]
       end
     end
   end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -39,7 +39,13 @@ class WorkshopPresenter < EventPresenter
   private
 
   def attendee_array
-    model.attendances.map {|i| [i.member.full_name, i.role.upcase] }
+    model.attendances.map do |i|
+      if organisers.include? i.member
+        [i.member.full_name, "ORGANISER"]
+      else
+      [i.member.full_name, i.role.upcase]
+      end
+    end
   end
 
   def model

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe WorkshopPresenter do
   let(:invitations) { [Fabricate(:student_session_invitation),
                        Fabricate(:student_session_invitation),
-                       Fabricate(:coach_session_invitation)] }
+                       Fabricate(:coach_session_invitation),
+                       Fabricate(:coach_session_invitation)
+                      ] }
   let(:chapter) { Fabricate(:chapter) }
   let(:sessions) { double(:workshop, attendances: invitations, host: Fabricate(:sponsor), chapter: chapter )}
   let(:workshop) { WorkshopPresenter.new(sessions) }
@@ -27,11 +29,16 @@ describe WorkshopPresenter do
     workshop.time
   end
 
-  it "#attendess_csv" do
+  it "#attendees_csv" do
+    expect(workshop).to receive(:organisers).at_least(:once).and_return [invitations.last.member]
+    expect(workshop.attendees_csv).not_to be_blank
 
     invitations.each do |invitation|
       expect(workshop.attendees_csv).to include(invitation.member.full_name)
-      expect(workshop.attendees_csv).to include(invitation.role.upcase)
+      expect(workshop.attendees_csv).to include(invitation.role.upcase).or include("ORGANISER")
     end
+    expect(workshop.attendees_csv).to include("ORGANISER")
+    expect(workshop.attendees_csv).to include("STUDENT")
+    expect(workshop.attendees_csv).to include("COACH")
   end
 end


### PR DESCRIPTION
If an attendee is listed as an organiser for a workshop, they'll shop up in the CSV as "ORGANISER" instead of as "STUDENT" or "COACH". This means their name badge will say "Organiser", and it helps attendees find
people who can help them out if they're stuck.