### PR TITLE
Allow admins & organisers to add notes to individual users.

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2,6 +2,7 @@
 @import 'partials/events';
 @import 'partials/social_media';
 @import 'partials/chapter';
+@import 'partials/member_note';
 
 section.title {
   background-image: image-url('bg.jpg');

--- a/app/assets/stylesheets/partials/_member_note.css.scss
+++ b/app/assets/stylesheets/partials/_member_note.css.scss
@@ -1,0 +1,16 @@
+.member_note {
+  margin-bottom: 1em;
+
+  border-bottom: 1px solid #ddd;
+  &:last-child {
+    border-bottom: none;
+  }
+
+  p {
+    margin-bottom: 0.2em;
+  }
+
+  cite {
+    font-size: 80%;
+  }
+}

--- a/app/controllers/admin/member_notes_controller.rb
+++ b/app/controllers/admin/member_notes_controller.rb
@@ -1,0 +1,13 @@
+class Admin::MemberNotesController < Admin::ApplicationController
+  def create
+    @note = MemberNote.new(member_note_params)
+    authorize @note
+    @note.author = current_user
+    flash[:error] = @note.errors.full_messages unless @note.save
+    redirect_to :back
+  end
+
+  def member_note_params
+    params.require(:member_note).permit(:note, :member_id)
+  end
+end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,6 +1,6 @@
 class Admin::MembersController < Admin::ApplicationController
 
   def show
-    @member = Member.find(params[:id])
+    @member = Member.includes(:member_notes).find(params[:id])
   end
 end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -2,5 +2,6 @@ class Admin::MembersController < Admin::ApplicationController
 
   def show
     @member = Member.includes(:member_notes).find(params[:id])
+    @member_note = MemberNote.new
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,6 +7,7 @@ class Member < ActiveRecord::Base
   has_many :jobs, foreign_key: :created_by_id
   has_many :subscriptions
   has_many :groups, through: :subscriptions
+  has_many :member_notes
 
   validates :auth_services, presence: true
   validates :name, :surname, :email, :about_you, presence: true, if: :can_log_in?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -31,6 +31,11 @@ class Member < ActiveRecord::Base
     groups.coaches.count > 0 || roles.where(name: 'coach').any?
   end
 
+  # Is this user a chapter organiser?
+  def chapter_organiser?
+    roles.where(resource_type: "Chapter").any?
+  end
+
   # Has this user ever attended a Codebar session?
   def newbie?
     (attended_sessions.count == 0) || (attended_sessions.count == 1 && attended_sessions.first.today?)

--- a/app/models/member_note.rb
+++ b/app/models/member_note.rb
@@ -1,0 +1,6 @@
+class MemberNote < ActiveRecord::Base
+  belongs_to :member
+  belongs_to :author, class_name: "Member"
+
+  validates :member, :author, :note, presence: true
+end

--- a/app/policies/member_note_policy.rb
+++ b/app/policies/member_note_policy.rb
@@ -1,0 +1,6 @@
+class MemberNotePolicy < ApplicationPolicy
+  # Chapter organisers can create notes.
+  def create?
+    user.is_admin? or user.chapter_organiser?
+  end
+end

--- a/app/policies/member_note_policy.rb
+++ b/app/policies/member_note_policy.rb
@@ -1,6 +1,6 @@
 class MemberNotePolicy < ApplicationPolicy
   # Chapter organisers can create notes.
   def create?
-    user.is_admin? or user.chapter_organiser?
+    user and (user.is_admin? or user.chapter_organiser?)
   end
 end

--- a/app/views/admin/members/_member_note.html.haml
+++ b/app/views/admin/members/_member_note.html.haml
@@ -1,0 +1,5 @@
+.member_note
+  %p
+    = member_note.note
+  %cite
+    &ndash; #{member_note.author.full_name}, #{member_note.created_at.to_s(:short)}

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -47,4 +47,8 @@
         = render partial: "member_note", collection: @member.member_notes
       - else
         %em No notes.
+      = simple_form_for [:admin, @member_note] do |f|
+        = f.input :note, label: false
+        = f.hidden_field :member_id, value: @member.id
+        = f.submit "Add note"
 

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -29,7 +29,7 @@
               #{group.name} (#{group.chapter.name})
   .row
     %hr
-    .medium-12.columns
+    .medium-8.columns
       %h3 Attended workshops
       - @member.session_invitations.attended.each do |invitation|
         .row
@@ -41,4 +41,10 @@
               = humanize_date_with_time(workshop.date_and_time, workshop.time)
           .medium-4.columns
             = invitation.note
+    .medium-4.columns
+      %h3 Member notes (#{@member.member_notes.count})
+      - if @member.member_notes.any?
+        = render partial: "member_note", collection: @member.member_notes
+      - else
+        %em No notes.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Planner::Application.routes.draw do
     end
 
     resources :members, only: [:show]
+    resources :member_notes, only: [:create]
 
     resources :chapters, only: [ :index, :new, :create, :show] do
       resources :workshops, only: [ :index ]

--- a/db/migrate/20150130001852_create_member_notes.rb
+++ b/db/migrate/20150130001852_create_member_notes.rb
@@ -1,0 +1,11 @@
+class CreateMemberNotes < ActiveRecord::Migration
+  def change
+    create_table :member_notes do |t|
+      t.references :member, index: true
+      t.references :author, index: true
+      t.text :note
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141204232033) do
+ActiveRecord::Schema.define(version: 20150130001852) do
 
   create_table "addresses", force: true do |t|
     t.string   "flat"
@@ -198,6 +198,17 @@ ActiveRecord::Schema.define(version: 20141204232033) do
     t.string   "description"
     t.string   "slug"
   end
+
+  create_table "member_notes", force: true do |t|
+    t.integer  "member_id"
+    t.integer  "author_id"
+    t.text     "note"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "member_notes", ["author_id"], name: "index_member_notes_on_author_id"
+  add_index "member_notes", ["member_id"], name: "index_member_notes_on_member_id"
 
   create_table "members", force: true do |t|
     t.string   "name"

--- a/spec/controllers/admin/member_notes_controller_spec.rb
+++ b/spec/controllers/admin/member_notes_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Admin::MemberNotesController, type: :controller do
+  let(:member) { Fabricate(:member) }
+  let(:admin) { Fabricate(:chapter_organiser) }
+  let!(:member_note) { Fabricate(:member_note) }
+
+  describe "POST #create" do
+    it "Doesn't allow anonymous users to create notes" do
+      expect {
+        post :create, member_note: {note: member_note.note, member_id: member.id}
+      }.not_to change {MemberNote.all.count}
+    end
+
+    it "Doesn't allow regular users to create notes" do
+      login member
+
+      expect {
+        post :create, member_note: {note: member_note.note, member_id: member.id}
+      }.not_to change {MemberNote.all.count}
+    end
+
+    it "Allows chapter organisers to create notes" do
+      login admin
+      request.env["HTTP_REFERER"] = "/admin/member/3"
+
+      expect {
+        post :create, member_note: {note: member_note.note, member_id: member.id}
+      }.to change {MemberNote.all.count}.by 1
+    end
+
+    it "Doesn't allow blank notes to be created" do
+      expect {
+        post :create, member_note: {note: " ", member_id: member.id}
+      }.not_to change {MemberNote.all.count}
+    end
+  end
+end

--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -14,3 +14,10 @@ end
 Fabricator(:coach, from: :member) do
   groups(count: 2) { |attrs, i| Fabricate(:coaches) }
 end
+
+Fabricator(:chapter_organiser, from: :member) do
+  after_save do |member|
+    chapter = Fabricate(:chapter)
+    member.add_role :organiser, chapter
+  end
+end

--- a/spec/fabricators/member_note_fabricator.rb
+++ b/spec/fabricators/member_note_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:member_note) do
+  member
+  author(fabricator: :member)
+  note { Faker::Lorem.paragraph }
+end

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+feature "Managing users" do
+  let(:member) { Fabricate(:member) }
+  let(:admin) { Fabricate(:chapter_organiser) }
+
+  before do
+    login admin
+  end
+
+  scenario "View a user" do
+    visit admin_member_path member
+
+    expect(page).to have_content member.name
+    expect(page).to have_content member.email
+    expect(page).to have_content member.about_you
+  end
+
+  scenario "Add a note to a user" do
+    visit admin_member_path member
+    expect(page).not_to have_content "Bananas and custard"
+
+    expect {
+      fill_in "member_note_note", with: "Bananas and custard"
+      click_on "Add note"
+    }.to change { MemberNote.all.count}.by 1
+
+    expect(page).to have_content "Member notes (1)"
+    expect(page).to have_content "Bananas and custard"
+  end
+end

--- a/spec/models/member_note_spec.rb
+++ b/spec/models/member_note_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe MemberNote do
+  context "Mandatory attributes" do
+    it "Requires a note" do
+      note = Fabricate.build(:member_note, note: nil)
+
+      expect(note).not_to be_valid
+      expect(note).to have(1).error_on(:note)
+
+      note.note = ""
+      expect(note).not_to be_valid
+      expect(note).to have(1).error_on(:note)
+    end
+
+    it "Requires a member" do
+      note = Fabricate.build(:member_note, member: nil)
+      expect(note).not_to be_valid
+      expect(note).to have(1).error_on(:member)
+    end
+
+    it "Requires an author" do
+      note = Fabricate.build(:member_note, author: nil)
+      expect(note).not_to be_valid
+      expect(note).to have(1).error_on(:author)
+    end
+  end
+end


### PR DESCRIPTION
Codebar has over a thousand members and several people helping to organise & run workshops. It would be useful to be able to keep notes on members within the app. 

This creates a new `MemberNote` model; a `Member has_many :member_notes`. Notes can be viewed and added in the admin interface, and can't be edited or deleted. A note stores who wrote it. Tests are included. 

![screen shot 2015-02-03 at 17 11 11](https://cloud.githubusercontent.com/assets/244541/6025122/ebe621f8-abc7-11e4-9ace-6a88a3fef5a9.png)
