### PR TITLE
Fixes sessions’s merge of date and time so it passes in all timezones.

### DIFF
--- a/app/models/sessions.rb
+++ b/app/models/sessions.rb
@@ -113,11 +113,7 @@ class Sessions < ActiveRecord::Base
   private
 
   def combine_date_and_time
-    self.date_and_time = DateTime.new(date_and_time.year,
-                                   date_and_time.month,
-                                   date_and_time.day,
-                                   time.hour,
-                                   time.min)
+    self.date_and_time = date_and_time.change(hour: time.hour, min: time.min)
   end
 
   def set_rsvp_close_time

--- a/spec/models/sessions_spec.rb
+++ b/spec/models/sessions_spec.rb
@@ -14,11 +14,11 @@ describe Sessions do
 
     it "merges date_and_time and time" do
       workshop.date_and_time = DateTime.new(2015,11,12,12,0)
-      workshop.time = Time.new(2000,01,01,18,30)
+      workshop.time = Time.utc(2000,01,01,18,30)
 
       workshop.save
 
-      expect(workshop.date_and_time.utc).to eq(DateTime.new(2015,11,12,18,30).utc)
+      expect(workshop.date_and_time).to eq(DateTime.new(2015,11,12,18,30))
     end
   end
 


### PR DESCRIPTION
Sessions' spec for merging date and time (#combine_date_and_time) on save was failing when run in other time zones.