### PR TITLE
Add support for extra information on each workshop

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -56,7 +56,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
   private
 
   def workshop_params
-    params.require(:sessions).permit(:date_and_time, :time, :chapter_id, :invitable, :seats, sponsor_ids: [])
+    params.require(:sessions).permit(:date_and_time, :time, :chapter_id, :invitable, :seats, :invite_note, sponsor_ids: [])
   end
 
   def sponsor_id

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -5,6 +5,7 @@
 
       = f.input :date_and_time, as: :string, placeholder: Date.tomorrow.strftime('%d %b, %Y'), required: true
       = f.input :time, as: :string, placeholder: DateTime.new(2014,6,1,12,30).strftime("%H:%M %P"), required: true, input_html: { id: "sessions_time" }
+      = f.input :invite_note, as: :text, placeholder: "Text you include here will be visible on the workshop page and in the email invitations. HTML formatting is OK."
       = f.input :invitable
   .row
     .large-12.columns.text-right

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -5,6 +5,7 @@
 
       = f.input :date_and_time, as: :string, placeholder: Date.tomorrow.strftime('%d %b, %Y'), required: true
       = f.input :time, as: :string, placeholder: DateTime.new(2014,6,1,12,30).strftime("%H:%M %P"), required: true, input_html: { id: "sessions_time" }
+      = f.input :invite_note, as: :text, placeholder: "Text you include here will be visible on the workshop page and in the email invitations. HTML formatting is OK."
       = f.input :invitable
   .row
     .large-12.columns.text-right

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -55,23 +55,35 @@
                   = sponsor.name
                   = link_to admin_workshop_destroy_sponsor_path(workshop_id: @workshop.id, sponsor_id: sponsor.id), data: { confirm: "Are you sure?" }, method: :delete do
                     =fa_icon "times"
-  - if @workshop.invitable?
-    .row
-      .medium-4.columns
-        %h4
-          Invitations
-          - if @workshop.invitations.any?
-            (#{@workshop.invitations.count})
-        - if !@workshop.date_and_time.future?
-          =link_to "Send Invitations", "#", class: "button round disabled"
-          %br
-          %small The workshop has already taken place
-        - elsif @workshop.has_valid_host?
-          =link_to "Send Invitations", admin_workshop_invite_path(@workshop), method: :post, class: "button round"
-        - else
-          =link_to "Send Invitations", "#", class: "button round disabled"
-          %br
-          %small you must specify a host before sending out invitations
+  .row
+    .medium-12.columns
+      %h4
+        Invitations
+        - if @workshop.invitations.any?
+          (#{@workshop.invitations.count})
+      .row
+        .medium-3.columns
+          - if !@workshop.invitable?
+            =link_to "Send Invitations", "#", class: "button round disabled"
+            %br
+            %small This workshop isn't marked as invitable.
+          - elsif !@workshop.date_and_time.future?
+            =link_to "Send Invitations", "#", class: "button round disabled"
+            %br
+            %small The workshop has already taken place
+          - elsif @workshop.has_valid_host?
+            =link_to "Send Invitations", admin_workshop_invite_path(@workshop), method: :post, class: "button round"
+          - else
+            =link_to "Send Invitations", "#", class: "button round disabled"
+            %br
+            %small you must specify a host before sending out invitations
+        .medium-9.columns
+          %p
+            Invitation note:
+            - if @workshop.invite_note.blank?
+              %em No invite note for this workshop.
+            - else
+              = @workshop.invite_note.html_safe
 
   - if @workshop.invitations.any?
     .row

--- a/app/views/invitation/_coach.html.haml
+++ b/app/views/invitation/_coach.html.haml
@@ -8,6 +8,10 @@
 %p
   = t('coaches.unable_attend')
 
+- unless @invitation.sessions.invite_note.blank?
+  %p
+    = @invitation.sessions.invite_note.html_safe
+
 %p
   = t('coaches.food')
   #{mail_to @invitation.sessions.chapter.email, @invitation.sessions.chapter.email}.

--- a/app/views/invitation/_student.html.haml
+++ b/app/views/invitation/_student.html.haml
@@ -4,4 +4,8 @@
 
 %p Please make sure you <b>bring your laptop</b> with you.
 
+- unless @invitation.sessions.invite_note.blank?
+  %p
+    = @invitation.sessions.invite_note.html_safe
+
 %p PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us email at #{mail_to @invitation.sessions.chapter.email, @invitation.sessions.chapter.email}.

--- a/app/views/session_invitation_mailer/attending.html.haml
+++ b/app/views/session_invitation_mailer/attending.html.haml
@@ -21,6 +21,9 @@
                   See you at our workshop!
                   %p
                     Please remember that removing the calendar entry will not cancel your invitation RSVP.
+                - unless @workshop.invite_note.blank?
+                  %p
+                    = @workshop.invite_note.html_safe
 
 
 

--- a/app/views/session_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/session_invitation_mailer/attending_reminder.html.haml
@@ -16,6 +16,10 @@
                 %p.lead
                   This is a quick email to remind you that you have signed up for tomorrow's workshop.
 
+                - unless @workshop.invite_note.blank?
+                  %p
+                    = @workshop.invite_note.html_safe
+
         .content
           %table{ bgcolor: "#FFFFFF" }
             %tr

--- a/app/views/session_invitation_mailer/invite_coach.html.haml
+++ b/app/views/session_invitation_mailer/invite_coach.html.haml
@@ -18,10 +18,14 @@
 
                 %p At the workshop you will be guiding students while they work through our tutorials. Or in other programming related areas that they request help in.
 
+                - unless @session.invite_note.blank?
+                  %p
+                    = @session.invite_note.html_safe
+
                 %p You can find all our tutorials at #{link_to "http://codebar.github.io/tutorials", "http://codebar.github.io/tutorials/"}. If you would like to improve any of the existing content, you can issue a pull request to our #{link_to "GitHub repository", "https://github.com/codebar/tutorials"}
 
                 %p Before attending, make sure you read and understand our #{link_to "code of conduct", "http://codebar.io/code-of-conduct"}. We have a zero tolerance policy and expect everyone to behave appropriately. You should also go through our #{link_to "How to be an effective teacher", "http://codebar.io/effective-teacher-guide"}. If you have anything to add to it, please open a pull request or an issue.
-                
+
                 %p.callout It would be awesome if you could also #{link_to "join the chat on gitter", "https://gitter.im/codebar/tutorials"} to offer help and guidance outside the workshops.
 
         .content

--- a/app/views/session_invitation_mailer/invite_student.html.haml
+++ b/app/views/session_invitation_mailer/invite_student.html.haml
@@ -15,6 +15,10 @@
                 %h3 Hi, #{@member.name}
                 %p.lead
                   If you will be attending the workshop please RSVP as we need to know who is coming to make sure we have enough coaches and food around.
+
+                - unless @session.invite_note.blank?
+                  %p
+                    = @session.invite_note.html_safe
                 %p
                   In our workshops, you can work through any of our #{link_to "tutorials", "http://codebar.github.io/tutorials" } or get help and guidance on other technologies or your personal projects. We believe that everyone should be entitled to free learning and our community has #{ link_to "a lot of devoted developers", full_url_for(coaches_url)} who help out weekly by coaching.
                 %p You will also get the opportunity to meet other people interested in coding and collaborate with them.

--- a/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
@@ -25,6 +25,10 @@
                   = link_to "remove yourself from the waiting list", full_url_for(invitation_url(@invitation))
                   so someone else can come to the workshop.
 
+                - unless @workshop.invite_note.blank?
+                  %p
+                    = @workshop.invite_note.html_safe
+
 
         .content
           %table{ bgcolor: "#FFFFFF" }

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -23,6 +23,10 @@
         %p
           Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and mentor our students.
 
+        - unless @workshop.invite_note.blank?
+          %p
+            = @workshop.invite_note.html_safe
+
       .medium-4.columns
         .panel
           = render 'workshop_actions'

--- a/db/migrate/20150223160726_add_invite_note_to_sessions.rb
+++ b/db/migrate/20150223160726_add_invite_note_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddInviteNoteToSessions < ActiveRecord::Migration
+  def change
+    add_column :sessions, :invite_note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150222110321) do
+ActiveRecord::Schema.define(version: 20150223160726) do
 
   create_table "addresses", force: true do |t|
     t.string   "flat"
@@ -285,11 +285,12 @@ ActiveRecord::Schema.define(version: 20150222110321) do
     t.datetime "date_and_time"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "invitable",       default: true
+    t.boolean  "invitable",              default: true
     t.string   "sign_up_url"
     t.integer  "chapter_id"
     t.datetime "time"
     t.datetime "rsvp_close_time"
+    t.text     "invite_note"
   end
 
   add_index "sessions", ["chapter_id"], name: "index_sessions_on_chapter_id"
@@ -339,7 +340,7 @@ ActiveRecord::Schema.define(version: 20150222110321) do
 
   create_table "testimonials", force: true do |t|
     t.integer  "member_id"
-    t.text     "text"
+    t.text     "text",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -10,16 +10,30 @@ feature 'Managing workshops' do
     member.add_role(:organiser, Chapter)
   end
 
-  scenario "creating a new workshop" do
-    visit new_admin_workshop_path
+  context "creating a new workshop" do
+    scenario "Creating a workshop without a note" do
+      visit new_admin_workshop_path
 
-    choose chapter.name
-    fill_in "Date and time", with: Date.today
-    fill_in "Time", with: "11:30"
+      choose chapter.name
+      fill_in "Date and time", with: Date.today
+      fill_in "Time", with: "11:30"
 
-    click_on "Save"
+      click_on "Save"
 
-    expect(page).to have_content "Send Invitations"
+      expect(page).to have_content "Send Invitations"
+    end
+
+    scenario "Creating a workshop with a note" do
+      note = Faker::Lorem.paragraph
+      visit new_admin_workshop_path
+      choose chapter.name
+      fill_in "Date and time", with: Date.today
+      fill_in "Time", with: "11:30"
+      fill_in "Invite note", with: note
+
+      click_on "Save"
+      expect(page).to have_content note
+    end
   end
 
   scenario "assigning a host to a workshop" do

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -18,6 +18,14 @@ feature 'Viewing a workshop page' do
       expect(page).to have_content("Sign up")
       expect(page).to have_content("Log in")
     end
+
+    scenario "can view extra session details" do
+      content = Faker::Lorem.paragraph
+      workshop.update_attribute(:invite_note, content)
+
+      visit workshop_path workshop
+      expect(page).to have_content(content)
+    end
   end
 
   xcontext "logged in member" do

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -7,19 +7,74 @@ describe SessionInvitationMailer do
   let(:member) { Fabricate(:member) }
   let(:invitation) { Fabricate(:session_invitation, sessions: session, member: member) }
 
-  it "#invite_student" do
-    invitation_token = "token"
+  context "#invite_student" do
+    it "Emails students an invitation" do
+      email_subject = "Workshop Invitation #{humanize_date_with_time(session.date_and_time, session.time)}"
+      SessionInvitationMailer.invite_student(session, member, invitation).deliver
 
-    email_subject = "Workshop Invitation #{humanize_date_with_time(session.date_and_time, session.time)}"
-    SessionInvitationMailer.invite_student(session, member, invitation).deliver
+      expect(email.subject).to eq(email_subject)
+    end
 
-    expect(email.subject).to eq(email_subject)
+    it "Includes the invitation note in the email" do
+      content = Faker::Lorem.paragraph
+      session.update_attribute(:invite_note, content)
+      SessionInvitationMailer.invite_student(session, member, invitation).deliver
+
+      expect(email.body.encoded).to include(content)
+    end
   end
 
-  it "#attending_reminder" do
-    email_subject = "Workshop Reminder #{humanize_date_with_time(session.date_and_time, session.time)}"
-    SessionInvitationMailer.attending_reminder(session, member, invitation).deliver
+  context "#invite_coach" do
+    it "Emails students an invitation" do
+      email_subject = "Workshop Coach Invitation #{humanize_date_with_time(session.date_and_time, session.time)}"
+      SessionInvitationMailer.invite_coach(session, member, invitation).deliver
 
-    expect(email.subject).to eq(email_subject)
+      expect(email.subject).to eq(email_subject)
+    end
+
+    it "Includes the invitation note in the email" do
+      content = Faker::Lorem.paragraph
+      session.update_attribute(:invite_note, content)
+      SessionInvitationMailer.invite_coach(session, member, invitation).deliver
+
+      expect(email.body.encoded).to include(content)
+    end
+  end
+
+  context "#attending" do
+    it "Includes the invitation note in the email" do
+      content = Faker::Lorem.paragraph
+      session.update_attribute(:invite_note, content)
+      SessionInvitationMailer.attending(session, member, invitation).deliver
+
+      expect(email.body.encoded).to include(content)
+    end
+  end
+
+  context "#attending_reminder" do
+    it "Emails a reminder to attending members" do
+      email_subject = "Workshop Reminder #{humanize_date_with_time(session.date_and_time, session.time)}"
+      SessionInvitationMailer.attending_reminder(session, member, invitation).deliver
+
+      expect(email.subject).to eq(email_subject)
+    end
+
+    it "Includes the invitation note in the email" do
+      content = Faker::Lorem.paragraph
+      session.update_attribute(:invite_note, content)
+      SessionInvitationMailer.attending_reminder(session, member, invitation).deliver
+
+      expect(email.body.encoded).to include(content)
+    end
+  end
+
+  context "#waiting_list_reminder" do
+    it "Includes an invitation note in the email" do
+      content = Faker::Lorem.paragraph
+      session.update_attribute(:invite_note, content)
+      SessionInvitationMailer.waiting_list_reminder(session, member, invitation).deliver
+
+      expect(email.body.encoded).to include(content)
+    end
   end
 end


### PR DESCRIPTION
This changeset adds an `invite_note` field on the `Sessions` model. That note is visible on the website, on the session invitation page, and on the emails we send out. This allows us to: 

- Include details about the lightning talks (who's speaking, ask for participants, etc)
- Include extra details if we're in an awkward location (hard to find/bad signage/etc)
- Add information about security when we have workshops at locations that have restrictive building policies
- Let us announce other small things without requiring a separate email/newsletter.

HTML is allowed in this field, because only admins can edit it and they should be trusted users. 