### PR TITLE
Fix payment answer in FAQ

### DIFF
--- a/app/views/dashboard/faq.html.haml
+++ b/app/views/dashboard/faq.html.haml
@@ -7,7 +7,7 @@
         %dd
           = t('faq.payment.a_p1')
           = link_to t('faq.payment.awesome_coaches'), coaches_path
-          = t('faq.payment.a_p1')
+          = t('faq.payment.a_p2')
 
         %dt= t('faq.technologies.q')
         %dd= raw t('faq.technologies.a')


### PR DESCRIPTION
The answer to "Do I need to pay to attend Codebar?" used to repeat itself, instead of displaying the second half of the answer.