### PR TITLE
Convert 'Codebar' to 'codebar' as per #237

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Codebar's planner
+# Contributing to codebar's planner
 
 ## Quick guide:
 

--- a/app/helpers/email_header_helper.rb
+++ b/app/helpers/email_header_helper.rb
@@ -8,7 +8,7 @@ module EmailHeaderHelper
   end
 
   def mail_args(member, subject)
-    { :from => "Codebar.io <meetings@codebar.io>",
+    { :from => "codebar.io <meetings@codebar.io>",
       :to => member.email,
       :subject => subject }
   end

--- a/app/mailers/course_invitation_mailer.rb
+++ b/app/mailers/course_invitation_mailer.rb
@@ -10,7 +10,7 @@ class CourseInvitationMailer < ActionMailer::Base
 
     load_attachments
 
-    subject = "Course :: #{@course.title} by Codebar - #{l(@course.date_and_time, format: :email_title)}"
+    subject = "Course :: #{@course.title} by codebar - #{l(@course.date_and_time, format: :email_title)}"
 
     mail(mail_args(member, subject)) do |format|
       format.html

--- a/app/mailers/job_mailer.rb
+++ b/app/mailers/job_mailer.rb
@@ -8,7 +8,7 @@ class JobMailer < ActionMailer::Base
 
   private
   def mail_args(member, subject)
-    { :from => "Codebar.io <notifications@codebar.io>",
+    { :from => "codebar.io <notifications@codebar.io>",
       :to => member.email,
       :subject => subject }
   end

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -23,7 +23,7 @@ class MemberMailer < ActionMailer::Base
 
   def welcome_student(member)
     @member = member
-    subject = "How Codebar works"
+    subject = "How codebar works"
 
     mail(mail_args(member, subject)) do |format|
       format.html { render 'welcome_student' }
@@ -32,7 +32,7 @@ class MemberMailer < ActionMailer::Base
 
   def welcome_coach(member)
     @member = member
-    subject = "How Codebar works"
+    subject = "How codebar works"
 
     mail(mail_args(member, subject)) do |format|
       format.html { render 'welcome_coach' }

--- a/app/mailers/session_invitation_mailer.rb
+++ b/app/mailers/session_invitation_mailer.rb
@@ -57,7 +57,7 @@ class SessionInvitationMailer < ActionMailer::Base
 
     load_attachments
 
-    subject = "#{title}: #{@session.title} by Codebar - #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "#{title}: #{@session.title} by codebar - #{humanize_date_with_time(@session.date_and_time, @session.time)}"
 
     mail(mail_args(member, subject)) do |format|
       format.html { render layout: "email" }
@@ -84,7 +84,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Reminder: you're on the Codebar waiting list (#{humanize_date_with_time(@session.date_and_time, @session.time)})"
+    subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(@session.date_and_time, @session.time)})"
     mail(mail_args(member, subject)) do |format|
       format.html
     end

--- a/app/models/workshop_calendar.rb
+++ b/app/models/workshop_calendar.rb
@@ -21,7 +21,7 @@ class WorkshopCalendar
       e.organizer = "#{workshop.chapter.email}"
       e.dtstart = DateTime.parse("#{start_date}#{start_time}")
       e.dtend = e.dtstart + 2.hours + 30.minutes
-      e.summary = "Codebar @ #{workshop.host.name}"
+      e.summary = "codebar @ #{workshop.host.name}"
       e.location = address.to_s
       e.ip_class = "PRIVATE"
     end

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -17,7 +17,7 @@
         Hi #{@invitation.member.name},
 
       %p
-        If you are new to Codebar, make sure you read our #{link_to("code of conduct", code_of_conduct_path)} and #{link_to("attendance policy", attendance_policy_path)} before getting your ticket.
+        If you are new to codebar, make sure you read our #{link_to("code of conduct", code_of_conduct_path)} and #{link_to("attendance policy", attendance_policy_path)} before getting your ticket.
 
       %p
         We always make an effort to have vegetarian, vegan and gluten-free food options available. If you have any other dietary requirements #{mail_to @course.chapter.email, "send us an email"}.

--- a/app/views/job_mailer/job_approved.html.haml
+++ b/app/views/job_mailer/job_approved.html.haml
@@ -20,7 +20,7 @@
                   job you submitted has been approved.
                 %p.callout
                   It is now available to all members at
-                  %a{ href: full_url_for(jobs_url) }Codebar's jobs section &raquo;
+                  %a{ href: full_url_for(jobs_url) }codebar's jobs section &raquo;
 
                 %table.social{ width: "100%" }
                   %tr

--- a/app/views/jobs/_form.html.haml
+++ b/app/views/jobs/_form.html.haml
@@ -7,7 +7,7 @@
           = f.input :title, label: "Job title", required: true, placeholder: "e.g. Internship"
       .row
         .large-6.columns
-          = f.input :company, required: true, placeholder: "e.g. Codebar", required: true
+          = f.input :company, required: true, placeholder: "e.g. codebar", required: true
       .row
         .large-6.columns
           = f.input :location, required: true, placeholder: "e.g. London or Remote", required: true

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -6,7 +6,7 @@
 
       %p.contact
         =t("footer.email_us")
-        =mail_to "hello@codebar.io?Subject=Hello%20Codebar", "hello@codebar.io"
+        =mail_to "hello@codebar.io?Subject=Hello%20codebar", "hello@codebar.io"
 
     .large-3.columns
       %ul.no-bullet

--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -4,16 +4,16 @@
 %meta{property: "fb:admins", content: "622070503" }
 %meta{property: "og:type", content: "website" }
 %meta{property: "og:locale", content: "en_GB" }
-%meta{property: "og:site_name", content: "Codebar"}
+%meta{property: "og:site_name", content: "codebar"}
 %meta{name: "keywords", content: "codebar, programming, diversity, html, css, javascript, ruby"}
 %meta{property: "og:image", content: "http://codebar.io/images/logo-square.png"}
 %meta{ property: "og:url", content: "http://codebar.io#{url_for(nil)}" }
 - if @meeting and current_page?(meeting_path(@meeting))
-  %meta{property: "og:title", content: "Codebar - #{@meeting.title}"}
-  %meta{name: "title", content: "Codebar - #{@meeting.title}"}
+  %meta{property: "og:title", content: "codebar - #{@meeting.title}"}
+  %meta{name: "title", content: "codebar - #{@meeting.title}"}
   %meta{property: "og:description", content: "#{@meeting.description}. This month we will be presenting talks from #{all_speakers(@meeting)}." }
   %meta{ name: "description", content: "#{@meeting.description}. This month we will be presenting talks from #{all_speakers(@meeting)}." }
 - else
-  %meta{property: "og:title", content: "Codebar"}
+  %meta{property: "og:title", content: "codebar"}
   %meta{property: "og:description", content: "Making tech more diverse and welcoming by bringing people together and helping teach programming skills."}
   %meta{ name: "description", content: "Making tech more diverse and welcoming by bringing people together and helping teach programming skills."}

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Codebar.io</title>
+    <title>codebar.io</title>
   </head>
   <body style="margin: 0; padding: 0">
     <div style="width: 100%; font-family: 'proxima-nova', 'Helvetica Neue', Helvetica, Arial, sans-serif">
@@ -15,7 +15,7 @@
         <%= yield %>
 
         <div style="color: #111111; font-size: 15px; font-weight: 300; margin-top: 60px;">Despo</div>
-        <div style="color: #111111; font-size: 16px; font-weight: 600; margin-top: 5px;"><a href="http://codebar.io" style="color: #663095; text-decoration: none;">Codebar</a></div>
+        <div style="color: #111111; font-size: 16px; font-weight: 600; margin-top: 5px;"><a href="http://codebar.io" style="color: #663095; text-decoration: none;">codebar</a></div>
 
         <p style="color: #6d6a6a; font-size: 13px; font-weight: 600; margin-top: 90px;">If you dont want to receive these emails <%= link_to "unsubscribe", full_url_for(unsubscribe_url(member_token(@member))), style: "color: #a369d5; text-decoration: underline" %></p>
       </div>

--- a/app/views/member_mailer/welcome_coach.html.haml
+++ b/app/views/member_mailer/welcome_coach.html.haml
@@ -1,7 +1,7 @@
 %h1 Hi #{@member.name}!
 
 %p
-  Welcome to Codebar. Thanks so much for volunteering - we rely on coaches
+  Welcome to codebar. Thanks so much for volunteering - we rely on coaches
   to make our workshops a success, and it really helps the students who attend.
   We're looking forward to seeing you at one of our events soon.
 
@@ -32,7 +32,7 @@
   or looking for help with their own projects. Don't worry if you're not an expert on
   the topics - your role is not about having all the answers! Guiding a student through
   solving their own problem is more useful in the long run. There are more
-  =link_to "tips for coaching on the Codebar website.", teaching_guide_url
+  =link_to "tips for coaching on the codebar website.", teaching_guide_url
 
 %p
   It's important to us that our workshops are a welcoming &amp; accepting environment
@@ -51,4 +51,4 @@
 %p
   #{"-- "}
   %br
-  The Codebar organisational team
+  The codebar organisational team

--- a/app/views/member_mailer/welcome_student.html.haml
+++ b/app/views/member_mailer/welcome_student.html.haml
@@ -1,6 +1,6 @@
 %h1 Hi #{@member.name}!
 
-%p Welcome to Codebar. We're looking forward to seeing you at one of our events soon.
+%p Welcome to codebar. We're looking forward to seeing you at one of our events soon.
 
 %p
   - if @member.subscriptions.any?
@@ -14,7 +14,7 @@
 %p
   Our workshops are available to women, LGBTQ people, and others under-represented
   in the tech industry. If you belong to one of these groups, you are more than welcome
-  to attend. You can find out more about Codebar's workshops
+  to attend. You can find out more about codebar's workshops
   = link_to "in our FAQ.", faq_url
 
 %p
@@ -22,7 +22,7 @@
   you to a coach with one to three other students. You can either work through
   = link_to "one of our tutorials", "http://tutorials.codebar.io/"
   or get help with your own project. After 2 hours of coaching, we retire to a nearby
-  pub for some post-Codebar relaxation.
+  pub for some post-codebar relaxation.
 
 %p
   It's important to us that our workshops are a welcoming &amp; accepting environment
@@ -40,4 +40,4 @@
 %p
   #{"-- "}
   %br
-  The Codebar organisational team
+  The codebar organisational team

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -23,7 +23,7 @@
         - if @member.coach?
           = f.input :about_you, as: :text, label: "What experience do you have? What languages do you like to use? Tell us a little about yourself!", required: true
         - else
-          = f.input :about_you, as: :text, label: "What do you want to work on at Codebar? What have you done in the past? Tell us a little about yourself!", required: true
+          = f.input :about_you, as: :text, label: "What do you want to work on at codebar? What have you done in the past? Tell us a little about yourself!", required: true
 
     .row
       .large-6.large-offset-3.columns.text-right

--- a/app/views/members/step2.html.haml
+++ b/app/views/members/step2.html.haml
@@ -3,7 +3,7 @@
     .medium-12.columns
       %h1 Pick an invite list
       %p
-        You can register for events on the Codebar site, but it's easier via email.
+        You can register for events on the codebar site, but it's easier via email.
         Join an email list below to receive invites for that location.
 
   - if current_user.coach?

--- a/app/views/session_invitation_mailer/change_of_details.html.erb
+++ b/app/views/session_invitation_mailer/change_of_details.html.erb
@@ -4,7 +4,7 @@
 <p style="font-weight: 300; font-size: 16px; color: #2e2e2e; margin-bottom: 50px;">Below you can find the updated session details:</p>
 
 
-<h2 style="color: #2d183d; font-size: 27px; font-weight: 500;letter-spacing: 0.03em; margin-bottom: 0;"><%= @session.title %> by Codebar</h2>
+<h2 style="color: #2d183d; font-size: 27px; font-weight: 500;letter-spacing: 0.03em; margin-bottom: 0;"><%= @session.title %> by codebar</h2>
 <small><%= @session.description %></small>
 <p style="font-size: 16px; font-weight: 300; margin-top: 7px;">on <b style="color: #555555;font-size: 16px; font-weight: 600; margin-top: 0;"><%= l(@session.date_and_time, format: :email)%></b></p>
 

--- a/app/views/workshops/added.html.haml
+++ b/app/views/workshops/added.html.haml
@@ -3,9 +3,9 @@
   .container
     .row
       .medium-8.columns
-        %h1 You're coming to Codebar!
+        %h1 You're coming to codebar!
         %p
-          Thanks for signing up to this Codebar event! We're looking forward to seeing you.
+          Thanks for signing up to this codebar event! We're looking forward to seeing you.
           Please be sure you've read our #{link_to 'Code of Conduct', code_of_conduct_path} before attending.
 
         - if @coach
@@ -14,7 +14,7 @@
           %p You'll need to bring your laptop with you, but you shouldn't need anything else.
 
         %p
-          We're looking forward to seeing you at Codebar soon!
+          We're looking forward to seeing you at codebar soon!
           = link_to "Drop us an email", "mailto:hello@codebar.io"
           if you have any questions.
         %p

--- a/app/views/workshops/removed.html.haml
+++ b/app/views/workshops/removed.html.haml
@@ -5,11 +5,11 @@
       .medium-8.columns
         %h1 Sorry to see you go. ☹
         %p
-          We're sad that you can't make it to this Codebar event - but thanks for letting us know!
+          We're sad that you can't make it to this codebar event - but thanks for letting us know!
           By cancelling your attendance, you're letting us give your place to someone else on the waiting list. And that's awesome.
 
         %p
-          Even though you can't make it to this Codebar, we're looking forward to seeing you at another Codebar soon!
+          Even though you can't make it to this codebar, we're looking forward to seeing you at another codebar soon!
           = link_to "Drop us an email", "mailto:hello@codebar.io"
           if you have any questions.
         %p

--- a/app/views/workshops/waitlisted.html.haml
+++ b/app/views/workshops/waitlisted.html.haml
@@ -5,7 +5,7 @@
       .medium-12.columns
         %h1 You're on the waiting list for this event.
         %p
-          You've been added to the waiting list for this Codebar event. We can't guarantee you a place, but we get a lot of cancellations on the day.
+          You've been added to the waiting list for this codebar event. We can't guarantee you a place, but we get a lot of cancellations on the day.
           %strong We strongly recommend you pack everything you need, as we may give you a place on short notice.
 
         %p Please be sure you've read our #{link_to 'Code of Conduct', code_of_conduct_path} before attending.
@@ -16,7 +16,7 @@
           %p As a student, you'll need to bring your laptop with you, but you shouldn't need anything else.
 
         %p
-          We hope to see you at Codebar soon!
+          We hope to see you at codebar soon!
           = link_to "Drop us an email", "mailto:hello@codebar.io"
           if you have any questions.
         %p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
-  brand: "Codebar.io"
+  brand: "codebar.io"
 
   date:
       formats:
@@ -180,7 +180,7 @@ en:
 
   faq:
     payment:
-      q: "Do I need to pay to attend Codebar?"
+      q: "Do I need to pay to attend codebar?"
       a_p1: "Absolutely not! We are lucky enough to have some great companies who are able to host the workshops and/or kindly provide food. And our"
       awesome_coaches: "awesome coaches"
       a_p2: "give their time freely to help the community."
@@ -191,8 +191,8 @@ en:
       q: "I want to attend a workshop. Am I eligible?"
       a: "Our workshops are available to women, LGBTQ and people who are underrepresented in the tech industry. If you belong to one of these groups, you are more than welcome to attend. If not, there are some other great initiatives like <a href=\"http://www.meetup.com/opentechschool-london\">Open Tech School London</a> where you can learn in a collaborative environment."
     career:
-      q: "Is Codebar only aimed at people who want to move into a career as a developer?"
-      a: "No! Codebar is about getting people excited about programming. We'll help them learn some basic coding skills, as well as how to explore and do things on their own. For those who do want to become developers, we will provide help and guidance to help them achieve their goal."
+      q: "Is codebar only aimed at people who want to move into a career as a developer?"
+      a: "No! codebar is about getting people excited about programming. We'll help them learn some basic coding skills, as well as how to explore and do things on their own. For those who do want to become developers, we will provide help and guidance to help them achieve their goal."
     format:
       q: "What is the format of the workshops?"
       a: "We try to have one coach for every two students. We will pair up students who want to work on the same tutorial, and assign them a coach. The rest just happens."
@@ -200,10 +200,10 @@ en:
       q: "Do I need to bring a laptop with me at the workshops?"
       a: "Yes, we suggest that you bring a laptop as it will be easier for you to carry on working on things after the workshops. It you don't have one, <a href=\"mailto:contact@codebar.io\">send us an email</a> so we can try and help out."
     online_resources:
-      q: "There are so many online resources, why should I come to Codebar?"
+      q: "There are so many online resources, why should I come to codebar?"
       a: "Coding can be intimidating and a lot of people find it hard to get started. By putting you in touch with people who can help and guide you we make the experience and learning process easier and more enjoyable."
     preperations:
-      q: "I would like to coach at Codebar. Is there anything I should do besides signing up?"
+      q: "I would like to coach at codebar. Is there anything I should do besides signing up?"
       a_p1: "Yes. First you should read our"
       coaching_guide_tutorials: "coaching guide tutorials"
       a_p2: ". Then spend sometime familiarising yourself with the"
@@ -216,8 +216,8 @@ en:
       q: "Is there disabled access at the workshops?"
       a: "Unfortunately, that depends entirely on where we are hosting our workshops and if the venue has disabled access. If you would like to attend, send us an email at <a href='mailto:meetings@codebar.io'>meetings[at]codebar.io</a> so we can enquire about it and let you know."
     bring_codebar_to_my_city:
-      q: "I would like to bring Codebar to my city. Can I do that?"
-      a: "Of course. Codebar is about building a community of experienced developers that are able to give up some of their time to help others. If you are keen on running Codebar where you live, we would love to speak to you about it and see how we can help make this happen, so send <a href=\"mailto:contact@codebar.io\">us an email</a>.Of course. Codebar is about building a community of experienced developers that are able to give up some of their time to help others. If you are keen on running Codebar where you live, we would love to speak to you about it and see how we can help make this happen, so send <a href=\"mailto:contact@codebar.io\">us an email</a>."
+      q: "I would like to bring codebar to my city. Can I do that?"
+      a: "Of course. codebar is about building a community of experienced developers that are able to give up some of their time to help others. If you are keen on running codebar where you live, we would love to speak to you about it and see how we can help make this happen, so send <a href=\"mailto:contact@codebar.io\">us an email</a>.Of course. codebar is about building a community of experienced developers that are able to give up some of their time to help others. If you are keen on running codebar where you live, we would love to speak to you about it and see how we can help make this happen, so send <a href=\"mailto:contact@codebar.io\">us an email</a>."
     our_coaches:
       q: "Our coaches"
       a_p1: "You can see all the coaches have helped out in our workshops on the"

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -11,13 +11,13 @@ feature 'chapters' do
     scenario "an admin can create a new chapter" do
       visit new_admin_chapter_path
 
-      fill_in "Name", with: "Codebar Brighton"
+      fill_in "Name", with: "codebar Brighton"
       fill_in "Email", with: "brighton@codebar.io"
       fill_in "City", with: "Brighton"
 
       click_on "Create chapter"
 
-      expect(page).to have_content("Chapter Codebar Brighton has been succesfuly created")
+      expect(page).to have_content("Chapter codebar Brighton has been succesfuly created")
     end
   end
 end

--- a/spec/mailers/course_invitation_mailer_spec.rb
+++ b/spec/mailers/course_invitation_mailer_spec.rb
@@ -9,7 +9,7 @@ describe CourseInvitationMailer do
     course = Fabricate(:course, title: "HTTP Fundamentals", date_and_time: DateTime.new(2013,10,30,18,30))
     invitation_token = "token"
 
-    email_subject = "Course :: #{course.title} by Codebar - Wednesday, 30 Oct at 18:30"
+    email_subject = "Course :: #{course.title} by codebar - Wednesday, 30 Oct at 18:30"
     CourseInvitationMailer.invite_student(course, member, invitation_token).deliver
 
     expect(email.subject).to eq(email_subject)

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MemberMailer, :type => :mailer do
     let(:mail) { MemberMailer.welcome_student(member) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("How Codebar works")
+      expect(mail.subject).to eq("How codebar works")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(["meetings@codebar.io"])
     end
@@ -21,7 +21,7 @@ RSpec.describe MemberMailer, :type => :mailer do
     let(:mail) { MemberMailer.welcome_coach(member) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("How Codebar works")
+      expect(mail.subject).to eq("How codebar works")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(["meetings@codebar.io"])
     end


### PR DESCRIPTION
This is a simple find and replace all for all instances of `"Codebar"`. Fixes #237.

I've commented on some things of possible concern.