### PR TITLE
Restrict Mailchimp API calls to production

### DIFF
--- a/lib/services/mailing_list.rb
+++ b/lib/services/mailing_list.rb
@@ -6,7 +6,7 @@ class MailingList
   end
 
   def subscribe(email, first_name, last_name)
-    return true if Rails.env.test?
+    return true unless Rails.env.production?
     client.lists.subscribe({id: list_id,
                             email: {email: email},
                             merge_vars: {FNAME: first_name, LNAME: last_name},
@@ -15,7 +15,7 @@ class MailingList
   end
 
   def unsubscribe(email)
-    return true if Rails.env.test?
+    return true unless Rails.env.production?
     client.lists.unsubscribe(id: list_id,
                              email: {email: email},
                              send_notify:  false)


### PR DESCRIPTION
This should fix #243. Can we even test this change? I'm kind of confused as to what's going on with the tests for this. What's "xit"? It skips the tests.

Also the style the parameters are passed into `client.lists.unsubscribe` is different to the style in `client.lists.subscribe`. Checked gibbon and the readme examples are written the same way. Oddly inconsistent though, for the methods to work differently. I look at it and feel like they should both be hashes.