### PR TITLE
Feature/export workshop attendees emails

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -3,7 +3,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
   include  Admin::WorkshopConcerns
 
   before_filter :set_workshop_by_id, only: [:show, :edit]
-  before_filter :set_and_decorate_workshop, only: [:coaches_checklist, :students_checklist]
+  before_filter :set_and_decorate_workshop, only: [:attendees_checklist]
 
   def index
     @chapter = Chapter.find(params[:chapter_id])
@@ -56,14 +56,8 @@ class Admin::WorkshopsController < Admin::ApplicationController
     redirect_to admin_workshop_path(@workshop), notice: "Workshops updated succesfully"
   end
 
-  def coaches_checklist
-    return render text: @workshop.coaches_checklist if request.format.text?
-
-    redirect_to admin_workshop_path(@workshop)
-  end
-
-  def students_checklist
-    return render text: @workshop.students_checklist if request.format.text?
+  def attendees_checklist
+    return render text: @workshop.attendees_checklist if request.format.text?
 
     redirect_to admin_workshop_path(@workshop)
   end
@@ -99,8 +93,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
   def workshop_id
     params[:workshop_id] || params[:id]
   end
-
-  private
 
   def set_host(host_id)
     return unless host_id

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -3,7 +3,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
   include  Admin::WorkshopConcerns
 
   before_filter :set_workshop_by_id, only: [:show, :edit]
-  before_filter :set_and_decorate_workshop, only: [:attendees_checklist]
+  before_filter :set_and_decorate_workshop, only: [:attendees_checklist, :attendees_emails]
 
   def index
     @chapter = Chapter.find(params[:chapter_id])
@@ -58,6 +58,12 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   def attendees_checklist
     return render text: @workshop.attendees_checklist if request.format.text?
+
+    redirect_to admin_workshop_path(@workshop)
+  end
+
+  def attendees_emails
+    return render text: @workshop.attendees_emails if request.format.text?
 
     redirect_to admin_workshop_path(@workshop)
   end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -29,16 +29,8 @@ class WorkshopPresenter < EventPresenter
     CSV.generate {|csv| attendee_array.each { |a| csv << a } }
   end
 
-  def students_checklist
-    model.attending_students.order('note asc').each_with_index.map do |a, pos|
-      "#{member_info(a.member, pos)}\t\t\t#{note(a)}"
-    end.join("\n\n")
-  end
-
-  def coaches_checklist
-    model.attending_coaches.each_with_index.map do |a, pos|
-      "#{member_info(a.member, pos)}"
-    end.join("\n\n")
+  def attendees_checklist
+    "Students \n\n" + students_checklist + "\n\n\n\n Coaches \n\n" + coaches_checklist
   end
 
   def time
@@ -59,6 +51,18 @@ class WorkshopPresenter < EventPresenter
   end
 
   private
+
+  def students_checklist
+    model.attending_students.order('note asc').each_with_index.map do |a, pos|
+      "#{member_info(a.member, pos)}\t\t\t#{note(a)}"
+    end.join("\n\n")
+  end
+
+  def coaches_checklist
+    model.attending_coaches.each_with_index.map do |a, pos|
+      "#{member_info(a.member, pos)}"
+    end.join("\n\n")
+  end
 
   def attendee_array
     model.attendances.map do |i|

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -34,7 +34,7 @@ class WorkshopPresenter < EventPresenter
   end
 
   def attendees_emails
-    model.attendances.map {|m| m.member.email if m.member }.join(', ')
+    model.attendances.map {|m| m.member.email if m.member }.compact.join(', ')
   end
 
   def time

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -33,6 +33,10 @@ class WorkshopPresenter < EventPresenter
     "Students \n\n" + students_checklist + "\n\n\n\n Coaches \n\n" + coaches_checklist
   end
 
+  def attendees_emails
+    model.attendances.map {|m| m.member.email if m.member }.join(', ')
+  end
+
   def time
     I18n.l(model.time, format: :time)
   end

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -17,12 +17,13 @@
   =link_to admin_workshop_path(format: 'csv'), class: 'item', title: "CSV for labels" do
     %i.fa.fa-users
     %label Labels
-  =link_to  admin_workshop_students_checklist_path(@workshop, format: 'text'), title: "Student checklist", class: 'item' do
+  =link_to admin_workshop_attendees_checklist_path(@workshop, format: 'text'), title: "Attendee checklist", class: 'item' do
     %i.fa.fa-list-ul
-    %label Students
-  =link_to  admin_workshop_coaches_checklist_path(@workshop, format: 'text'), title: "Coach checklist", class: 'item' do
-    %i.fa.fa-list-ul
-    %label Coaches
+    %label Attendees
+  =link_to '#', title: "Emails", class: 'item' do
+    %i.fa.fa-at
+    %label Emails
+
 
 %section
   .stripe.reverse

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -20,7 +20,7 @@
   =link_to admin_workshop_attendees_checklist_path(@workshop, format: 'text'), title: "Attendee checklist", class: 'item' do
     %i.fa.fa-list-ul
     %label Attendees
-  =link_to '#', title: "Emails", class: 'item' do
+  =link_to admin_workshop_attendees_emails_path(@workshop, format: 'text'), title: "Attendee emails", class: 'item' do
     %i.fa.fa-at
     %label Emails
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,8 +119,7 @@ Planner::Application.routes.draw do
       post :sponsor
       delete 'sponsor', action: 'destroy_sponsor', as: :destroy_sponsor
       post :invite
-      get 'students_checklist'
-      get 'coaches_checklist'
+      get 'attendees_checklist'
 
       resource :invitations, only: [:update]
       resources :invitations, only: [:update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Planner::Application.routes.draw do
       delete 'sponsor', action: 'destroy_sponsor', as: :destroy_sponsor
       post :invite
       get 'attendees_checklist'
+      get 'attendees_emails'
 
       resource :invitations, only: [:update]
       resources :invitations, only: [:update]


### PR DESCRIPTION
- Removed student and coach separate textfile exports from workshop admin page
- Added new option for 'Attendees Checklist', which combines students and coaches into one page
- Added new option for 'Attendees Emails', which displays all attendees' emails in plaintext format
- Updated UI for buttons on workshop page