### PR TITLE
Fix logo url in email header

### DIFF
--- a/app/views/shared_mailers/_body_header.html.haml
+++ b/app/views/shared_mailers/_body_header.html.haml
@@ -7,7 +7,7 @@
         %table{ bgcolor: "#fdfdfd" }
           %tr
             %td
-              = image_tag 'https://raw.githubusercontent.com/codebar/assets/master/logo/png/logotype.png', alt: "codebar logo"
+              = image_tag 'https://raw.githubusercontent.com/codebar/assets/master/logo/png/160x160px/logotype-160.png', alt: "codebar logo"
             %td{ align: "right"}
               %h6.collapse= title
     %td


### PR DESCRIPTION
Updating the logo url in`shared_mailers/_body_header.html.haml`
Ref: #337 