### PR TITLE
Update redcarpet to 3.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rdoc (4.2.0)
-    redcarpet (3.3.2)
+    redcarpet (3.3.3)
     request_store (1.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)


### PR DESCRIPTION
Picking up https://github.com/vmg/redcarpet/pull/516 (leaks ~300 bytes
on every markdown render), which might help with #322.

(I believe this pushing this change is sufficient for heroku to
update, but I'm not intimately familiar with heroku ruby deployments.)