### PR TITLE
Configure tests to format coverage results locally

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,18 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'simplecov'
+require 'coveralls'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start 'rails' do
+  add_group "Presenters", "app/presenters"
+  add_group "Policies", "app/policies"
+end
+
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/its'
-
-require 'coveralls'
-Coveralls.wear!
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
This should keep coveralls working, but also emit the output in
coverage/index.html so that you can see the effect of your change when
writing it.

Also use the rails profile so results are neatly grouped.