### PR TITLE
Spec auth infrastructure

### DIFF
--- a/spec/fabricators/auth_service_fabricator.rb
+++ b/spec/fabricators/auth_service_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:auth_service) do
-  provider { Faker::Company.name }
-  uid { Fabricate.sequence(:uid) }
+  provider "github"
+  uid { Fabricate.sequence(:uid) { |i| i.to_s } }
 end

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -5,6 +5,7 @@ feature 'when visiting the homepage' do
   let!(:next_session) { Fabricate(:sessions) }
   let!(:next_course) { Fabricate(:course) }
   let!(:event) { Fabricate(:event) }
+  let!(:member) { Fabricate(:member) }
 
   before(:each) do
     visit root_path
@@ -37,6 +38,15 @@ feature 'when visiting the homepage' do
     visit root_path
 
     expect(page).to have_content "Sign in"
+  end
+
+  scenario "i can see the menu button when signed in" do
+    visit root_path
+    authenticate_as member
+    click_on "Sign in"
+
+    expect(page).not_to have_content "Sign in"
+    expect(page).to have_content "Menu"
   end
 
   context "signing up" do

--- a/spec/omniauth_spec_helpers.rb
+++ b/spec/omniauth_spec_helpers.rb
@@ -1,0 +1,9 @@
+module OmniAuthSpecHelpers
+  def authenticate_as(member)
+    OmniAuth.config.add_mock(:github,
+                             {uid: member.auth_services.first.uid,
+                              credentials: {token: "token",
+                                            secret: "secret"}
+                             })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,10 +11,13 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
+require 'omniauth_spec_helpers'
+
 RSpec.configure do |config|
   config.include ApplicationHelper
   config.include CoursesHelper
   config.include LoginHelpers
+  config.include OmniAuthSpecHelpers
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
@@ -23,11 +26,16 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
+    OmniAuth.config.test_mode = true
+
     DatabaseCleaner.clean_with(:truncation)
     DatabaseCleaner.strategy = :deletion
+
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:github]
   end
 
   config.around(:each) do |example|
+    OmniAuth.config.mock_auth[:github] = nil
     DatabaseCleaner.cleaning do
       example.run
     end


### PR DESCRIPTION
Currently, none of the tests really cover signed-in behaviour. This gives us enough test mocking for specs to click on the "Sign in" button and have it work as expected (the github auth is mocked out).