### PR TITLE
Random spot allocation for workshops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '2.2.2'
 
 gem 'rails', '4.1.12'
 
+gem 'activejob_backport'
 gem 'acts-as-taggable-on', '~> 3.4'
 gem 'haml'
 gem 'compass-rails', github: 'Compass/compass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       activesupport (= 4.1.12)
       builder (~> 3.1)
       erubis (~> 2.7.0)
+    activejob_backport (0.0.3)
+      activesupport (>= 4.0.0)
     activemodel (4.1.12)
       activesupport (= 4.1.12)
       builder (~> 3.1)
@@ -382,6 +384,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activejob_backport
   acts-as-taggable-on (~> 3.4)
   better_errors
   capybara
@@ -440,4 +443,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Despo Pentara
+Copyright (c) 2013 Despo Pentara and Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,12 +27,12 @@
 
 $(function(){
   $(document).foundation();
-  $('#sessions_date_and_time, #event_date_and_time').pickadate({
+  $('#sessions_date_and_time, #event_date_and_time, .random_allocate_input.date').pickadate({
     format: 'dd/mm/yyyy'
   });
 
   $('#announcement_expires_at, #ban_expires_at').pickadate();
-  $('#sessions_time, #event_begins_at, #event_ends_at').pickatime({
+  $('#sessions_time, #event_begins_at, #event_ends_at, .random_allocate_input.time').pickatime({
     format: 'HH:i'
   });
 
@@ -42,4 +42,12 @@ $(function(){
     allow_single_deselect: true
     no_results_text: 'No results matched'
   });
+
+  var random_allocate_enable = function() {
+     var enabled = $('input#random_allocate').prop('checked');
+     $('.random_allocate_input').prop('disabled', !enabled);
+  };
+
+  $('input#random_allocate').change(random_allocate_enable);
+  random_allocate_enable();
 });

--- a/app/assets/stylesheets/partials/_admin_workshop.scss
+++ b/app/assets/stylesheets/partials/_admin_workshop.scss
@@ -2,3 +2,7 @@
   padding-top: 10px;
 }
 
+.input.random_allocate_at {
+  border: 1px solid black;
+  padding: 10px;
+}

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -19,6 +19,8 @@ class Admin::WorkshopsController < Admin::ApplicationController
     @workshop = Sessions.new(workshop_params)
     authorize(@workshop)
 
+    set_random_allocate
+
     if @workshop.save
       grant_organiser_access(@workshop.chapter.organisers.map(&:id))
       set_host(host_id)
@@ -50,6 +52,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
     @workshop.update_attributes(workshop_params)
 
+    set_random_allocate
     set_organisers(organiser_ids)
     set_host(host_id)
 
@@ -114,6 +117,16 @@ class Admin::WorkshopsController < Admin::ApplicationController
     organiser_ids.reject!(&:empty?)
     grant_organiser_access(organiser_ids)
     revoke_organiser_access(organiser_ids)
+  end
+
+  def set_random_allocate
+    if params[:random_allocate] == "enabled"
+      date = DateTime.parse(params[:random_allocate_date])
+      time = Time.parse(params[:random_allocate_time])
+      @workshop.update(random_allocate_at: date.change(hour: time.hour, min: time.min))
+    else
+      @workshop.update(random_allocate_at: nil)
+    end
   end
 
   def host_id

--- a/app/controllers/concerns/invitation_controller_concerns.rb
+++ b/app/controllers/concerns/invitation_controller_concerns.rb
@@ -20,8 +20,7 @@ module InvitationControllerConcerns
         return redirect_to :back, notice: "You have already RSVP'd to another workshop on this date. If you would prefer to attend this workshop, please cancel your other RSVP first."
       end
 
-      @workshop = WorkshopPresenter.new(@invitation.sessions)
-      if (@invitation.for_student? and @workshop.student_spaces?) or (@invitation.for_coach? and @workshop.coach_spaces?)
+      if @invitation.can_accept?
         @invitation.update_attribute(:attending, true)
         @invitation.waiting_list.delete  if @invitation.waiting_list.present?
         SessionInvitationMailer.attending(@invitation.sessions, @invitation.member, @invitation).deliver

--- a/app/controllers/concerns/invitation_controller_concerns.rb
+++ b/app/controllers/concerns/invitation_controller_concerns.rb
@@ -43,7 +43,7 @@ module InvitationControllerConcerns
 
           next_spot = WaitingList.next_spot(@invitation.sessions, @invitation.role)
 
-          if next_spot.present?
+          if next_spot.present? and next_spot.invitation.can_accept?
             invitation = next_spot.invitation
             next_spot.delete
             invitation.update_attribute(:attending, true)

--- a/app/controllers/invitation_controller.rb
+++ b/app/controllers/invitation_controller.rb
@@ -24,10 +24,9 @@ class InvitationController < ApplicationController
   end
 
   def accept_with_note
-    @workshop = WorkshopPresenter.new(@invitation.sessions)
     @invitation.update_attribute(:note, params[:session_invitation][:note])
 
-    if @workshop.student_spaces?
+    if @invitation.can_accept?
       @invitation.update_attribute(:attending, true)
       SessionInvitationMailer.attending(@invitation.sessions, @invitation.member, @invitation).deliver
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,4 +39,10 @@ module ApplicationHelper
   def twitter_id
     Planner::Application.config.twitter_id
   end
+
+  def present(model, presenter_class=nil)
+    klass = presenter_class || "#{model.class}Presenter".constantize
+    presenter = klass.new(model)
+    yield(presenter) if block_given?
+  end
 end

--- a/app/jobs/allocate_spaces_job.rb
+++ b/app/jobs/allocate_spaces_job.rb
@@ -1,0 +1,50 @@
+class AllocateSpacesJob < ActiveJob::Base
+  queue_as :default
+
+  def self.perform_when_needed(workshop)
+    logger.info "Scheduling allocation of #{workshop.date_and_time} " \
+                "workshop at #{workshop.random_allocate_at}"
+    AllocateSpacesJob.set(
+      wait_until: workshop.random_allocate_at).perform_later(workshop)
+  end
+
+  def perform(workshop)
+    if workshop.random_allocate_at.nil?
+      return
+    end
+
+    if not workshop.random_allocate_at.past?
+      AllocateSpacesJob.perform_when_needed(workshop)
+      return
+    end
+
+    logger.info "Performing space allocation for #{workshop.date_and_time}"
+
+    @workshop = WorkshopPresenter.new(workshop)
+
+    workshop.transaction do
+      while @workshop.student_spaces?
+        assign_space(workshop, 'Student') or break
+      end
+
+      while @workshop.coach_spaces?
+        assign_space(workshop, 'Coach') or break
+      end
+    end
+  end
+
+  private
+
+  def assign_space(workshop, role)
+    waiting = WaitingList.waiting_for(workshop, role)
+    winner = waiting.sample or return false
+
+    invitation = winner.invitation
+    winner.destroy!
+    invitation.update!({attending: true})
+    SessionInvitationMailer.attending(
+      invitation.sessions, invitation.member, invitation, true).deliver
+    return true
+  end
+
+end

--- a/app/models/session_invitation.rb
+++ b/app/models/session_invitation.rb
@@ -27,4 +27,17 @@ class SessionInvitation < ActiveRecord::Base
       SessionInvitationMailer.invite_student(self.sessions, self.member, self).deliver
     end
   end
+
+  def can_accept?
+    if for_student?
+      return sessions.student_spaces?
+    end
+
+    if for_coach?
+      return sessions.coach_spaces?
+    end
+
+    # We'll fall off the end falsely if the invitation is neither a
+    # student nor a coach
+  end
 end

--- a/app/models/session_invitation.rb
+++ b/app/models/session_invitation.rb
@@ -29,6 +29,10 @@ class SessionInvitation < ActiveRecord::Base
   end
 
   def can_accept?
+    if not sessions.can_accept?
+      return false
+    end
+
     if for_student?
       return sessions.student_spaces?
     end

--- a/app/models/sessions.rb
+++ b/app/models/sessions.rb
@@ -60,6 +60,10 @@ class Sessions < ActiveRecord::Base
     future? && rsvp_close_time.future?
   end
 
+  def can_accept?
+    random_allocate_at.nil? or random_allocate_at.past?
+  end
+
   def future?
     date_and_time.future?
   end

--- a/app/models/sessions.rb
+++ b/app/models/sessions.rb
@@ -64,6 +64,12 @@ class Sessions < ActiveRecord::Base
     random_allocate_at.nil? or random_allocate_at.past?
   end
 
+  # nil if allocations are being made immediately, otherwise the time
+  # when allocations will be made
+  def allocation_time
+    can_accept? ? nil : random_allocate_at
+  end
+
   def future?
     date_and_time.future?
   end

--- a/app/models/sessions.rb
+++ b/app/models/sessions.rb
@@ -18,7 +18,7 @@ class Sessions < ActiveRecord::Base
 
   validates :chapter_id, presence: true
 
-  before_save :combine_date_and_time, :set_rsvp_close_time
+  before_save :combine_date_and_time, :set_rsvp_close_time, :schedule_allocation
 
   def host
     SponsorSession.hosts.for_session(self.id).first.sponsor rescue nil
@@ -114,6 +114,12 @@ class Sessions < ActiveRecord::Base
 
   def set_rsvp_close_time
     self.rsvp_close_time ||= self.date_and_time
+  end
+
+  def schedule_allocation
+    if allocation_time and random_allocate_at_changed?
+      AllocateSpacesJob.perform_when_needed(self)
+    end
   end
 
 end

--- a/app/models/sessions.rb
+++ b/app/models/sessions.rb
@@ -64,6 +64,14 @@ class Sessions < ActiveRecord::Base
     date_and_time.future?
   end
 
+  def coach_spaces?
+    not host.nil? and host.coach_spots > attending_coaches.length
+  end
+
+  def student_spaces?
+    not host.nil? and host.seats > attending_students.length
+  end
+
   # Is this person attending this event?
   def attendee?(person)
     return false if person.nil?

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -18,7 +18,11 @@ class WaitingList < ActiveRecord::Base
     by_workshop(workshop).where_role('Coach').where(auto_rsvp: true).map(&:member)
   end
 
+  def self.waiting_for(workshop, role)
+    by_workshop(workshop).where_role(role).where(auto_rsvp: true)
+  end
+
   def self.next_spot(workshop, role)
-    by_workshop(workshop).where_role(role).where(auto_rsvp: true).first
+    self.waiting_for(workshop, role).first
   end
 end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -54,6 +54,16 @@ class WorkshopPresenter < EventPresenter
             "(in #{distance_of_time_in_words_to_now(date_and_time)})"
   end
 
+  def random_allocate_date
+    model.random_allocate_at.nil? ? "" :
+      model.random_allocate_at.strftime("%d/%m/%Y")
+  end
+
+  def random_allocate_time
+    model.random_allocate_at.nil? ? "" :
+      model.random_allocate_at.strftime("%H:%M")
+  end
+
   private
 
   def students_checklist

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -20,5 +20,8 @@
       = f.collection_select :organisers, Member.all, :id, :full_name, { selected: @workshop.organisers.map(&:id) }, { multiple: true }
       = f.input :invitable
   .row
+    .large-4.columns
+      = render partial: "random_allocate_input"
+  .row
     .large-12.columns.text-right
       = f.submit "Save", class: "button"

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -18,5 +18,8 @@
     .large-6.columns
       = f.input :invitable
   .row
+    .large-4.columns
+      = render partial: "random_allocate_input"
+  .row
     .large-12.columns.text-right
       = f.submit "Save", class: "button"

--- a/app/views/admin/workshops/_random_allocate_input.html.haml
+++ b/app/views/admin/workshops/_random_allocate_input.html.haml
@@ -1,0 +1,23 @@
+- present(@workshop, WorkshopPresenter) do |workshop|
+  .input.random_allocate_at
+    .input
+      %input#random_allocate{type: "checkbox", name: "random_allocate", value: "enabled",
+                             checked: (not @workshop.random_allocate_at.nil?)}
+      %label.control-label{for: "random_allocate"}
+        Randomly assign spaces
+    .input.required
+      %label.required.control-label{for: "random_allocate_input_date"}
+        Random assignment date
+      %input{type: "text", name: "random_allocate_date",
+             id: "random_allocate_input_date",
+             class: ["random_allocate_input", "date"],
+             data: {value: workshop.random_allocate_date },
+             required: true}
+    .input.required
+      %label.required.control-label{for: "random_allocate_input_time"}
+        Random assignment time
+      %input{type: "text", name: "random_allocate_time",
+             id: "random_allocate_input_time",
+             class: ["random_allocate_input", "time"],
+             data: {value: workshop.random_allocate_time },
+             required: true}

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -39,6 +39,10 @@
           %strong.label.round.primary #{@workshop.venue.seats} student spots, #{@workshop.venue.coach_spots} coach spots
           - unless @workshop.spaces?
             %label.label.round.warning Full
+    .row
+      .medium-12.columns
+        - if not @workshop.random_allocate_at.nil? and @workshop.random_allocate_at.future?
+          Spots will be randomly allocated at #{l(@workshop.random_allocate_at)}
 
     %br
 

--- a/app/views/invitation/_waiting_list.html.haml
+++ b/app/views/invitation/_waiting_list.html.haml
@@ -1,7 +1,11 @@
 - if not invitation.waiting_list.blank?
   - if invitation.waiting_list.auto_rsvp?
-
-    .text-center Waiting List position: <strong>#{invitation.waiting_list_position}</strong>/#{@workshop.waiting_list_count_for(invitation.role)}
+    - if not invitation.sessions.allocation_time.nil?
+      .text-center
+        You are on the waiting list. Places for this workshop will be
+        allocated at #{l(invitation.sessions.allocation_time)}.
+    - else
+      .text-center Waiting List position: <strong>#{invitation.waiting_list_position}</strong>/#{@workshop.waiting_list_count_for(invitation.role)}
     %br
     = link_to "Remove from Waiting list", invitation_waiting_list_path(invitation), method: :delete, class: 'button expand round alert', "data-confirm" => "Are you sure you want to let go of your spot? You cannot undo this."
   - else

--- a/app/views/invitation/_waiting_list.html.haml
+++ b/app/views/invitation/_waiting_list.html.haml
@@ -1,9 +1,4 @@
-- if invitation.waiting_list.blank?
-  %p The workshop is full.
-  = link_to "Join the Waiting List", invitation_waiting_list_path(invitation), method: :post, class: 'button round expand', "data-confirm" => "Are you sure you want to join the waiting list? If any spots become available, even last minute, you will get a spot for the workshop."
-
-  = link_to "Not sure, just remind me", invitation_waiting_list_path(invitation, auto_rsvp: false), method: :post, class: "button round expand"
-- else
+- if not invitation.waiting_list.blank?
   - if invitation.waiting_list.auto_rsvp?
 
     .text-center Waiting List position: <strong>#{invitation.waiting_list_position}</strong>/#{@workshop.waiting_list_count_for(invitation.role)}
@@ -11,3 +6,16 @@
     = link_to "Remove from Waiting list", invitation_waiting_list_path(invitation), method: :delete, class: 'button expand round alert', "data-confirm" => "Are you sure you want to let go of your spot? You cannot undo this."
   - else
     = link_to "Don't send me a reminder", invitation_waiting_list_path(invitation), method: :delete, class: 'button expand round alert'
+
+- else
+  - if not invitation.sessions.allocation_time.nil?
+    %p
+      Places for this workshop will be allocated at
+      #{l(invitation.sessions.allocation_time)}. Sign up now and we'll
+      allocate a space if one is available.
+  - else invitation.waiting_list.blank?
+    %p The workshop is full.
+
+  = link_to "Join the Waiting List", invitation_waiting_list_path(invitation), method: :post, class: 'button round expand', "data-confirm" => "Are you sure you want to join the waiting list? If any spots become available, even last minute, you will get a spot for the workshop."
+
+  = link_to "Not sure, just remind me", invitation_waiting_list_path(invitation, auto_rsvp: false), method: :post, class: "button round expand"

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -59,19 +59,16 @@
                 %strong Why?
                 = @invitation.member.bans.active.first.reason
           - else
-            - if @invitation.for_coach?
-              - if @workshop.coach_spaces?
+            - if @invitation.can_accept?
+              - if @invitation.for_coach?
                 = link_to "Attend", accept_invitation_url(@invitation), class: "expand button round center"
               - else
-                = render partial: 'invitation/waiting_list', locals: { invitation: @invitation }
-            - else
-              - if @workshop.student_spaces?
                 = simple_form_for @invitation, url: :accept_with_note_invitation, method: :post do |f|
                   = f.input :note, label: "I will be working on... ", collection: @tutorial_titles, required: true, include_blank: false
                   = f.button :submit, "Attend",  class: "button expand round"
                   %label *Letting us know what you plan to work on will help us pair you up with a coach.
-              - else
-                = render partial: 'invitation/waiting_list', locals: { invitation: @invitation }
+            - else
+              = render partial: 'invitation/waiting_list', locals: { invitation: @invitation }
 
 
 .stripe

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,9 @@ module Planner
     config.i18n.fallbacks = true
     config.i18n.available_locales = [:en]
     #config.i18n.enforce_available_locales = false
+
+    # Use delayed_job adapter for job queueing
+    config.active_job.queue_adapter = :delayed_job
   end
 end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,9 @@ Planner::Application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Use test adapter for job queueing
+  config.active_job.queue_adapter = :test
+
   # Fake omniauth for testing
   OmniAuth.config.test_mode = true
 end

--- a/db/migrate/20151126102454_add_random_allocate_to_sessions.rb
+++ b/db/migrate/20151126102454_add_random_allocate_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddRandomAllocateToSessions < ActiveRecord::Migration
+  def change
+    add_column :sessions, :random_allocate_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110180108) do
+ActiveRecord::Schema.define(version: 20151126102454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -387,11 +387,12 @@ ActiveRecord::Schema.define(version: 20151110180108) do
     t.datetime "date_and_time"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "invitable",       default: true
+    t.boolean  "invitable",          default: true
     t.string   "sign_up_url"
     t.integer  "chapter_id"
     t.datetime "time"
     t.datetime "rsvp_close_time"
+    t.datetime "random_allocate_at"
   end
 
   add_index "sessions", ["chapter_id"], name: "index_sessions_on_chapter_id", using: :btree

--- a/spec/fabricators/session_fabricator.rb
+++ b/spec/fabricators/session_fabricator.rb
@@ -28,3 +28,14 @@ Fabricator(:sessions_no_spots, class_name: :sessions) do
   end
 end
 
+Fabricator(:sessions_random_allocate, class_name: :sessions) do
+  date_and_time DateTime.now+2.days
+  time DateTime.now
+  title Faker::Lorem.sentence
+  description Faker::Lorem.sentence
+  chapter
+  random_allocate_at DateTime.now
+  after_build do |sessions|
+    Fabricate(:sponsor_session, sessions: sessions, sponsor: Fabricate(:sponsor), host: true )
+  end
+end

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -15,6 +15,11 @@ feature 'a member can' do
 
     it_behaves_like "invitation route"
 
+    scenario "when spots are randomly allocated" do
+      invitation.sessions.update_attribute(:random_allocate_at, DateTime.now + 2.days)
+      visit invitation_route
+      expect(page).to have_content("Places for this workshop will be allocated at")
+    end
   end
 
   context "#course" do

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -47,4 +47,21 @@ feature 'Managing workshops' do
       expect(page).to have_content sponsor.name
     end
   end
+
+  scenario "creating a workshop with random allocation" do
+    visit new_admin_workshop_path
+
+    select chapter.name
+    fill_in "Date", with: Date.today
+    fill_in "Time", with: "11:30"
+    check "Randomly assign spaces"
+    fill_in "Random assignment date", with: Date.today
+    fill_in "Random assignment time", with: "9:30"
+
+    click_on "Save"
+
+    expect(page).to have_content "Invite"
+    expect(page).to have_content "will be randomly allocated"
+  end
+
 end

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -53,10 +53,10 @@ feature 'Managing workshops' do
 
     select chapter.name
     fill_in "Date", with: Date.today
-    fill_in "Time", with: "11:30"
+    fill_in "Time", with: Time.now + 2.hour
     check "Randomly assign spaces"
     fill_in "Random assignment date", with: Date.today
-    fill_in "Random assignment time", with: "9:30"
+    fill_in "Random assignment time", with: Time.now + 1.hour
 
     click_on "Save"
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ApplicationHelper do
+
+  context "#present" do
+    let(:chapter) { Chapter.new }
+    let(:sessions) { Sessions.new }
+
+    it "presents a chapter with no class argument" do
+      present(chapter) do |c|
+        expect(c).to be_a(ChapterPresenter)
+      end
+    end
+
+    it "presents a workshop with explicit class" do
+      present(sessions, WorkshopPresenter) do |s|
+        expect(s).to be_a(WorkshopPresenter)
+      end
+    end
+  end
+
+end

--- a/spec/jobs/allocate_spaces_job_spec.rb
+++ b/spec/jobs/allocate_spaces_job_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+RSpec.describe AllocateSpacesJob, type: :job do
+  context "workshop with random allocation" do
+    let(:workshop) { Fabricate(:sessions_random_allocate) }
+
+    it "does nothing when no students are waiting" do
+      AllocateSpacesJob.new.perform(workshop)
+
+      expect(workshop.attending_students).to eq([])
+      expect(workshop.attending_coaches).to eq([])
+    end
+
+    it "assigns a student from the waitlist" do
+      invitation = Fabricate(:session_invitation, sessions: workshop, role: "Student")
+      WaitingList.add(invitation)
+
+      AllocateSpacesJob.new.perform(workshop)
+
+      expect(workshop.attending_students).to eq([invitation])
+      expect(workshop.attending_coaches).to eq([])
+    end
+
+    it "assigns all members from the waitlist, if they will fit" do
+      student_invitations = workshop.host.seats.times.map {
+        |n| Fabricate(:session_invitation, sessions: workshop, role: "Student") }
+      student_invitations.map { |invitation| WaitingList.add(invitation) }
+
+      coach_invitations = workshop.host.coach_spots.times.map {
+        |n| Fabricate(:session_invitation, sessions: workshop, role: "Coach") }
+      coach_invitations.map { |invitation| WaitingList.add(invitation) }
+
+      AllocateSpacesJob.new.perform(workshop)
+
+      expect(workshop.attending_students).to match_array(student_invitations)
+      expect(workshop.attending_coaches).to match_array(coach_invitations)
+    end
+
+    it "assigns members up to the seat limit" do
+      student_count = workshop.host.seats * 2
+      coach_count = workshop.host.coach_spots * 2
+
+      student_invitations = student_count.times.map {
+        |n| Fabricate(:session_invitation, sessions: workshop, role: "Student") }
+      student_invitations.map { |invitation| WaitingList.add(invitation) }
+
+      coach_invitations = coach_count.times.map {
+        |n| Fabricate(:session_invitation, sessions: workshop, role: "Coach") }
+      coach_invitations.map { |invitation| WaitingList.add(invitation) }
+
+      AllocateSpacesJob.new.perform(workshop)
+
+      expect(workshop.attending_students
+            ).to all(satisfy {|i| student_invitations.include?(i)})
+      expect(workshop.attending_coaches
+            ).to all(satisfy {|i| coach_invitations.include?(i)})
+
+      expect(workshop.attending_students.length).to eq(workshop.host.seats)
+      expect(workshop.attending_coaches.length).to eq(workshop.host.coach_spots)
+    end
+  end
+
+  context "workshop with random allocation time in the future" do
+    let(:workshop) { Fabricate(:sessions_random_allocate,
+                               random_allocate_at: DateTime.now+2.days) }
+
+    it "reschedules itself" do
+      invitations = workshop.host.seats.times.map {
+        |n| Fabricate(:session_invitation, sessions: workshop) }
+      invitations.map { |invitation| WaitingList.add(invitation) }
+
+      # Fabricating the session will have enqueued an allocation job
+      # for it, so clear the queue
+      ActiveJob::Base.queue_adapter.enqueued_jobs = []
+
+      AllocateSpacesJob.new.perform(workshop)
+
+      expect(ActiveJob::Base.queue_adapter.enqueued_jobs
+            ).to contain_exactly(a_hash_including(job: AllocateSpacesJob,
+                                                  at: workshop.random_allocate_at.to_i))
+
+      expect(workshop.attending_students).to eq([])
+      expect(workshop.attending_coaches).to eq([])
+    end
+  end
+
+  context "workshop without random allocation" do
+    let(:workshop) { Fabricate(:sessions) }
+
+    it "does nothing" do
+      invitations = workshop.host.seats.times.map {
+        |n| Fabricate(:session_invitation, sessions: workshop) }
+      invitations.map { |invitation| WaitingList.add(invitation) }
+
+      AllocateSpacesJob.new.perform(workshop)
+
+      expect(workshop.attending_students).to eq([])
+      expect(workshop.attending_coaches).to eq([])
+    end
+  end
+end

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe WaitingList, type: :model do
       end
     end
 
+    context "#waiting_for" do
+      it "returns all the students waiting" do
+        invitations = 5.times.map { |n| Fabricate(:session_invitation, sessions: workshop) }
+        invitations.map { |invitation| WaitingList.add(invitation) }
+
+        expect(WaitingList.waiting_for(workshop, "Student").map {
+                 |w| w.invitation}).to match_array(invitations)
+      end
+    end
+
     context "#next_spot" do
       it "returns the next spot to be allocated" do
         invitation = Fabricate(:session_invitation, sessions: workshop)

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -29,6 +29,30 @@ describe WorkshopPresenter do
     workshop.time
   end
 
+  context "#random_allocate_date" do
+    it "returns the empty string when no date is set" do
+      expect(sessions).to receive(:random_allocate_at).and_return(nil)
+      expect(workshop.random_allocate_date).to be == ""
+    end
+
+    it "returns a date when a date is set" do
+      expect(sessions).to receive(:random_allocate_at).twice.and_return(DateTime.new)
+      expect(workshop.random_allocate_date).to match(%r{.*/.*/.*})
+    end
+  end
+
+  context "#random_allocate_time" do
+    it "returns the empty string when no time is set" do
+      expect(sessions).to receive(:random_allocate_at).and_return(nil)
+      expect(workshop.random_allocate_time).to be == ""
+    end
+
+    it "returns a date when a time is set" do
+      expect(sessions).to receive(:random_allocate_at).twice.and_return(DateTime.new)
+      expect(workshop.random_allocate_time).to match(%r{.*:.*})
+    end
+  end
+
   it "#attendees_csv" do
     expect(workshop).to receive(:organisers).at_least(:once).and_return [invitations.last.member]
     expect(workshop.attendees_csv).not_to be_blank


### PR DESCRIPTION
Random spot allocation, first cut. An allocation time can be set in the admin page. Before this time, all invitation responses go onto the waiting list. When the allocation job runs, it picks people randomly from the waiting list. After this, spot allocation works in the traditional way (preferring earlier signups).

This isn't as tested as I'd like it to be yet - the code is all at least superficially covered by specs, but I haven't written a full integration test for it or set up enough of a working dev system to test this properly. However, I'm fairly confident that it doesn't break any existing functionality if the feature isn't turned on, so it should be safe to merge, even if it needs more changes after it.

This pull request closes #254.