### PR TITLE
Resolved https errors for google fonts and gravatar images.

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -65,7 +65,7 @@ class Member < ActiveRecord::Base
   end
 
   def avatar size=100
-    "http://gravatar.com/avatar/#{md5_email}?s=#{size}"
+    "https://secure.gravatar.com/avatar/#{md5_email}?s=#{size}"
   end
 
   def attended_sessions

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -28,7 +28,7 @@
     .large-3.columns
       = render partial: 'shared/social_media'
       %span.git-tip
-        %script{ :"data-gittip-username" => "by_codebar", :src => "//gttp.co/v1.js" }
+        %script{ :"data-gittip-username" => "~by_codebar", :src => "//gttp.co/v1.js" }
   .row
     .large-12.columns
       = link_to "https://www.gosquared.com/", title: "GoSquared.com" do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,9 +9,9 @@
     = stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true
     = javascript_include_tag "vendor/modernizr"
     = javascript_include_tag "application", "data-turbolinks-track" => true
-    %link{ href: 'http://fonts.googleapis.com/css?family=Gabriela', rel: 'stylesheet', type: 'text/css' }
-    %link{ href: 'http://fonts.googleapis.com/css?family=Cousine:400,700', rel:'stylesheet', type:'text/css'}
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300' rel='stylesheet' type='text/css'>
+    %link{ href: 'https://fonts.googleapis.com/css?family=Gabriela', rel: 'stylesheet', type: 'text/css' }
+    %link{ href: 'https://fonts.googleapis.com/css?family=Cousine:400,700', rel:'stylesheet', type:'text/css'}
+    %link{ href: 'https://fonts.googleapis.com/css?family=Open+Sans:400,300', rel:'stylesheet', type:'text/css' }
     = csrf_meta_tags
   %body.no-js
     .off-canvas-wrap{ "data-offcanvas" => true }

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -52,7 +52,7 @@ describe Member do
 
       it "#avatar" do
         encrypted_email = Digest::MD5.hexdigest(member.email.strip.downcase)
-        expect(member.avatar).to eq("http://gravatar.com/avatar/#{encrypted_email}?s=100")
+        expect(member.avatar).to eq("https://secure.gravatar.com/avatar/#{encrypted_email}?s=100")
       end
 
       it "#attended_sessions" do


### PR DESCRIPTION
Fixes #356 
Created during @codebar and @ladieswhocode event.

Had a look at resolving assets.codebar.io.... errors as well, but not able to resolve this, as the link will not work over https.