### PR TITLE
Fix for issue #333

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -78,6 +78,7 @@ class WorkshopsController < ApplicationController
   def added
     @workshop = Sessions.find(params[:id])
     @coach = SessionInvitation.where(sessions: @workshop, member: current_user, attending: true, role: "Coach").any?
+    @chapter = @workshop.chapter
   end
 
   # Show a "You've been waitlisted for this event" page.

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -72,6 +72,7 @@ class WorkshopsController < ApplicationController
   # Show a "You've been removed from this event" page.
   def removed
     @workshop = WorkshopPresenter.new(Sessions.find(params[:id]))
+    @chapter = @workshop.chapter
   end
 
   # Show a "You've been added to this event" page.
@@ -85,6 +86,7 @@ class WorkshopsController < ApplicationController
   def waitlisted
     @workshop = Sessions.find(params[:id])
     @coach = WaitingList.coaches(@workshop).include? current_user
+    @chapter = @workshop.chapter
   end
 
   private

--- a/app/mailers/session_invitation_mailer.rb
+++ b/app/mailers/session_invitation_mailer.rb
@@ -9,6 +9,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @workshop = WorkshopPresenter.new(sessions)
     @member = member
     @invitation = invitation
+    @chapter = @session.chapter
 
     subject = "Workshop Invitation #{humanize_date_with_time(@session.date_and_time, @session.time)}"
 
@@ -21,6 +22,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @session = sessions
     @member = member
     @invitation = invitation
+    @chapter = @session.chapter
 
     subject = "Workshop Coach Invitation #{humanize_date_with_time(@session.date_and_time, @session.time)}"
 
@@ -36,6 +38,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
     @waiting_list = waiting_list
+    @chapter = @session.chapter
 
     subject = "Attendance Confirmation for #{humanize_date_with_time(@session.date_and_time, @session.time)}"
 
@@ -54,6 +57,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @host_address = AddressDecorator.decorate(@session.host.address)
     @member = member
     @invitation = invitation
+    @chapter = @session.chapter
 
     load_attachments
 
@@ -70,6 +74,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @host_address = AddressDecorator.decorate(@session.host.address)
     @member = member
     @invitation = invitation
+    @chapter = @session.chapter
 
     subject = "Workshop Reminder #{humanize_date_with_time(@session.date_and_time, @session.time)}"
     mail(mail_args(member, subject)) do |format|
@@ -83,6 +88,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @host_address = AddressDecorator.decorate(@session.host.address)
     @member = member
     @invitation = invitation
+    @chapter = @session.chapter
 
     subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(@session.date_and_time, @session.time)})"
     mail(mail_args(member, subject)) do |format|
@@ -95,6 +101,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @host_address = AddressDecorator.decorate(@session.host.address)
     @member = invitation.member
     @invitation = invitation
+    @chapter = @session.chapter
 
     subject = "A spot just became available"
 

--- a/app/views/shared_mailers/_social.html.haml
+++ b/app/views/shared_mailers/_social.html.haml
@@ -17,6 +17,10 @@
         %tr
           %td
             %h5=t("footer.contact_info")
-            %p Email: <strong><a href="emailto:hello@codebar.io">hello@codebar.io</a></strong>
+            %p
+              - if @session
+                %strong= link_to "Email us", "mailto:#{@session.chapter.email}?cc=hello@codebar.io"
+              - else
+                %strong= link_to "Email us", "mailto:hello@codebar.io"
 
       %span.clear

--- a/app/views/workshops/added.html.haml
+++ b/app/views/workshops/added.html.haml
@@ -15,7 +15,7 @@
 
         %p
           We're looking forward to seeing you at codebar soon!
-          = link_to "Drop us an email", "mailto:hello@codebar.io"
+          = link_to "Drop us an email", "mailto:#{@chapter.email}&cc=hello@codebar.io"
           if you have any questions.
         %p
           = link_to "« Return to the workshop page", workshop_path(@workshop)

--- a/app/views/workshops/added.html.haml
+++ b/app/views/workshops/added.html.haml
@@ -15,7 +15,7 @@
 
         %p
           We're looking forward to seeing you at codebar soon!
-          = link_to "Drop us an email", "mailto:#{@chapter.email}&cc=hello@codebar.io"
+          = link_to "Drop us an email", "mailto:#{@chapter.email}?cc=hello@codebar.io"
           if you have any questions.
         %p
           = link_to "« Return to the workshop page", workshop_path(@workshop)

--- a/app/views/workshops/removed.html.haml
+++ b/app/views/workshops/removed.html.haml
@@ -10,7 +10,7 @@
 
         %p
           Even though you can't make it to this codebar, we're looking forward to seeing you at another codebar soon!
-          = link_to "Drop us an email", "mailto:hello@codebar.io"
+          = link_to "Drop us an email", "mailto:#{@chapter.email}&cc=hello@codebar.io"
           if you have any questions.
         %p
           = link_to "« Return to the workshop page", workshop_path(@workshop)

--- a/app/views/workshops/removed.html.haml
+++ b/app/views/workshops/removed.html.haml
@@ -10,7 +10,7 @@
 
         %p
           Even though you can't make it to this codebar, we're looking forward to seeing you at another codebar soon!
-          = link_to "Drop us an email", "mailto:#{@chapter.email}&cc=hello@codebar.io"
+          = link_to "Drop us an email", "mailto:#{@chapter.email}?cc=hello@codebar.io"
           if you have any questions.
         %p
           = link_to "« Return to the workshop page", workshop_path(@workshop)

--- a/app/views/workshops/waitlisted.html.haml
+++ b/app/views/workshops/waitlisted.html.haml
@@ -17,7 +17,7 @@
 
         %p
           We hope to see you at codebar soon!
-          = link_to "Drop us an email", "mailto:#{@chapter.email}&cc=hello@codebar.io"
+          = link_to "Drop us an email", "mailto:#{@chapter.email}?cc=hello@codebar.io"
           if you have any questions.
         %p
           = link_to "« Return to the workshop page", workshop_path(@workshop)

--- a/app/views/workshops/waitlisted.html.haml
+++ b/app/views/workshops/waitlisted.html.haml
@@ -17,7 +17,7 @@
 
         %p
           We hope to see you at codebar soon!
-          = link_to "Drop us an email", "mailto:hello@codebar.io"
+          = link_to "Drop us an email", "mailto:#{@chapter.email}&cc=hello@codebar.io"
           if you have any questions.
         %p
           = link_to "« Return to the workshop page", workshop_path(@workshop)

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -3,7 +3,8 @@ require "spec_helper"
 describe SessionInvitationMailer do
 
   let(:email) { ActionMailer::Base.deliveries.last }
-  let(:session) { Fabricate(:sessions, title: "HTML & CSS") }
+  let(:chapter) { Fabricate(:chapter, email: "london@codebar.io") }
+  let(:session) { Fabricate(:sessions, title: "HTML & CSS", chapter: chapter) }
   let(:member) { Fabricate(:member) }
   let(:invitation) { Fabricate(:session_invitation, sessions: session, member: member) }
 
@@ -14,6 +15,8 @@ describe SessionInvitationMailer do
     SessionInvitationMailer.invite_student(session, member, invitation).deliver
 
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(chapter.email)
+    expect(email.body.encoded).to match("cc=hello@codebar.io")
   end
 
   it "#attending_reminder" do
@@ -21,5 +24,8 @@ describe SessionInvitationMailer do
     SessionInvitationMailer.attending_reminder(session, member, invitation).deliver
 
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(chapter.email)
+    expect(email.body.encoded).to match("cc=hello@codebar.io")
   end
+
 end


### PR DESCRIPTION
[https://github.com/codebar/planner/issues/333](https://github.com/codebar/planner/issues/333)

I initially changed the views on these pages: 

```
http://localhost:3000/workshops/2/removed
http://localhost:3000/workshops/2/added
http://localhost:3000/workshops/2/waitlisted
```

However, when trying to recreate the issue with the normal workflow of the site (adding to a workshop, removing from the workshop), I wasn't actually ever reaching these pages. Perhaps they are deprecated?

Then, I changed the `app/views/shared_mailers/_social.html.haml` partial and updated this test `spec/mailers/session_invitation_mailer_spec.rb`.
