### PR TITLE
fixed overlapping columns on event lists for mobile

### DIFF
--- a/app/assets/stylesheets/event.scss
+++ b/app/assets/stylesheets/event.scss
@@ -1,5 +1,6 @@
 #minified {
   .sponsor {
+    margin-top: 15px;
     max-width: 90px;
     max-height: 60px;
   }

--- a/app/assets/stylesheets/partials/_chapter.scss
+++ b/app/assets/stylesheets/partials/_chapter.scss
@@ -30,7 +30,7 @@
   }
 
   .organisers {
-    margin-top: 15px;
+    margin-top: 12px;
   }
 }
 

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -1,6 +1,6 @@
 .event#minified
   .row
-    .small-2.columns
+    .small-3.medium-2.columns
       .date
         .time
           = event.time
@@ -15,7 +15,7 @@
           - if @user.event_organiser?(event)
             = link_to event.admin_path do
               %label.label Manage
-    .small-10.columns
+    .small-9.medium-10.columns
       .title
         =link_to event.to_s, event.path
         - if event.venue.present?

--- a/app/views/meetings/_meeting.html.haml
+++ b/app/views/meetings/_meeting.html.haml
@@ -1,10 +1,10 @@
 .event#minified
   .row
-    .small-2.columns
+    .small-3.medium-2.columns
       .date
         .time
           = meeting.time
-    .small-10.columns
+    .small-9.medium-10.columns
       .title
         =link_to meeting.to_s, meeting.path
         - if meeting.venue.present?


### PR DESCRIPTION
For mobile on the event list the column with time & location was overlapping with the column of organisers/sponsors. Also the shadow of the organiser's profile picture was cut off by the sponsor logo.

<img width="318" alt="screen shot 2015-12-06 at 17 55 29" src="https://cloud.githubusercontent.com/assets/3497625/11614725/b5eef036-9c42-11e5-9427-d8a4169c2bb3.png">
