### PR TITLE
Fix waitlist reminder email

### DIFF
--- a/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,12 +14,12 @@
               %td
                 %h3 Hi, #{@member.name}
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for tomorrow's workshop.
+                  This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date_with_time(@session.date_and_time, @session.time)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place.
                   We'll email you if this happens.
                   %strong Attendees often drop out at short notice,
-                  so you should keep your laptop with you and check your email tomorrow afternoon.
+                  so you should keep your laptop with you and check your email during the afternoon on the day of the workshop.
                 %p
                   Alternatively, if you know you can no longer make it, you should
                   = link_to "remove yourself from the waiting list", full_url_for(invitation_url(@invitation))

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -19,7 +19,12 @@ describe SessionInvitationMailer do
   it "#attending_reminder" do
     email_subject = "Workshop Reminder #{humanize_date_with_time(session.date_and_time, session.time)}"
     SessionInvitationMailer.attending_reminder(session, member, invitation).deliver
+    expect(email.subject).to eq(email_subject)
+  end
 
+  it "#waitlist_reminder" do
+    email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(session.date_and_time, session.time)})"
+    SessionInvitationMailer.waiting_list_reminder(session, member, invitation).deliver
     expect(email.subject).to eq(email_subject)
   end
 end

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -26,5 +26,8 @@ describe SessionInvitationMailer do
     email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(session.date_and_time, session.time)})"
     SessionInvitationMailer.waiting_list_reminder(session, member, invitation).deliver
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match("you should keep your laptop with you and check your email during the afternoon on the day of the workshop.")
+    expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date_with_time(session.date_and_time, session.time)}")
+
   end
 end


### PR DESCRIPTION
Fix for issue

https://github.com/codebar/planner/issues/370

Fixed email content to contain date of workshop instead of hardcoded string tomorrow as email is being sent between 4 and 30 hours... fyi : @RabeaGleissner