### PR TITLE
- only display approve button if job hasn’t expired

### DIFF
--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -6,7 +6,7 @@ class Admin::JobsController < Admin::ApplicationController
   end
 
   def show
-    @job = Job.find(params[:id])
+    @job = Job.unscoped.find(params[:id])
     authorize @job
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -9,4 +9,8 @@ class Job < ActiveRecord::Base
   scope :ordered, -> { order('created_at desc') }
   default_scope -> { where('expiry_date > ?', Date.today) }
 
+  def expired?
+    self.expiry_date.past?
+  end
+
 end

--- a/app/views/admin/jobs/show.html.haml
+++ b/app/views/admin/jobs/show.html.haml
@@ -2,29 +2,31 @@
   .row
     .large-12.columns
       %h1 Review job
-.alert-box
-  .row
-    .large-12.columns
-      %p
-        Before approving this job make sure
-        %ul.no-bullet
-          %li
-            %input#work_details{type: 'checkbox'}
-            %label{for: 'work_details'} The post details the work that will have to be undertaken
-          %li
-            %input#roles{type: 'checkbox'}
-            %label{for: 'roles'} It's suitable for people looking for Internships and Junior roles that will enable them to build up their career
-          %li
-            %input#reliable_source{type: 'checkbox'}
-            %label{for: 'reliable_source'} It was posted by someone you know or a reliable source
-          %li
-            %input#payment{type: 'checkbox'}
-            %label{for: 'payment'} Payment confirmation was posted in the London organisers Slack channel
-          %li
-            %input#to-the-point{type: 'checkbox'}
-            %label{for: 'to-the-point'} The post is short and to the point
+- unless @job.approved? or @job.expired?
+  .alert-box
+    .row
+      .large-12.columns
+        %p
+          Before approving this job make sure
+          %ul.no-bullet
+            %li
+              %input#work_details{type: 'checkbox'}
+              %label{for: 'work_details'} The post details the work that will have to be undertaken
+            %li
+              %input#roles{type: 'checkbox'}
+              %label{for: 'roles'} It's suitable for people looking for Internships and Junior roles that will enable them to build up their career
+            %li
+              %input#reliable_source{type: 'checkbox'}
+              %label{for: 'reliable_source'} It was posted by someone you know or a reliable source
+            %li
+              %input#payment{type: 'checkbox'}
+              %label{for: 'payment'} Payment confirmation was posted in the London organisers Slack channel
+            %li
+              %input#to-the-point{type: 'checkbox'}
+              %label{for: 'to-the-point'} The post is short and to the point
 
-%br
+  %br
+
 %br
 =render partial: 'jobs/show', locals: { admin: true }
 
@@ -35,4 +37,5 @@
       - if @job.approved?
         %label.label.success Approved
       - else
-        =link_to "Approve", admin_job_approve_path(@job), class: 'button round alert'
+        - unless @job.expired?
+          =link_to "Approve", admin_job_approve_path(@job), class: 'button round alert'

--- a/spec/features/admin/jobs_spec.rb
+++ b/spec/features/admin/jobs_spec.rb
@@ -40,4 +40,18 @@ feature 'Admin Jobs' do
 
   end
 
+  scenario 'An admin can view all reviewed jobs jobs' do
+    job = Fabricate(:job)
+    expired_job = Fabricate(:job, expiry_date: Date.today-1.week)
+
+    visit all_admin_jobs_path
+
+    expect(page).to have_content(job.title)
+    expect(page).to have_content(expired_job.title)
+
+    click_on expired_job.title
+
+    expect(page).to have_content(expired_job.description)
+
+  end
 end

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -39,4 +39,12 @@ describe Job do
     end
 
   end
+
+  context "#expired?" do
+    it "checks if the job post has past its expiry_date" do
+      job = Job.new(expiry_date: Date.today-1.day)
+
+      expect(job.expired?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
- use unscoped retrieve expired_jobs