### PR TITLE
Move pronoun field below first/last name field

### DIFF
--- a/app/views/members/_form.html.haml
+++ b/app/views/members/_form.html.haml
@@ -1,12 +1,12 @@
 = simple_form_for @member, method: :put do |f|
   .row
-    .large-4.column
-      = f.input :preferred_pronoun
-  .row
     .large-6.columns
       = f.input :name
     .large-6.columns
       = f.input :surname
+  .row
+    .large-4.column
+      = f.input :preferred_pronoun, placeholder: "e.g. she/her"
 
   .row
     .large-6.columns

--- a/app/views/members/_new.html.haml
+++ b/app/views/members/_new.html.haml
@@ -1,12 +1,12 @@
 = simple_form_for @member, method: :put do |f|
   .row
     .large-6.columns
-      = f.input :preferred_pronoun
-  .row
-    .large-6.columns
       = f.input :name
     .large-6.columns
       = f.input :surname
+  .row
+    .large-6.columns
+      = f.input :preferred_pronoun, placeholder: "e.g. she/her"
 
   .row
     .large-6.columns

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -9,13 +9,13 @@
   = simple_form_for @member, method: :put, url: {action: :step1}, html: {class: "sign-up-wizard"} do |f|
     .row
       .large-6.large-offset-3.columns
-        = f.input :preferred_pronoun
-    .row
-      .large-6.large-offset-3.columns
         = f.input :name, label: "First name", required: true
     .row
       .large-6.large-offset-3.columns
         = f.input :surname, required: true
+    .row
+      .large-6.large-offset-3.columns
+        = f.input :preferred_pronoun, placeholder: "e.g. she/her"
 
     .row
       .large-6.large-offset-3.columns


### PR DESCRIPTION
Fixes #400 

This PR moves the "Preferred Pronouns" field on the "New Member" form further down the page, underneath the First/Last name fields. We're doing this because people can get confused and think "Mr/Mrs/Ms/Mx" goes in there (as often this is the first field you will see on any sign up form).

<img width="973" alt="codebar_preferred_pronouns_fixed" src="https://cloud.githubusercontent.com/assets/542140/13200092/f7164ae8-d831-11e5-8139-e38c8096f016.png">

Hope I did this right! Really easy to follow 'Getting Started' guide in the README of this repo.

:sun_with_face: 