### PR TITLE
change “preferred_pronoun” to “pronouns”

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -62,7 +62,7 @@ class MembersController < ApplicationController
 
   def member_params
     params.require(:member).permit(
-      :preferred_pronoun, :name, :surname, :email, :mobile, :twitter, :about_you, :skill_list
+      :pronouns, :name, :surname, :email, :mobile, :twitter, :about_you, :skill_list
     )
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -33,7 +33,7 @@ class Member < ActiveRecord::Base
   end
 
   def full_name
-    pronoun  = self.preferred_pronoun.present? ? "(#{self.preferred_pronoun})" : nil
+    pronoun  = self.pronouns.present? ? "(#{self.pronouns})" : nil
     [name, surname, pronoun].compact.join " "
   end
 

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -24,8 +24,8 @@
     .row
       .medium-8.columns
         %dl
-          %dt Preferred pronoun
-          %dd= @member.preferred_pronoun || "Not specified"
+          %dt Pronouns
+          %dd= @member.pronouns || "Not specified"
 
           %dt Email
           %dd= mail_to @member.email, @member.email

--- a/app/views/members/_form.html.haml
+++ b/app/views/members/_form.html.haml
@@ -6,7 +6,7 @@
       = f.input :surname
   .row
     .large-4.column
-      = f.input :preferred_pronoun, placeholder: "e.g. she/her"
+      = f.input :pronouns, label: "What pronouns do you use?", placeholder: "e.g. she/her"
 
   .row
     .large-6.columns

--- a/app/views/members/_new.html.haml
+++ b/app/views/members/_new.html.haml
@@ -6,7 +6,7 @@
       = f.input :surname
   .row
     .large-6.columns
-      = f.input :preferred_pronoun, placeholder: "e.g. she/her"
+      = f.input :pronouns, label: "What pronouns do you use?", placeholder: "e.g. she/her"
 
   .row
     .large-6.columns

--- a/app/views/members/_show.html.haml
+++ b/app/views/members/_show.html.haml
@@ -10,8 +10,8 @@
     .row
       .medium-8.columns
         %dl
-          %dt Preferred pronoun
-          %dd= member.preferred_pronoun || "Not specified"
+          %dt Pronouns
+          %dd= member.pronouns || "Not specified"
 
           %dt Email
           %dd= mail_to member.email, member.email

--- a/app/views/members/step1.html.haml
+++ b/app/views/members/step1.html.haml
@@ -15,7 +15,7 @@
         = f.input :surname, required: true
     .row
       .large-6.large-offset-3.columns
-        = f.input :preferred_pronoun, placeholder: "e.g. she/her"
+        = f.input :pronouns, label: "What pronouns do you use?", placeholder: "e.g. she/her"
 
     .row
       .large-6.large-offset-3.columns

--- a/db/migrate/20160228102639_change_preferred_pronoun_to_pronouns_in_member.rb
+++ b/db/migrate/20160228102639_change_preferred_pronoun_to_pronouns_in_member.rb
@@ -1,0 +1,5 @@
+class ChangePreferredPronounToPronounsInMember < ActiveRecord::Migration
+  def change
+    rename_column :members, :preferred_pronoun, :pronouns
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160211182925) do
+ActiveRecord::Schema.define(version: 20160228102639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -353,7 +353,7 @@ ActiveRecord::Schema.define(version: 20160211182925) do
     t.string   "mobile"
     t.boolean  "received_coach_welcome_email",   default: false
     t.boolean  "received_student_welcome_email", default: false
-    t.string   "preferred_pronoun"
+    t.string   "pronouns"
   end
 
   create_table "members_permissions", id: false, force: :cascade do |t|

--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:member) do
-  preferred_pronoun "she/her"
+  pronouns "she/her"
   name { Faker::Name.first_name }
   surname { Faker::Name.last_name }
   email { Faker::Internet.email }

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -41,7 +41,7 @@ feature "A new student signs up", js: false do
     visit new_member_path
     click_on "Sign in with Github"
 
-    fill_in "member_preferred_pronoun", with: "she"
+    fill_in "member_pronouns", with: "she"
     fill_in "member_name", with: "Jane"
     fill_in "member_surname", with: "Doe"
     fill_in "member_email", with: "jane@codebar.io"
@@ -52,7 +52,7 @@ feature "A new student signs up", js: false do
 
     click_on "Done"
 
-    expect(page).to have_content("Preferred pronoun")
+    expect(page).to have_content("Pronouns")
     expect(page).to have_content("she")
     expect(page).to have_content("Jane Doe")
     expect(page).to have_link("jane@codebar.io")

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -47,7 +47,7 @@ describe Member do
       let (:member) { Fabricate(:member) }
 
       it "#full_name" do
-        expect(member.full_name).to eq("#{member.name} #{member.surname} (#{member.preferred_pronoun})")
+        expect(member.full_name).to eq("#{member.name} #{member.surname} (#{member.pronouns})")
       end
 
       it "#avatar" do


### PR DESCRIPTION
Fixes #403

This PR changes "preferred_pronoun" to "pronouns" in the Database.

Also changes the question “Preferred pronoun?” to “What pronouns do you use?” in the member sign up form. And “Preferred pronoun” on a profile page to “Pronouns”.

<img width="505" alt="403_pronouns_on_signup" src="https://cloud.githubusercontent.com/assets/542140/13378825/e556b05c-de0a-11e5-88b2-d738b6dcf309.png">

Based on: http://mashable.com/2015/10/18/transgender-ally-words/. "Preferred pronouns" could suggest that they are not someones "actual" pronouns, where in fact they are of course. So instead we can ask "What pronouns do you use?" :+1: 

---

This is the most Rails work I've ever done, so I may not have gotten it right! Help greatly appreciated.

:sun_with_face: 