### PR TITLE
Fix 410

### DIFF
--- a/app/controllers/admin/bans_controller.rb
+++ b/app/controllers/admin/bans_controller.rb
@@ -9,10 +9,10 @@ class Admin::BansController < Admin::ApplicationController
     @member = Member.find(member_id)
 
     @ban = @member.bans.build(ban_params)
-    puts @ban.inspect
     @ban.added_by = current_user
 
     if @ban.save
+      MemberMailer.ban(@ban.member, @ban).deliver_now
       redirect_to [:admin, @member], notice: 'The user has been banned'
     else
       render 'new'

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -2,7 +2,7 @@ class Admin::MembersController < Admin::ApplicationController
 
   def show
     @member = Member.includes(:member_notes).find(params[:id])
-    @invitations = @member.session_invitations.attended.order_by_latest rescue nil
+    @invitations = @member.session_invitations.accepted_or_attended.order_by_latest
     @last_attendance = @invitations.first.sessions if @invitations.any?
     @member_note = MemberNote.new
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,7 +7,7 @@ class DashboardController < ApplicationController
     @user = current_user ? MemberPresenter.new(current_user) : nil
     @upcoming_workshops = upcoming_events.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash}
 
-    @testimonials = Testimonial.order("RANDOM() ").limit(10)
+    @testimonials = Testimonial.order("RANDOM() ").limit(5).includes(:member)
 
     @sponsors = Sponsor.latest
   end

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -25,7 +25,7 @@ class MemberMailer < ActionMailer::Base
     @member = member
     subject = "How codebar works"
 
-    mail(mail_args(member, subject, 'hello@codebar.io', "hello@codebar.io")) do |format|
+    mail(mail_args(member, subject, 'hello@codebar.io')) do |format|
       format.html { render 'welcome_student' }
     end
   end
@@ -34,7 +34,7 @@ class MemberMailer < ActionMailer::Base
     @member = member
     subject = "How codebar works"
 
-    mail(mail_args(member, subject, 'hello@codebar.io', "hello@codebar.io")) do |format|
+    mail(mail_args(member, subject, 'hello@codebar.io')) do |format|
       format.html { render 'welcome_coach' }
     end
   end

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -56,4 +56,14 @@ class MemberMailer < ActionMailer::Base
       format.html { render 'attendance_warning' }
     end.deliver
   end
+
+  def ban(member, ban)
+    @member = member
+    @reason = ban.reason
+    @expiry_date = I18n.l(ban.expires_at, format: :default)
+
+    mail(mail_args(member, @reason, 'hello@codebar.io', "hello@codebar.io")) do |format|
+      format.html { render 'ban' }
+    end.deliver
+  end
 end

--- a/app/models/concerns/invitation_concerns.rb
+++ b/app/models/concerns/invitation_concerns.rb
@@ -11,6 +11,7 @@ module InvitationConcerns
     validates :token, uniqueness: true
 
     scope :accepted, ->  { where(attending: true) }
+    scope :accepted_or_attended, ->  { where("attending=? or attended=?", true, true) }
     scope :not_accepted, ->  { where("attending is NULL or attending = false") }
 
   end

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -5,13 +5,13 @@
   =link_to "#", class: 'item', "data-reveal-id" => "note-modal" do
     %i.fa.fa-pencil
     %label Note
-  - unless @member.coach?
+  - if @member.student?
     =link_to admin_member_send_eligibility_email_path(@member), class: 'item' do
       %i.fa.fa-envelope
       %label Eligibility
-    =link_to admin_member_send_attendance_email_path(@member), class: 'item' do
-      %i.fa.fa-clock-o
-      %label Attendance
+  =link_to admin_member_send_attendance_email_path(@member), class: 'item' do
+    %i.fa.fa-clock-o
+    %label Attendance
 
 %section
   .stripe.reverse
@@ -75,7 +75,7 @@
           .panel
             %p
               #{@member.name} RSVPed to
-              %label.label.secondary.round #{@member.session_invitations.accepted.count}
+              %label.label.secondary.round #{@invitations.accepted.count}
               workshops and attended
               %label.label.secondary.round #{@invitations.count}.
               - if @invitations.to_coaches.any? or @invitations.to_students.any?
@@ -83,11 +83,11 @@
                 %ul.no-bullet
                   - if @invitations.to_coaches.any?
                     %li
-                      %label.label.round #{@invitations.to_coaches.count}
+                      %label.label.round #{@invitations.to_coaches.attended.count}
                       times as a coach
                   - if @invitations.to_students.any?
                     %li
-                      %label.label.secondary.round #{@invitations.to_students.count}
+                      %label.label.secondary.round #{@invitations.to_students.attended.count}
                       times as a student
         - if @invitations.any?
           %p
@@ -104,6 +104,11 @@
               - workshop = invitation.sessions
               - if workshop.present?
                 %tr
+                  %td
+                    - if invitation.attended?
+                      %i.fa.fa-check
+                    - else
+                      %i.fa.fa-warning
                   %td
                     =link_to invitation_path(invitation) do
                       %label.label=workshop.chapter.name

--- a/app/views/member_mailer/attendance_warning.html.haml
+++ b/app/views/member_mailer/attendance_warning.html.haml
@@ -1,15 +1,16 @@
 %h1 Hi #{@member.name},
 
 %p
-  We noticed that you have missed more than 3 workshops that you have RSVP'd to.
+  We noticed that you have missed more than 2 workshops that you have RSVP'd to.
   Because our workshops are heavily oversubscribed each week, we have a
   three-strikes policy. If you cannot make it to a workshop that you have
-  RSVP'd to, please cancel your spot via email before 2PM or get in touch with
-  us directly at london@codebar.io if something comes up very last-minute.
+  RSVP'd to, please remember to update your attendance details through our website before 3:30PM
+  at the latest on the day of the event.
 
 %p
-  Please be advised that if you miss one more workshop, we will temporarily
-  suspend your invitations for one month.
+  Please be advised that <strong>if you miss one more workshop, we will temporarily
+  suspend your membership</strong> for one month and you will not be able to attend
+  any of our workshops for that period of time.
 
 %p
   Thanks for your understanding.

--- a/app/views/member_mailer/ban.html.haml
+++ b/app/views/member_mailer/ban.html.haml
@@ -1,0 +1,18 @@
+%h1 Hi #{@member.name},
+
+%p
+  We are really sorry to have to do this, but your account has been suspended until #{@expiry_date}. This means that you will not be able to attend any of our events until then.
+
+%p
+  If this email has been sent because you have violated our attendancy policy you can read more about it #{link_to "here", attendance_policy_url}. Alternatively, please have a look at our eligibility criteria and code of conduct.
+  %ul
+    %li= link_to "Elibility criteria", student_guide_url(:eligibility_criteria)
+    %li= link_to "Code of conduct", code_of_conduct_url
+
+%p
+  Thanks for your understanding.
+
+%p
+  #{"-- "}
+  %br
+  The codebar organisational team

--- a/app/views/member_mailer/ban.html.haml
+++ b/app/views/member_mailer/ban.html.haml
@@ -6,7 +6,7 @@
 %p
   If this email has been sent because you have violated our attendancy policy you can read more about it #{link_to "here", attendance_policy_url}. Alternatively, please have a look at our eligibility criteria and code of conduct.
   %ul
-    %li= link_to "Elibility criteria", student_guide_url(:eligibility_criteria)
+    %li= link_to "Elibility criteria", student_guide_url(anchor: "eligibility_criteria")
     %li= link_to "Code of conduct", code_of_conduct_url
 
 %p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
         dashboard: "%a, %d %b %Y, %H:%M"
   time:
       formats:
-        default: "%a, %d %b %Y %H:%M "
+        default: "%a, %d %b %Y %H:%M"
         email: "%a, %d %B at %H:%M"
         email_title: "%A, %d %b at %H:%M"
         short: "%d/%m/%Y %H:%M "

--- a/spec/fabricators/ban_fabricator.rb
+++ b/spec/fabricators/ban_fabricator.rb
@@ -1,0 +1,7 @@
+Fabricator(:ban) do
+  reason "Violation of attendance policy"
+  note Faker::Lorem.word
+  expires_at Date.today+1.month
+  added_by { Fabricate(:member) }
+
+end

--- a/spec/fabricators/session_invitation_fabricator.rb
+++ b/spec/fabricators/session_invitation_fabricator.rb
@@ -2,7 +2,7 @@ Fabricator(:session_invitation) do
   member
   attending nil
   attended nil
-  note "I'd love to attend"
+  note { Faker::Lorem.word }
   sessions
   role "Student"
 end

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 feature "Managing users" do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:chapter_organiser) }
+  let!(:invitation) { Fabricate(:attended_session_invitation, member: member) }
+  let!(:attending_invitation) { Fabricate(:attending_session_invitation, member: member) }
+  let!(:other_invitation) { Fabricate(:session_invitation, member: member) }
 
   before do
     login admin
@@ -14,6 +17,9 @@ feature "Managing users" do
     expect(page).to have_content member.name
     expect(page).to have_content member.email
     expect(page).to have_content member.about_you
+    expect(page).to have_content invitation.note
+    expect(page).to have_content attending_invitation.note
+    expect(page).to_not have_content other_invitation.note
   end
 
   scenario "Add a note to a user" do

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -23,4 +23,17 @@ feature "Managing users" do
 
     expect(page).to have_content "Bananas and custard"
   end
+
+  scenario "Ban a user" do
+    visit admin_member_path member
+    click_on "Ban"
+
+    select "Violated attendance policy", from: "ban_reason"
+    fill_in "ban_note", with: Faker::Lorem.word
+    fill_in "ban_expires_at", with: Date.today+1.month
+    click_on "Ban user"
+
+    expect(page).to have_content "The user has been banned"
+  end
+
 end

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe MemberMailer, :type => :mailer do
     end
   end
 
+  describe "ban email" do
+    let(:ban) { Fabricate(:ban, reason: "Attendance violation") }
+    let(:mail) { MemberMailer.ban(member, ban).deliver_now }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Attendance violation")
+      expect(mail.to).to eq([member.email])
+      expect(mail.from).to eq(["hello@codebar.io"])
+      expect(mail.cc).to eq(["hello@codebar.io"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("your account has been suspended")
+    end
+  end
+
   describe "welcome" do
     it "sends the coach welcome email to coaches" do
       member = Fabricate(:coach)
@@ -78,6 +94,15 @@ RSpec.describe MemberMailer, :type => :mailer do
       expect_any_instance_of(MemberMailer).to receive(:welcome_student)
       MemberMailer.welcome(member).deviver_now
     end
+
+    it "sends a ban email to a member" do
+      member = Fabricate(:member)
+      ban = Fabricate(:ban)
+      expect_any_instance_of(MemberMailer).to receive(:ban).with(member, ban)
+
+      MemberMailer.ban(member, ban).deviver_now
+    end
+
 
     it "actually sends a coach email" do
       member = Fabricate(:coach)

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe MemberMailer, :type => :mailer do
       member = Fabricate(:student)
       expect_any_instance_of(MemberMailer).not_to receive(:welcome_coach)
       expect_any_instance_of(MemberMailer).to receive(:welcome_student)
-      MemberMailer.welcome(member).deviver_now
+      MemberMailer.welcome(member).deliver_now
     end
 
     it "sends a ban email to a member" do
@@ -100,7 +100,7 @@ RSpec.describe MemberMailer, :type => :mailer do
       ban = Fabricate(:ban)
       expect_any_instance_of(MemberMailer).to receive(:ban).with(member, ban)
 
-      MemberMailer.ban(member, ban).deviver_now
+      MemberMailer.ban(member, ban).deliver_now
     end
 
 

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe MemberMailer, :type => :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("you have missed more than 3 workshops")
+      expect(mail.body.encoded).to match("you have missed more than 2 workshops")
     end
   end
 

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MemberMailer, :type => :mailer do
       expect(mail.subject).to eq("How codebar works")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(["hello@codebar.io"])
-      expect(mail.cc).to eq(["hello@codebar.io"])
+      expect(mail.cc).to eq([])
     end
 
     it "renders the body" do
@@ -25,7 +25,7 @@ RSpec.describe MemberMailer, :type => :mailer do
       expect(mail.subject).to eq("How codebar works")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(["hello@codebar.io"])
-      expect(mail.cc).to eq(["hello@codebar.io"])
+      expect(mail.cc).to eq([])
     end
 
     it "renders the body" do


### PR DESCRIPTION
- emails banned user - fixes #410 
- lists both attended and rsvp'ed invitations on admin/member view,
- removes cc from member welcome email