### PR TITLE
Rescue from Standard Error instead of rescuing from Exception

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ if Rails.env.development?
     end
 
     puts "..done!"
-  rescue Exception => e
+  rescue => e
     puts e.inspect
     puts "Something went wrong. Try running `bundle exec rake db:drop db:create db:migrate` first"
   end


### PR DESCRIPTION
For details as to why rescuing from Standard Error is preferable when compared to rescuing from Exception one can read -
1. http://stackoverflow.com/a/10048406/272398
2. https://robots.thoughtbot.com/rescue-standarderror-not-exception
