### PR TITLE
add edit/update for chapters, admin & organisers only. with tests.

### DIFF
--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -29,9 +29,27 @@ class Admin::ChaptersController < Admin::ApplicationController
     @subscribers = @chapter.subscriptions.last(20).reverse
   end
 
+  def edit
+    @chapter = Chapter.find(params[:id])
+    authorize @chapter
+  end
+
+  def update
+    @chapter = Chapter.find(params[:id])
+    authorize(@chapter)
+
+    if @chapter.update(chapter_params)
+      flash[:notice] = "Chapter #{@chapter.name} has been successfully updated"
+      redirect_to [:admin, @chapter ]
+    else
+      flash[:notice] = @chapter.errors.full_messages
+      render 'edit'
+    end
+  end
+
   private
 
   def chapter_params
-    params.require(:chapter).permit(:name, :email, :city)
+    params.require(:chapter).permit(:name, :email, :city, :twitter)
   end
 end

--- a/app/policies/chapter_policy.rb
+++ b/app/policies/chapter_policy.rb
@@ -9,6 +9,20 @@ class ChapterPolicy < ApplicationPolicy
   end
 
   def show?
-    user.is_admin? or user.has_role?(:organiser, record) or user.has_role?(:organiser)
+    is_admin_or_organiser?
+  end
+
+  def edit?
+  	is_admin_or_organiser?
+  end
+
+  def update?
+  	is_admin_or_organiser?
+  end
+
+  private
+
+  def is_admin_or_organiser?
+  	user.is_admin? or user.has_role?(:organiser, record) or user.has_role?(:organiser)
   end
 end

--- a/app/views/admin/chapters/edit.html.haml
+++ b/app/views/admin/chapters/edit.html.haml
@@ -1,0 +1,20 @@
+%section#banner
+  .row
+    .medium-12.columns
+      %h2 Edit Chapter #{@chapter.name}
+      = simple_form_for [:admin, @chapter] do |f|
+        .row
+          .large-6.columns
+            = f.input :name, placeholder: 'e.g. Cambridge', required: true
+        .row
+          .large-6.columns
+            = f.input :email, placeholder: 'e.g. cambridge@codebar.io', required: true
+        .row
+          .large-6.columns
+            = f.input :city, required: true
+        .row
+          .large-6.columns
+            = f.input :twitter, required: false
+        .row
+          .large-12.columns.text-right
+            = f.submit 'Update chapter', class: 'button'

--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -2,6 +2,9 @@
   .row
     .medium-12.columns
       %h2.subheader
+        %small
+          = link_to edit_admin_chapter_path(@chapter) do
+            %i.fa.fa-edit
         = @chapter.name
         %small= @chapter.email
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,7 @@ Planner::Application.routes.draw do
     end
     resources :member_notes, only: [:create]
 
-    resources :chapters, only: [ :index, :new, :create, :show] do
+    resources :chapters, only: [ :index, :new, :create, :show, :edit, :update] do
       resources :workshops, only: [ :index ]
     end
 

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -20,4 +20,63 @@ feature 'chapters' do
       expect(page).to have_content("Chapter codebar Brighton has been successfully created")
     end
   end
+
+  context "#editing a chapter" do
+    let(:chapter) { Fabricate(:chapter) }
+
+
+    context "organiser editing their chapter" do
+      before do
+        login(chapter.organisers.first)
+      end
+
+      scenario "an organiser can update a chapter they organise" do
+        visit edit_admin_chapter_path(chapter)
+
+        fill_in "Name", with: "codebar Brighton"
+        fill_in "Email", with: "brighton@codebar.io"
+        fill_in "City", with: "Brighton"
+
+        click_on "Update chapter"
+
+        expect(page).to have_content("Chapter codebar Brighton has been successfully updated")
+      end
+    end
+
+    context "organiser editing a chapter they do not organise" do
+  
+      let(:chapter_organiser) { Fabricate(:chapter_organiser)}
+      before do
+        login(chapter_organiser)
+      end
+
+      scenario "an organiser cannot update a chapter they do not organise" do
+        visit edit_admin_chapter_path(chapter)
+
+        expect(page).to have_current_path('/')
+      end
+    end
+
+    context "admin editing a chapter they do not organise" do
+  
+      # let(:chapter_organiser) { Fabricate(:chapter_organiser)}
+      let(:member) { Fabricate(:member)}
+      before do
+        login_as_admin(member)
+      end
+
+      scenario "an organiser cannot update a chapter they do not organise" do
+        visit edit_admin_chapter_path(chapter)
+
+        fill_in "Name", with: "codebar Brighton"
+        fill_in "Email", with: "brighton@codebar.io"
+        fill_in "City", with: "Brighton"
+
+        click_on "Update chapter"
+
+
+        expect(page).to have_content("Chapter codebar Brighton has been successfully updated")
+      end
+    end
+  end
 end


### PR DESCRIPTION
fixes #456 

The ability for a chapter to have its own Twitter was already in there. So I have just added the ability for organisers and admin to edit chapters (in order to update their twitter account). This is then the twitter account displayed on the front end chapter 'show' page.

Admin can edit any chapters.
Organisers can only edit the chapters they organise.