### PR TITLE
Remove 'at' from admin area for new signup [ci skip]

### DIFF
--- a/app/views/admin/subscriptions/_index.html.haml
+++ b/app/views/admin/subscriptions/_index.html.haml
@@ -7,5 +7,5 @@
             = link_to admin_member_path(subscription.member) do
               #{subscription.member.full_name}
               %br
-              %small joined #{subscription.group.to_s} at #{l(subscription.created_at, format: :log)}
+              %small joined #{subscription.group.to_s} #{l(subscription.created_at, format: :log)}
 


### PR DESCRIPTION
fixes #469  