### PR TITLE
addition: add chapter to admin:feedback display

### DIFF
--- a/app/views/admin/feedback/index.html.haml
+++ b/app/views/admin/feedback/index.html.haml
@@ -17,6 +17,8 @@
             .large-2.columns
               - (0...feedback.rating).each do |rating|
                 %i.fa.fa-star
+            .large-1.columns
+              = feedback.tutorial.workshop.chapter.name
           - if feedback.request.present?
             .row
               .large-12.columns


### PR DESCRIPTION
Each piece of feedback now also renders the chapter that feedback came from. To do this, I added a bit of code to the admin:feedback index template. This is an attempt to address issue #467.