### PR TITLE
Add workshop association for feedback

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -35,7 +35,7 @@ class FeedbackController < ApplicationController
   private
 
   def feedback_params
-    params.require(:feedback).permit(:coach_id, :tutorial_id, :request, :rating, :suggestions)
+    params.require(:feedback).permit(:coach_id, :tutorial_id, :request, :rating, :suggestions, :workshop_id)
   end
 
   def set_coaches(workshop)

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,10 @@
+module FeedbackHelper
+
+  def recent_workshop_details
+    recent_workshops = Workshop.recent.includes(:chapter)
+
+    recent_workshops.each_with_object({}) do |workshop, recent_workshops_details|
+      recent_workshops_details[workshop.id] = "#{workshop.chapter.name} - #{workshop.date_and_time.strftime('%A, %b %d')}"
+    end
+  end
+end

--- a/app/models/concerns/listable.rb
+++ b/app/models/concerns/listable.rb
@@ -1,10 +1,13 @@
 module Listable
+  NUMBER_OF_RECENT_WORKSHOPS_TO_RETRIEVE = 10.freeze
+
   extend ActiveSupport::Concern
 
   included do
 
     scope :upcoming, -> { where("date_and_time >= ?", Time.zone.now).order(:date_and_time) }
     scope :past, -> { where("date_and_time < ?", Time.zone.now).order(:date_and_time) }
+    scope :recent, -> { where("date_and_time < ?", Time.zone.now).order(date_and_time: :desc).limit(NUMBER_OF_RECENT_WORKSHOPS_TO_RETRIEVE) }
   end
 
   module ClassMethods

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,7 @@
 class Feedback < ActiveRecord::Base
   belongs_to :tutorial
   belongs_to :coach, class_name: "Member"
+  belongs_to :workshop
 
   validates :rating, inclusion: { in: 1..5, message: "can't be blank" }
   validates :tutorial, presence: true

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -23,6 +23,9 @@
           .large-6.columns
             = f.association :tutorial, label_method: :title, value_method: :id, label: 'What tutorial did you go through?', include_blank: '- Select Tutorial -'
         .row
+          .large-6.columns
+            = f.input :workshop_id, collection: recent_workshop_details, value_method: :first, label_method: :last, label: 'Which workshop did you attend?', include_blank: '- Select Workshop -'
+        .row
           .large-12.columns
             = f.input :request, label: 'How did you find the workshop?'
         .row

--- a/db/migrate/20161228121833_add_workshop_id_to_feedback.rb
+++ b/db/migrate/20161228121833_add_workshop_id_to_feedback.rb
@@ -1,0 +1,5 @@
+class AddWorkshopIdToFeedback < ActiveRecord::Migration
+  def change
+    add_column :feedbacks, :workshop_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -229,6 +229,7 @@ ActiveRecord::Schema.define(version: 20161028141043) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "rating"
+    t.integer  "workshop_id"
   end
 
   add_index "feedbacks", ["coach_id"], name: "index_feedbacks_on_coach_id", using: :btree

--- a/spec/helpers/feedback_helper_spec.rb
+++ b/spec/helpers/feedback_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe FeedbackHelper do
+
+  describe "#recent_workshop_details", type: :helper do
+    it "gets the recently held workshop details" do
+      chapters = [Fabricate(:chapter_with_groups, name: "London"),
+                  Fabricate(:chapter_with_groups, name: "Brighton")]
+
+      workshops = 2.times.map { |n| Fabricate(:workshop, chapter: chapters.sample, date_and_time: Time.zone.now - n.weeks) }
+
+      expect(helper.recent_workshop_details.keys).to eq(workshops.collect(&:id))
+    end
+  end
+
+end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -64,7 +64,7 @@ describe Workshop do
     let(:most_recent) { Fabricate(:workshop, date_and_time: 1.day.ago) }
 
     before do
-      Fabricate(:workshop, date_and_time: Time.zone.now-1.week)
+      @old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now-1.week)
       set_upcoming
       most_recent
     end
@@ -149,6 +149,13 @@ describe Workshop do
         attendee_invites.each {|a| expect(workshop.waitlisted? a.member).to be false }
       end
     end
+
+    describe ".recent" do
+      it "retrieves some of the most recently held workshops" do
+        expect(Workshop.recent).to eq([most_recent, @old_workshop])
+      end
+    end
+
   end
 
   context "#invitable_yet?" do


### PR DESCRIPTION
**Please note**: Currently I haven't added any index wrt `workshop_id` column in the Feedback table because I don't think we are currently having any page where we display workshop specific feedback.