### PR TITLE
Change earliest turn up time for attendees

### DIFF
--- a/app/views/session_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/session_invitation_mailer/attending_reminder.html.haml
@@ -19,7 +19,7 @@
                   If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.
                   <a href="https://codebar.io/student-guide#attendance">We have a three-strikes attendance policy for no-shows.</a>
                 %p
-                  <strong>Please do not turn up before #{(@session.date_and_time - 15.minutes).strftime("%H:%M")}.</strong> If you are early, please wait in a nearby cafe.
+                  <strong>Please do not turn up before #{(@session.date_and_time).strftime("%H:%M")}.</strong> If you are early, please wait in a nearby cafe.
 
 
         .content


### PR DESCRIPTION
Change the earliest possible turn up time to the start time of event rather than 15 minutes prior.