### PR TITLE
Change so students know to have backup options

### DIFF
--- a/app/views/session_invitation_mailer/attending.html.haml
+++ b/app/views/session_invitation_mailer/attending.html.haml
@@ -19,8 +19,11 @@
                   - else
                     Your spot has been confirmed.
                     - if @invitation.role.eql?("Student")
-                      If you haven't already, please remember to let us know what you will be working on through the invitation.
-                  See you at our workshop!
+                      If you haven't already, please remember to let us know what you will be working on through the invitation. 
+                      Projects that involve specific frameworks, libraries, or languages that are not part of the codebar tutorials 
+                      (anything other than Ruby or Javascript) are welcome, but we cannot guarantee that a coach will be available to help you.  
+                      We recommend having a backup option to work on, such as codebar tutorials or katas (codewars.com or exercism.io). 
+                      See you at our workshop!
 
                   %p
                     If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.


### PR DESCRIPTION
Adds in caveat to student confirmation email that students with more ambitious projects (ie, other than codebar tutorials or katas in Ruby or JS) should also plan a backup for the workshop.