### PR TITLE
Fix link to chapter on profile page

### DIFF
--- a/app/views/members/_show.html.haml
+++ b/app/views/members/_show.html.haml
@@ -39,7 +39,7 @@
           %ul.no-bullet
             - member.groups.each do |group|
               %li
-                = link_to [:admin, group] do
+                = link_to chapter_path(group.chapter.slug) do
                   #{group.name} (#{group.chapter.name})
         - else
           %label.label.secondary You are not subscribed to any groups

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -72,6 +72,6 @@ feature "A new student signs up", js: false do
     click_button group.chapter.name
     click_on "Done"
 
-    expect(page).to have_content("#{group.name} (#{group.chapter.name})")
+    expect(page).to have_link("#{group.name} (#{group.chapter.name})", href: "/#{group.chapter.slug}")
   end
 end


### PR DESCRIPTION
The member profile page lists all the current users' subscriptions. But the entries link to the admin section of the site, which most people won't have access to.

![screen shot 2017-01-08 at 16 17 31](https://cloud.githubusercontent.com/assets/233676/21751365/f968e942-d5bd-11e6-8729-9f5464545614.png)

People clicking the link will see a message "You can't be here" (indicating that they haven't got enough permissions for this).

![screen shot 2017-01-08 at 16 14 53](https://cloud.githubusercontent.com/assets/233676/21751345/95c5731a-d5bd-11e6-867a-4dff107145c1.png)

I think the original intention was to link to the chapter page. This PR fixes the link.