### PR TITLE
Forcing new users to complete 2-step sign up

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Using these field values:
 
 Create an application at [https://github.com/settings/applications/new](https://github.com/settings/applications/new).
 
+When signing up for an account, whether in test, development or production, you are now required complete the two-step process in order to access any other pages.  A global before_action handling this fucntionality can be found in the ApplicationController.
+
 #### Add your application details to your environment
 
 Create a file named `.env` in the root of the application folder (`touch .env`) 


### PR DESCRIPTION
Added few sentences to GitHub Authentication section instructing users that they must complete the two-step sign up process in order to get past the global before action.  This will be relevant when Issue #442 is closed.