### PR TITLE
remove donate button whilst bank details change

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -24,7 +24,7 @@
         %li= link_to t("navigation.coaches"), coaches_path
         %li= link_to t("navigation.sponsors"), sponsors_path
         %li= link_to t("navigation.events"), events_path
-        %li.active= link_to t("navigation.donate"), "http://donate.codebar.io"
+        -# %li.active= link_to t("navigation.donate"), "http://donate.codebar.io"
 
     .large-3.columns
       = render partial: 'shared/social_media'

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -42,10 +42,10 @@
           %li
             = link_to sponsors_path do
               %span Sponsors
-        %li
-          = link_to  'http://donate.codebar.io' do
-            %span
-              %highlight Donate
+        -# %li
+        -#   = link_to  'http://donate.codebar.io' do
+        -#     %span
+        -#       %highlight Donate
         - if !logged_in?
           %li
             = link_to '/auth/github' do


### PR DESCRIPTION
I think we should remove the donate button on the codebar website for a week whilst we change bank account. Thoughts??