### PR TITLE
Limit data on events index

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,14 +5,12 @@ class EventsController < ApplicationController
 
   def index
     events = [ Workshop.recent.all ]
-    events << Course.recent.all
     events << Meeting.recent.all
     events << Event.recent.all
     events = events.compact.flatten.sort_by(&:date_and_time).reverse.group_by(&:date)
     @past_events = events.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash}
 
     events = [ Workshop.upcoming.all ]
-    events << Course.upcoming.all
     events << Meeting.upcoming.all
     events << Event.upcoming.all
     events = events.compact.flatten.sort_by(&:date_and_time).group_by(&:date)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,10 +4,10 @@ class EventsController < ApplicationController
   before_action :is_logged_in?, only: [:student, :coach]
 
   def index
-    events = [ Workshop.past.all ]
-    events << Course.past.all
-    events << Meeting.past.all
-    events << Event.past.all
+    events = [ Workshop.recent.all ]
+    events << Course.recent.all
+    events << Meeting.recent.all
+    events << Event.recent.all
     events = events.compact.flatten.sort_by(&:date_and_time).reverse.group_by(&:date)
     @past_events = events.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash}
 
@@ -25,7 +25,7 @@ class EventsController < ApplicationController
     @event = EventPresenter.new(event)
     @host_address = AddressDecorator.new(@event.venue.address)
 
-    if logged_in?
+    if logged_in? 
       invitation = Invitation.where(member: current_user, event: event, attending: true).try(:first)
       if invitation
         redirect_to event_invitation_path(@event, invitation) and return

--- a/app/models/concerns/listable.rb
+++ b/app/models/concerns/listable.rb
@@ -1,5 +1,5 @@
 module Listable
-  NUMBER_OF_RECENT_WORKSHOPS_TO_RETRIEVE = 10.freeze
+  NUMBER_RECORDS_TO_RETRIEVE = 10.freeze
 
   extend ActiveSupport::Concern
 
@@ -7,7 +7,7 @@ module Listable
 
     scope :upcoming, -> { where("date_and_time >= ?", Time.zone.now).order(:date_and_time) }
     scope :past, -> { where("date_and_time < ?", Time.zone.now).order(:date_and_time) }
-    scope :recent, -> { where("date_and_time < ?", Time.zone.now).order(date_and_time: :desc).limit(NUMBER_OF_RECENT_WORKSHOPS_TO_RETRIEVE) }
+    scope :recent, -> { where("date_and_time < ?", Time.zone.now).order(date_and_time: :desc).limit(NUMBER_RECORDS_TO_RETRIEVE) }
   end
 
   module ClassMethods

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,9 @@ development:
   encoding: unicode
   database: planner_development
   pool: 5
+  host: localhost
+ # username: codebar
+ # password: secret
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -12,3 +15,8 @@ test:
   encoding: unicode
   database: planner_test
   pool: 5
+  host: localhost
+# username: codebar
+# password: secret
+
+

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,9 +3,6 @@ development:
   encoding: unicode
   database: planner_development
   pool: 5
-  host: localhost
- # username: codebar
- # password: secret
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -15,8 +12,3 @@ test:
   encoding: unicode
   database: planner_test
   pool: 5
-  host: localhost
-# username: codebar
-# password: secret
-
-

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe EventsController, type: :controller do
+  
+  describe '#index' do
+    
+    let!(:workshops) { 
+      15.times.map { Fabricate(:workshop, date_and_time: 1.week.ago) }
+    }
+    
+    it 'returns only recent events' do
+      get :index
+      expect(assigns(:past_events).first.second.length).to be Listable::NUMBER_RECORDS_TO_RETRIEVE
+    end
+    
+  end
+
+end

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -7,9 +7,10 @@ feature 'event listing' do
   let!(:event) { Fabricate(:event) }
   let!(:past_event) { Fabricate(:event, date_and_time: Time.zone.now-2.weeks) }
 
-  before { visit events_path }
-
   scenario 'I can view a list with upcoming and past events' do
+
+    visit events_path
+    
     within(".upcoming") do
       expect(page).to have_content upcoming_workshop.host.name
       expect(page).to have_content upcoming_workshop.to_s

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -2,31 +2,23 @@ require 'spec_helper'
 
 feature 'event listing' do
 
-  let!(:upcoming_course) { Fabricate(:course) }
-  let!(:past_course) { Fabricate(:course, chapter: upcoming_course.chapter, date_and_time: Time.zone.now-1.week) }
   let!(:upcoming_workshop) { Fabricate(:workshop) }
   let!(:past_workshop) { Fabricate(:workshop, date_and_time: Time.zone.now-1.week) }
   let!(:event) { Fabricate(:event) }
   let!(:past_event) { Fabricate(:event, date_and_time: Time.zone.now-2.weeks) }
 
-  before do
-    visit events_path
-  end
+  before { visit events_path }
 
-  scenario 'i can view a list with upcoming events' do
-
+  scenario 'I can view a list with upcoming and past events' do
     within(".upcoming") do
-      expect(page).to have_content upcoming_course.title
-      expect(page).to have_content "Workshop"
+      expect(page).to have_content upcoming_workshop.host.name
+      expect(page).to have_content upcoming_workshop.to_s
       expect(page).to have_content event.name
     end
-  end
-
-  scenario 'i can view a list with past events' do
 
     within(".past") do
-      expect(page).to have_content past_course.title
-      expect(page).to have_content "Workshop"
+      expect(page).to have_content past_workshop.host.name
+      expect(page).to have_content past_workshop.to_s
       expect(page).to have_content past_event.name
     end
   end


### PR DESCRIPTION
The /events page is currently loading unreasonably slowly.

Using an amount of data that closely reflected production data (~550 events), the time to first byte went from (average of 3) 9.8s to 0.6s