### PR TITLE
Use an 'indenticon' as the default fallback image for Gravatar

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -1130,8 +1130,8 @@ $table-margin-bottom: rem-calc(10);
 $thumb-border-style: none;
 $thumb-border-width: rem-calc(1);
 // $thumb-border-color: #fff;
-$thumb-box-shadow: 1px 3px 3px 0 rgba(0, 0, 0, 0.5);
-$thumb-box-shadow-hover: 1px 3px 6px 0 rgba(0, 0, 0, 1);
+$thumb-box-shadow: none;
+$thumb-box-shadow-hover: 0 0 5px 0 rgba(0, 0, 0, 0.25);
 
 
 // Radius and transition speed for thumbs

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -76,7 +76,7 @@ class Member < ActiveRecord::Base
   end
 
   def avatar size=100
-    "https://secure.gravatar.com/avatar/#{md5_email}?s=#{size}"
+    "https://secure.gravatar.com/avatar/#{md5_email}?size=#{size}&default=identicon"
   end
 
   def attended_sessions

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -69,7 +69,7 @@ describe Member do
 
       it "#avatar" do
         encrypted_email = Digest::MD5.hexdigest(member.email.strip.downcase)
-        expect(member.avatar).to eq("https://secure.gravatar.com/avatar/#{encrypted_email}?s=100")
+        expect(member.avatar).to eq("https://secure.gravatar.com/avatar/#{encrypted_email}?size=100&default=identicon")
       end
 
       it "#attended_sessions" do


### PR DESCRIPTION
This closes #566. Makes the default images a bit more interesting. Also removes the drop shadow for a cleaner look.

Monthlies page after

![screenshot from 2017-08-16 19-19-49](https://user-images.githubusercontent.com/2591901/29378993-eca2a538-82b8-11e7-8a26-638257f9753a.png)

Monthlies page before

![screenshot from 2017-08-16 19-19-59](https://user-images.githubusercontent.com/2591901/29378995-ecab1e16-82b8-11e7-8af0-1e2dd0edb245.png)

Events page after

![screenshot from 2017-08-16 19-20-56](https://user-images.githubusercontent.com/2591901/29378994-eca52222-82b8-11e7-9193-b6e2d57569ed.png)

Events page before

![screenshot from 2017-08-16 19-21-04](https://user-images.githubusercontent.com/2591901/29378996-ecab8f90-82b8-11e7-9b2f-a968aab8120b.png)
