### PR TITLE
remove dashed border on gravatar thumbnails

### DIFF
--- a/app/assets/stylesheets/partials/_organisers.scss
+++ b/app/assets/stylesheets/partials/_organisers.scss
@@ -1,3 +1,3 @@
-.organisers a {
+.user-link {
   border-bottom: none;
 }

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -47,7 +47,7 @@
             .organiser
               .row
                 .small-12.columns
-                  =link_to twitter_url_for(organiser.twitter) do
+                  =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
                     =image_tag organiser.avatar(65), class: 'th radius', title: organiser.full_name
               .row
                 .small-12.columns

--- a/app/views/coach/_coach.html.haml
+++ b/app/views/coach/_coach.html.haml
@@ -6,7 +6,7 @@
           %li.coach
             .row
               .small-2.columns
-                =link_to twitter_url_for(coach.twitter) do
+                =link_to twitter_url_for(coach.twitter), class: 'user-link' do
                   =image_tag coach.avatar(96), class: 'th radius', title: coach.full_name
 
               .small-10.columns
@@ -14,7 +14,7 @@
                   = coach.full_name
                 %p= coach.about_you
                 - if coach.skills.any?
-                  %p 
-                    skills: 
+                  %p
+                    skills:
                     - coach.skills.each do |skill|
                       = link_to skill.name, skill_url(skill.name), class: "skill"

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -50,7 +50,7 @@
           %li.coach
             .row
               .small-2.columns
-                =link_to twitter_url_for(tutor.twitter) do
+                =link_to twitter_url_for(tutor.twitter), class: 'user-link' do
                   =image_tag tutor.avatar(106), class: 'th radius'
               .small-10.columns
                 =link_to twitter_url_for(tutor.twitter) do
@@ -94,11 +94,10 @@
       %ul.small-block-grid-2.medium-block-grid-4
         - @course.organisers.each do |organiser|
           %li.text-center
-            =link_to twitter_url_for(organiser.twitter) do
+            =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
               =image_tag organiser.avatar(56), class: 'th radius', title: organiser.full_name
             %br
             %br
             = organiser.full_name
             %br= organiser.mobile
             %br
-

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -38,7 +38,7 @@
           %li.coach
             .row
               .small-2.columns
-                =link_to twitter_url_for(tutor.twitter) do
+                =link_to twitter_url_for(tutor.twitter), class: 'user-link' do
                   =image_tag tutor.avatar(106), class: 'th radius'
               .small-10.columns
                 =link_to twitter_url_for(tutor.twitter) do

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -26,7 +26,7 @@
           - if event.organisers.any?
             .organisers
               - event.organisers.each do |organiser|
-                =link_to twitter_url_for(organiser.twitter) do
+                =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
                   =image_tag organiser.avatar(26), class: 'th radius', title: organiser.full_name
         .medium-6.columns#sponsors
           - if event.sponsors.any?

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -95,7 +95,7 @@
           %ul.small-block-grid-2.medium-block-grid-4
             - @event.verified_coaches.each do |coach|
               %li.text-center
-                =link_to twitter_url_for(coach.twitter) do
+                =link_to twitter_url_for(coach.twitter), class: 'user-link' do
                   =image_tag coach.avatar(56), class: 'th radius', title: coach.full_name
                   %br
                   %br
@@ -112,7 +112,7 @@
         %ul.small-block-grid-2.medium-block-grid-4
           - @event.organisers.each do |organiser|
             %li.text-center
-              =link_to twitter_url_for(organiser.twitter) do
+              =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
                 =image_tag organiser.avatar(56), class: 'th radius', title: organiser.full_name
                 %br
                 %br

--- a/app/views/invitations/show.html.haml
+++ b/app/views/invitations/show.html.haml
@@ -128,7 +128,7 @@
           %ul.small-block-grid-2.medium-block-grid-5
             - @event.verified_coaches.each do |coach|
               %li.text-center
-                =link_to twitter_url_for(coach.twitter) do
+                =link_to twitter_url_for(coach.twitter), class: 'user-link' do
                   =image_tag coach.avatar(56), class: 'th radius', title: coach.full_name
                   %br
                   %br
@@ -145,7 +145,7 @@
           %ul.small-block-grid-2.medium-block-grid-5
             - @event.verified_students.each do |student|
               %li.text-center
-                =link_to twitter_url_for(student.twitter) do
+                =link_to twitter_url_for(student.twitter), class: 'user-link' do
                   =image_tag student.avatar(56), class: 'th radius', title: student.full_name
                   %br
                   %br
@@ -163,7 +163,7 @@
           %ul.small-block-grid-1.medium-block-grid-4
             - @event.organisers.each do |organiser|
               %li.text-center
-                =link_to twitter_url_for(organiser.twitter) do
+                =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
                   =image_tag organiser.avatar(56), class: 'th radius', title: organiser.full_name
                   %br
                   %br

--- a/app/views/meetings/_meeting.html.haml
+++ b/app/views/meetings/_meeting.html.haml
@@ -23,7 +23,7 @@
           - if meeting.organisers.any?
             .organisers
               - meeting.organisers.each do |organiser|
-                =link_to twitter_url_for(organiser.twitter) do
+                =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
                   =image_tag organiser.avatar(26), class: 'th radius', title: organiser.full_name
 
         .medium-6.columns#sponsors

--- a/app/views/members/_avatar_listing.html.haml
+++ b/app/views/members/_avatar_listing.html.haml
@@ -1,7 +1,7 @@
 %ul.small-block-grid-2.medium-block-grid-4
   - member.each do |member|
     %li.text-center
-      =link_to twitter_url_for(member.twitter) do
+      =link_to twitter_url_for(member.twitter), class: 'user-link' do
         =image_tag member.avatar(56), class: 'th radius', title: member.full_name
       %br
       %br


### PR DESCRIPTION
Remove dashed border that appeared on gravatar thumbnails:

<img width="130" alt="screen shot 2017-08-22 at 03 47 40" src="https://user-images.githubusercontent.com/2683270/29547286-0c621318-86f1-11e7-8400-f320cc780973.png">
<img width="70" alt="screen shot 2017-08-22 at 03 42 52" src="https://user-images.githubusercontent.com/2683270/29547287-0c6552a8-86f1-11e7-9487-61cd83feea15.png">
