### PR TITLE
Improve flakey jobs test

### DIFF
--- a/spec/fabricators/job_fabricator.rb
+++ b/spec/fabricators/job_fabricator.rb
@@ -1,9 +1,4 @@
 titles = [
-  'Junior Software Engineer',
-  'Junior Software Developer',
-  'Junior Front-end Developer',
-  'Junior Back-end Developer',
-  'Junior Full-stack Developer',
   'Software Engineer',
   'Software Developer',
   'Front-end Developer',


### PR DESCRIPTION
PRs keep failing because there is an ambiguous test that sometimes passes sometimes fails. This should make it so this test passes reliably.