### PR TITLE
Limit events page to only show 40 most recent past events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,8 +8,9 @@ class EventsController < ApplicationController
     events << Course.past.all
     events << Meeting.past.all
     events << Event.past.all
-    events = events.compact.flatten.sort_by(&:date_and_time).reverse.group_by(&:date)
-    @past_events = events.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash}
+    events = events.compact.flatten.sort_by(&:date_and_time).reverse.first(40)
+    events_hash_grouped_by_date = events.group_by(&:date)
+    @past_events = events_hash_grouped_by_date.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash}
 
     events = [ Workshop.upcoming.all ]
     events << Course.upcoming.all

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,12 +3,14 @@ require 'services/ticket'
 class EventsController < ApplicationController
   before_action :is_logged_in?, only: [:student, :coach]
 
+  RECENT_EVENTS_DISPLAY_LIMIT = 40
+
   def index
-    events = [ Workshop.past.all ]
-    events << Course.past.all
-    events << Meeting.past.all
-    events << Event.past.all
-    events = events.compact.flatten.sort_by(&:date_and_time).reverse.first(40)
+    events = [ Workshop.past.limit(RECENT_EVENTS_DISPLAY_LIMIT) ]
+    events << Course.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
+    events << Meeting.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
+    events << Event.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
+    events = events.compact.flatten.sort_by(&:date_and_time).reverse.first(RECENT_EVENTS_DISPLAY_LIMIT)
     events_hash_grouped_by_date = events.group_by(&:date)
     @past_events = events_hash_grouped_by_date.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash}
 

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -1,33 +1,54 @@
 require 'spec_helper'
 
 feature 'event listing' do
+  describe 'I can see the names and titles of events' do
+    let!(:upcoming_course) { Fabricate(:course) }
+    let!(:upcoming_workshop) { Fabricate(:workshop) }
+    let!(:event) { Fabricate(:event) }
+    let!(:past_course) { Fabricate(:course, chapter: upcoming_course.chapter, date_and_time: Time.zone.now-1.week) }
+    let!(:past_event) { Fabricate(:event, date_and_time: Time.zone.now-2.weeks) }
+    let!(:past_workshop) { Fabricate(:workshop, date_and_time: Time.zone.now-1.week) }
 
-  let!(:upcoming_course) { Fabricate(:course) }
-  let!(:past_course) { Fabricate(:course, chapter: upcoming_course.chapter, date_and_time: Time.zone.now-1.week) }
-  let!(:upcoming_workshop) { Fabricate(:workshop) }
-  let!(:past_workshop) { Fabricate(:workshop, date_and_time: Time.zone.now-1.week) }
-  let!(:event) { Fabricate(:event) }
-  let!(:past_event) { Fabricate(:event, date_and_time: Time.zone.now-2.weeks) }
+    before do
+      visit events_path
+    end
 
-  before do
-    visit events_path
-  end
+    scenario 'i can view a list with upcoming events' do
 
-  scenario 'i can view a list with upcoming events' do
+      within(".upcoming") do
+        expect(page).to have_content upcoming_course.title
+        expect(page).to have_content "Workshop"
+        expect(page).to have_content event.name
+      end
+    end
 
-    within(".upcoming") do
-      expect(page).to have_content upcoming_course.title
-      expect(page).to have_content "Workshop"
-      expect(page).to have_content event.name
+    scenario 'i can view a list with past events' do
+
+      within(".past") do
+        expect(page).to have_content past_course.title
+        expect(page).to have_content "Workshop"
+        expect(page).to have_content past_event.name
+      end
     end
   end
 
-  scenario 'i can view a list with past events' do
+  context 'when there are more than 40 past events' do
+    before(:each) do
+      41.times.map { Fabricate(:event, date_and_time: Time.zone.now-2.weeks) }
+      Fabricate(:workshop, date_and_time: Time.zone.now-3.weeks)
+      visit events_path
+    end
 
-    within(".past") do
-      expect(page).to have_content past_course.title
-      expect(page).to have_content "Workshop"
-      expect(page).to have_content past_event.name
+    scenario 'I can only see 40 past events' do
+      within(".past") do
+        expect(page).to have_selector(".event", count: 40)
+      end
+    end
+
+    scenario 'I can\'t see a past event outside of the most recent 40' do
+      within(".past") do
+        expect(page).not_to have_content "Workshop"
+      end
     end
   end
 end


### PR DESCRIPTION
Combine all event types, sort by date and then return 40 most recent.
Introduce new temp variable events_hash_grouped_by_date to make type conversion from array more explicit.

We tried to make the simplest possible change which satisfies the requests as specified in @matyikriszta's comment: https://github.com/codebar/planner/pull/551#issuecomment-305225200, specifically:

> what I'm saying is that we should show the last X events across the workshops and events