### PR TITLE
Relocated sponsors, faq and coaches into submenu

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -1193,12 +1193,12 @@ $thumb-radius: rem-calc(50);
 // $topbar-title-font-size: rem-calc(17);
 
 // Style the top bar dropdown elements
-$topbar-dropdown-bg: #FFFFFF;
+$topbar-dropdown-bg: #eee;
 $topbar-dropdown-link-color: $primary-color;
-$topbar-dropdown-link-bg: #FFFFFF;
+$topbar-dropdown-link-bg: #eee;
 // $topbar-dropdown-link-weight: normal;
 // $topbar-dropdown-toggle-size: 5px;
-$topbar-dropdown-toggle-color: #FFFFFF;
+$topbar-dropdown-toggle-color: #000000;
 // $topbar-dropdown-toggle-alpha: 0.4;
 
 // Set the link colors and styles for top-level nav
@@ -1389,6 +1389,19 @@ a {
 
 .top-bar {
   padding: 0 10px;
+}
+
+.top-bar-section .dropdown li:not(.has-form) a:not(.button) {
+	line-height: 3rem;
+}
+
+.top-bar-section .dropdown li.active:not(.has-form) a:not(.button) {
+	background-color: #ddd;
+}
+
+.top-bar-section .dropdown li:not(.has-form):not(.active) > a:not(.button):hover,
+.top-bar-section .dropdown li:not(.has-form) a:not(.button):hover {
+	background-color: #4bafff;
 }
 
 .avatar-container {

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -20,12 +20,19 @@
         %li
           = link_to 'http://tutorials.codebar.io' do
             %span Tutorials
-        %li{class: active_link_class(coaches_path)}
-          = link_to coaches_path do
-            %span Coaches
-        %li{class: active_link_class(sponsors_path)}
-          = link_to sponsors_path do
-            %span Sponsors
+        %li.has-dropdown
+          %a{href: "#"} About
+          %ul.dropdown
+            %li{class: active_link_class(coaches_path)}
+              = link_to coaches_path do
+                %span Coaches
+            %li{class: active_link_class(sponsors_path)}
+              = link_to sponsors_path do
+                %span Sponsors
+            %li{class: active_link_class(faq_path)}
+              = link_to faq_path do
+                %span= t("navigation.faq")
+
         %li{class: active_link_class(jobs_path)}
           = link_to jobs_path do
             %span Jobs


### PR DESCRIPTION
Related to #543

This creates an 'About' section on the nav bar, which has a submenu. The submenu contains the FAQ page, the Sponsors page and the Coaches page. The 'About' doesn't link to anything.

We're not sure about the styling and wanted to get some more thoughts on it. What do you think?

<img width="601" alt="screen shot 2017-10-05 at 20 14 57" src="https://user-images.githubusercontent.com/16868713/31247998-37086aa4-aa0a-11e7-9ebe-0eb4d320fe1f.png">
