### PR TITLE
Updates to text around the sign up process

### DIFF
--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -3,7 +3,7 @@
     .large-12.columns
       %h4= @chapter.name
       %p.lead
-        = t('chapters.intro')
+        = raw t('chapters.intro', email: @chapter.email)
       - if logged_in?
         = render partial: 'subscriptions'
       - else

--- a/app/views/members/new.html.haml
+++ b/app/views/members/new.html.haml
@@ -13,6 +13,8 @@
         = t('members.new.students.intro')
         = link_to t('members.new.students.criteria_link'), 'http://codebar.io/student-guide#eligibility'
         = t('members.new.students.criteria_brief')
+      %p.lead
+        = t('members.new.students.github')
       = link_to registration_path(member_type: "student"), class: "button round" do
         = t('members.sign_up_as_student')
         %i.fa.fa-github.fa-fw

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,7 @@ en:
         intro: "If you would like to attend as a student, make sure you meet our"
         criteria_link: "eligibility criteria"
         criteria_brief: "as our workshops are only available to women, LGBTQ, people from underrepresented minority groups."
+        github: "Lastly, when you click the sign up button, you'll be taken to something called GitHub. After logging in with a GitHub account, you'll be taken back to the codebar website. If you don't have an account yet, you'll need to create one. It doesn't take long and it's something that will come in handy when you get started with coding!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
 
   footer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,7 +228,7 @@ en:
       a_p2: ". They are ordered by number of attendances. This is our way of showing our appreciation to them, as without them, we wouldn't be able to exist."
 
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,7 +228,7 @@ en:
       a_p2: ". They are ordered by number of attendances. This is our way of showing our appreciation to them, as without them, we wouldn't be able to exist."
 
   chapters:
-    intro: "Places for our workshops are limited so please RSVP if you would like to attend."
+    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"


### PR DESCRIPTION
At the moment, the codebar.io/chaptername page is the first page that our codebar Oxford posters direct to. That page doesn't have very much information on it, so I've added in some text which directs people to the FAQ page and clarifies things a bit:

![image](https://user-images.githubusercontent.com/16868713/31457200-f4f386a4-aeb3-11e7-8b5e-040dc9965ab2.png)

I've also added some text about GitHub onto the second page of the sign up process to warn people that they're about to leave the codebar site, just in case the transition is unnerving. I've chosen to not include a link to GitHub here because they'll be taken there anyway.

![image](https://user-images.githubusercontent.com/16868713/31457256-1fbd091e-aeb4-11e7-9dcc-18f0b1e51a79.png)

Feel free to suggest changes to the wording; I'm a bit sleepy at the time of writing them. 

#599 