### PR TITLE
Fix intermittent Jobs test failures

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,25 @@ if Rails.env.development?
     tutorials = 10.times.map { |n| Fabricate(:tutorial, workshop: workshop.sample) }
     feedback_requests = 5.times.map { Fabricate(:feedback_request) }
     feedbacks = 5.times.map { Fabricate(:feedback, tutorial: tutorials.sample, coach: coaches.sample) }
-    jobs = 5.times.map { Fabricate(:job) }
+
+    job_titles = [
+      'Software Engineer',
+      'Software Developer',
+      'Front-end Developer',
+      'Back-end Developer',
+      'Full-stack Developer'
+    ]
+
+    job_companies = [
+      'ACME',
+      'Globex',
+      'Soylent',
+      'Initech',
+      'Umbrella',
+      'Wonka'
+    ]
+
+    jobs = 5.times.map { Fabricate(:job, title: job_titles.sample, company: job_companies.sample) }
 
     40.times do |n|
       coach = coaches.sample

--- a/spec/fabricators/job_fabricator.rb
+++ b/spec/fabricators/job_fabricator.rb
@@ -1,23 +1,7 @@
-titles = [
-  'Software Engineer',
-  'Software Developer',
-  'Front-end Developer',
-  'Back-end Developer',
-  'Full-stack Developer'
-]
-
-companies = [
-  'ACME',
-  'Globex',
-  'Soylent',
-  'Initech',
-  'Umbrella',
-  'Wonka'
-]
 
 Fabricator(:job) do
-  title { titles.sample }
-  company { companies.sample }
+  title 'Software Developer'
+  company 'ACME'
   description { Faker::Lorem.paragraph }
   location { Faker::Address.city }
   email { Faker::Address.city }

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -9,7 +9,7 @@ feature 'chapters' do
 
       visit new_admin_chapter_path
 
-      expect(current_path).to eq "/"
+      expect(page).to have_current_path("/")
       expect(page).to have_content "You can't be here"
     end
   end

--- a/spec/features/admin/jobs_spec.rb
+++ b/spec/features/admin/jobs_spec.rb
@@ -17,8 +17,8 @@ feature 'Admin Jobs' do
   # end
 
   scenario 'An admin can view jobs pending approval' do
-    job = Fabricate(:job, approved: false)
-    approved_job = Fabricate(:job)
+    job = Fabricate(:job, title: 'Unapproved Developer', approved: false)
+    approved_job = Fabricate(:job, title: 'Approved Developer')
 
     visit admin_jobs_path
     expect(page).to have_content(job.title)
@@ -42,8 +42,8 @@ feature 'Admin Jobs' do
   end
 
   scenario 'An admin can view all reviewed jobs jobs' do
-    job = Fabricate(:job)
-    expired_job = Fabricate(:job, expiry_date: Date.today-1.week)
+    job = Fabricate(:job, title: "Current Developer")
+    expired_job = Fabricate(:job, title: "Expired developer", expiry_date: Date.today-1.week)
 
     visit all_admin_jobs_path
 

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -40,8 +40,8 @@ feature 'Jobs' do
 
 
         scenario 'can see a listing of all non expired job posts' do
-          jobs = 2.times.map {  Fabricate.create(:job) }
-          expired = 3.times.map {  Fabricate.create(:job, expiry_date: Date.today-2.day) }
+          jobs = 2.times.map { |i| Fabricate.create(:job, title: "Current Dev #{i}") }
+          expired = 3.times.map { |i| Fabricate.create(:job, title: "Expired Dev #{i}", expiry_date: Date.today-2.day) }
 
           visit root_path
           click_link("Jobs", match: :first)

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -17,7 +17,7 @@ feature "A new student signs up", js: false do
     visit root_path
     click_on "Sign up as a student"
     click_on "I understand and meet the eligibility criteria. Sign me up as a student"
-    expect(current_path).to eq(step1_member_path)
+    expect(page).to have_current_path(step1_member_path(member_type: 'student'))
   end
 
   scenario "A visitor must fill in all mandatory fields in order to sign up", js: true do
@@ -47,7 +47,7 @@ feature "A new student signs up", js: false do
     fill_in "member_about_you", with: Faker::Lorem.paragraph
     click_on "Next"
 
-    expect(current_path).to eq(step2_member_path)
+    expect(page).to have_current_path(step2_member_path)
 
     click_on "Done"
 
@@ -67,7 +67,7 @@ feature "A new student signs up", js: false do
     member.update(can_log_in: true)
 
     visit step2_member_path
-    expect(current_path).to eq(step2_member_path)
+    expect(page).to have_current_path(step2_member_path)
 
     click_button group.chapter.name
     click_on "Done"

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -108,7 +108,7 @@ feature 'Viewing a workshop page' do
           expect(page).to have_content("Please tell us whether you want to attend as a student or coach.")
 
           click_link "Please tell us whether you want to attend as a student or coach."
-          expect(current_path).to eq subscriptions_path
+          expect(page).to have_current_path(subscriptions_path)
         end
 
         it "cannot access RSVP as a student or coach" do


### PR DESCRIPTION
The fabricator for jobs was choosing job titles at random. This meant that tests could not rely on the presence or absence of them on HTML pages, at least when a test case generated multiple job postings. 

For instance, sometimes the random number generator would choose the same title for an expired posting as one for a current posting, and thus a `expect(page).to_not have_content(expired_job.title)` would fail (because it would have the title for the current job). Whenever asserting on a specific string of text coming from a model, it's usually best to have that text be explicitly set in the test itself.

I've moved the random job/company title selection into the seeds file because it actually is nice to have realistic names when looking at the site in development mode.

This should solve flakeyness experienced in #594 (well, one of the failing tests was due to this), #598, #600, #601, #602 and probably more.