### PR TITLE
Add Slack icon/link to codebar footer

### DIFF
--- a/app/assets/stylesheets/partials/_social_media.scss
+++ b/app/assets/stylesheets/partials/_social_media.scss
@@ -1,3 +1,12 @@
+li.slack a {
+  color: #3eb991;
+  color: rgba(62, 185, 145, 0.8);
+
+  &:hover {
+    color: rgba(62, 185, 145, 1);
+  }
+}
+
 li.facebook a {
   color: #4e69a2;
   color: rgba(78, 105, 162, 0.8);

--- a/app/views/shared/_social_media.html.haml
+++ b/app/views/shared/_social_media.html.haml
@@ -1,4 +1,9 @@
 %ul.inline-list.right.social-media
+  %li.slack
+    = link_to 'https://codebar-slack.herokuapp.com' do
+      %span.fa-stack.fa-lg
+        %i.fa.fa-square.fa-stack-2x
+        %i.fa.fa-slack.fa-stack-1x.fa-inverse
   %li.github
     = link_to 'https://github.com/codebar' do
       %span.fa-stack.fa-lg


### PR DESCRIPTION
The new icon links to the signup form: https://codebar-slack.herokuapp.com/

![image](https://user-images.githubusercontent.com/1155816/31830204-67c9b644-b5b7-11e7-872f-6fd552b6eb91.png)