### PR TITLE
updated html class so visible with adblock

### DIFF
--- a/app/assets/stylesheets/partials/_sponsors.scss
+++ b/app/assets/stylesheets/partials/_sponsors.scss
@@ -1,5 +1,5 @@
 #sponsors {
-  .sponsor-logo {
+  .sponsor-logo-image {
     padding-bottom: 20px;
   }
 }

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -32,7 +32,7 @@
           %p
             = @host_address.to_html
         .medium-4.columns
-          = image_tag @event.venue.avatar, class: 'sponsor-logo'
+          = image_tag @event.venue.avatar, class: 'sponsor-logo-image'
       .row
         .large-12.columns
           %iframe{ width: '100%', height: '250', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }

--- a/app/views/invitations/show.html.haml
+++ b/app/views/invitations/show.html.haml
@@ -78,7 +78,7 @@
         %p
           = @host_address.to_html
       .medium-4.columns
-        = image_tag @event.venue.avatar, class: 'sponsor-logo'
+        = image_tag @event.venue.avatar, class: 'sponsor-logo-image'
     .row
       .large-12.columns
         %iframe{ width: '100%', height: '250', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }

--- a/app/views/sponsors/index.html.haml
+++ b/app/views/sponsors/index.html.haml
@@ -17,4 +17,4 @@
       %ul.small-block-grid-2.medium-block-grid-3.large-block-grid-4#sponsors
         - @sponsors.each do |sponsor|
           %li.text-center
-            = link_to image_tag(sponsor.avatar, class: "sponsor-logo", alt: sponsor.name), sponsor.website
+            = link_to image_tag(sponsor.avatar, class: "sponsor-logo-image", alt: sponsor.name), sponsor.website


### PR DESCRIPTION
currently sponsors are not visible on /sponsors when browser has [adblock](https://getadblock.com/) or [adblock plus](https://adblockplus.org/)

When I enable adblock no sponsors visible, when I disable they all appear!
apologies for poor quality gifs!
![missing sponsors](https://cl.ly/381k3c150e0b/codebar-sponsors%20copy.gif)

Tested this on safari, chrome and firefox with same results.

Investigating it seems the disappearance of sponsor logos is based on the class-name `sponsor-logo`.

Can see that Adblock adds styling of `display:none;` to `.sponsor-logo`
![Adblock styling](https://cl.ly/2S3o0B30451P/adblock-style.png)

Found similar issue here
https://github.com/Mobilization/2015.mobilization.pl/issues/1

They helpfully have full list of blocked classnames filtered out by adblock
https://github.com/Mobilization/2015.mobilization.pl/issues/1#issuecomment-119881690

When I update the class name `class="sponsor-logo"` to `class="sponsor-logo-image"` the sponsors appear again with Adblock turned on.
![updating classname](https://cl.ly/1v1F2g3i1f3q/codebar-sponsors-class-change.gif)

I replaced all appearances of `sponsor-logo` class with `sponsor-logo-image` to fix this issue.

Any feedback on this is welcome. 