### PR TITLE
Fixes indentation issues on homepage

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -15,56 +15,53 @@
         .large-offset-1.large-11.columns
           = render partial: 'members/testimonials'
 
-  .stripe
-    .row#showcase
-      .large-4.columns
-        .text-center
-          %h4 Students
-        %p Our students come from a variety of backgrounds. Some want to become full-time developers, whereas some would like to learn the basics of coding in a supportive environment.
-        %p
-          Sign up to join our vibrant community and attend our workshops.
+%section.stripe
+  .row#showcase
+    .large-4.columns
+      .text-center
+        %h4 Students
+      %p Our students come from a variety of backgrounds. Some want to become full-time developers, whereas some would like to learn the basics of coding in a supportive environment.
+      %p Sign up to join our vibrant community and attend our workshops.
 
-        .text-center
-          = link_to "Sign up as a student", new_member_path, class: 'button'
-      .large-4.columns
-        .text-center
-          %h4 Coaches
-        %p
-          We encourage new students to work on our HTML/CSS, JavaScript, Ruby, Python or Git #{link_to "tutorials", "http://tutorials.codebar.io"}. We also help them understand programming concepts.
-        %p Therefore  are always on the lookout for more developers to join our community and help coach at our workshops.
-        .text-center
-          = link_to "Sign up as a coach", new_member_path, class: 'button'
-      .large-4.columns
-        .text-center
-          %h4 Workshops
-        %p
-          We are hosted by some amazing companies who support our cause. Our normal format is 30 minutes of socialising with food and drink, followed by a lightning talk then coding.
-        %p
-          Help our expansion and enable us to provide help and support to our chapters by hosting and sponsoring our workshops.
+      .text-center
+        = link_to "Sign up as a student", new_member_path, class: 'button'
+    .large-4.columns
+      .text-center
+        %h4 Coaches
+      %p
+        We encourage new students to work on our HTML/CSS, JavaScript, Ruby, Python or Git #{link_to "tutorials", "http://tutorials.codebar.io"}. We also help them understand programming concepts.
+      %p Therefore  are always on the lookout for more developers to join our community and help coach at our workshops.
+      .text-center
+        = link_to "Sign up as a coach", new_member_path, class: 'button'
+    .large-4.columns
+      .text-center
+        %h4 Workshops
+      %p
+        We are hosted by some amazing companies who support our cause. Our normal format is 30 minutes of socialising with food and drink, followed by a lightning talk then coding.
+      %p
+        Help our expansion and enable us to provide help and support to our chapters by hosting and sponsoring our workshops.
 
+      .text-center
+        = mail_to "hello@codebar.io", "Host a workshop", class: 'button'
 
-        .text-center
-          = mail_to "hello@codebar.io", "Host a workshop", class: 'button'
+%section.stripe#chapter
+  .events#container
+    .row
+      .large-8.columns
+        - if @upcoming_workshops.empty?
+          %p
+            = t("no_upcoming_events")
+          %p
+            =link_to t("view_past_events"), events_url(anchor: 'past'), class: "button round expand"
 
-
-  %section#chapter.stripe
-    .events#container
-      .row
-        .large-8.columns
-          - if @upcoming_workshops.empty?
-            %p
-              = t("no_upcoming_events")
-            %p
-              =link_to t("view_past_events"), events_url(anchor: 'past'), class: "button round expand"
-
-          - if @upcoming_workshops.any?
-            - @upcoming_workshops.each do |date, workshops|
-              .grouped-events
-                %h4= date
-                = render workshops
-        .large-4.columns#chapters
-          %h3 Chapters
-          %ul.no-bullet
-            - @chapters.each do |chapter|
-              %li
-                = link_to chapter.name, chapter_path(chapter.slug)
+        - if @upcoming_workshops.any?
+          - @upcoming_workshops.each do |date, workshops|
+            .grouped-events
+              %h4= date
+              = render workshops
+      .large-4.columns#chapters
+        %h3 Chapters
+        %ul.no-bullet
+          - @chapters.each do |chapter|
+            %li
+              = link_to chapter.name, chapter_path(chapter.slug)


### PR DESCRIPTION
While reviewing another PR I noticed the indentation on the homepage wasn't right which caused elements to wrap other elements they weren't supposed to wrap. This is a quick fox for that issue.
