### PR TITLE
Prevent main nav menu links from being focusable when closed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -45,5 +45,20 @@ $(function(){
 
   $('#member_lookup_id').chosen().change(function(e) {
     $('#view_profile').attr('href', '/admin/members/' + $(this).val())
-  })
+  });
+  
+  // Prevent tabbing through side menu links when menu is hidden.
+  // This somewhat hacky approach is required because Foundation doesn't
+  // allow us to modify the functionality directly :(
+  var $menuContainer = $('.off-canvas-wrap');
+  var $menuLinks = $('.left-off-canvas-menu').find('a');
+  var toggleMenuLinkTabindex = function() {
+    // Use rAF to delay the call a frame, to wait until the class has been updated:
+    window.requestAnimationFrame(function(){
+      var menuIsVisible = $menuContainer.hasClass('move-right');
+      $menuLinks.attr('tabindex', menuIsVisible ? 0 : -1);
+    });
+  };
+  toggleMenuLinkTabindex();
+  $(document).on('click', toggleMenuLinkTabindex);
 });


### PR DESCRIPTION
This is unfortunately a very hacky fix, because [Foundation has terrible accessibility (which they freely admit in their documentation)](https://foundation.zurb.com/sites/docs/v/5.5.3/components/offcanvas.html#accessibility).

I think it works as a temporary workaround, which we can remove when we one day redesign the site and remove Foundation.

Fixes #609