### PR TITLE
Updates welcome email instructions

### DIFF
--- a/app/views/member_mailer/welcome_coach.html.haml
+++ b/app/views/member_mailer/welcome_coach.html.haml
@@ -6,7 +6,11 @@
 
 %p
   - if @member.subscriptions.any?
-    You'll automatically receive invitations to our workshops via email.
+    For our London chapter, you will be able to RSVP to workshops via our website. We open RSVPs at 1PM on the Friday before the workshop. You will be able to register through the workshop page. Join the #london-chapters channel
+    = link_to 'on our Slack', 'http://codebar-slack.herokuapp.com/'
+    to receive a notification when we open RSVPs, or follow us on Twitter
+    - link_to '@codebar', 'https://twitter.com/codebar'
+    . For our other chapters, you'll automatically receive invitations to our workshops to your inbox.
   - else
     We send out invitations to our events via email.
     = link_to "Sign up from the subscriptions page", subscriptions_url

--- a/app/views/member_mailer/welcome_coach.html.haml
+++ b/app/views/member_mailer/welcome_coach.html.haml
@@ -6,11 +6,13 @@
 
 %p
   - if @member.subscriptions.any?
-    For our London chapter, you will be able to RSVP to workshops via our website. We open RSVPs at 1PM on the Friday before the workshop. You will be able to register through the workshop page. Join the #london-chapters channel
-    = link_to 'on our Slack', 'http://codebar-slack.herokuapp.com/'
-    to receive a notification when we open RSVPs, or follow us on Twitter
-    - link_to '@codebar', 'https://twitter.com/codebar'
-    . For our other chapters, you'll automatically receive invitations to our workshops to your inbox.
+    You'll automatically receive email invitations to our workshops as soon as a workshop is open for RSVP.
+    - if @member.chapters.pluck(:name).include?("London")
+      However, our London chapter doesn't send workshop invitations via email, so you won't receive email invites for regular London events. We open RSVPs at around 1pm on the Friday before the workshop, and you will be able to register through the workshop page on our website. To be notified when we open RSVPs, join the #london-chapters channel
+      = link_to 'on our Slack', 'http://slack.codebar.io'
+      or
+      = link_to 'follow us', 'https://twitter.com/codebar'
+      on Twitter.
   - else
     We send out invitations to our events via email.
     = link_to "Sign up from the subscriptions page", subscriptions_url

--- a/app/views/member_mailer/welcome_student.html.haml
+++ b/app/views/member_mailer/welcome_student.html.haml
@@ -4,7 +4,11 @@
 
 %p
   - if @member.subscriptions.any?
-    You'll automatically receive invitations to our workshops via email.
+    For our London chapter, you will be able to RSVP to workshops via our website. We open RSVPs at 1PM on the Friday before the workshop. You will be able to register through the workshop page. Join the #london-chapters channel
+    = link_to 'on our Slack', 'http://codebar-slack.herokuapp.com/'
+    to receive a notification when we open RSVPs, or follow us on Twitter
+    - link_to '@codebar', 'https://twitter.com/codebar'
+    . For our other chapters, you'll automatically receive invitations to our workshops to your inbox.
   - else
     We send out invitations to our events via email.
     = link_to "Sign up from the subscriptions page", subscriptions_url

--- a/app/views/member_mailer/welcome_student.html.haml
+++ b/app/views/member_mailer/welcome_student.html.haml
@@ -4,11 +4,13 @@
 
 %p
   - if @member.subscriptions.any?
-    For our London chapter, you will be able to RSVP to workshops via our website. We open RSVPs at 1PM on the Friday before the workshop. You will be able to register through the workshop page. Join the #london-chapters channel
-    = link_to 'on our Slack', 'http://codebar-slack.herokuapp.com/'
-    to receive a notification when we open RSVPs, or follow us on Twitter
-    - link_to '@codebar', 'https://twitter.com/codebar'
-    . For our other chapters, you'll automatically receive invitations to our workshops to your inbox.
+    You'll automatically receive email invitations to our workshops as soon as a workshop is open for RSVP.
+    - if @member.chapters.pluck(:name).include?("London")
+      However, our London chapter doesn't send workshop invitations via email, so you won't receive email invites for regular London events. We open RSVPs at around 1pm on the Friday before the workshop, and you will be able to register through the workshop page on our website. To be notified when we open RSVPs, join the #london-chapters channel
+      = link_to 'on our Slack', 'http://slack.codebar.io'
+      or
+      = link_to 'follow us', 'https://twitter.com/codebar'
+      on Twitter.
   - else
     We send out invitations to our events via email.
     = link_to "Sign up from the subscriptions page", subscriptions_url


### PR DESCRIPTION
This PR updates the coach and student welcome email copy to include instructions on how RSVPs work for for the London chapter.

Resolves #615 

This is work in progress, any copy change suggestions are welcome.