### PR TITLE
internationalization (I18n) work

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   helper_method :current_service
 
+  before_action :set_locale
+
   def render_not_found
     respond_to do |format|
       format.html { render :template => "errors/not_found", layout: false, :status => 404 }
@@ -116,6 +118,10 @@ class ApplicationController < ActionController::Base
 
   def has_access?
     is_logged_in?
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,10 +22,6 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
 
-  def default_url_options
-    { locale: I18n.locale }
-  end
-
   def render_not_found
     respond_to do |format|
       format.html { render :template => "errors/not_found", layout: false, :status => 404 }
@@ -127,8 +123,8 @@ class ApplicationController < ActionController::Base
   private
 
   def set_locale
-    locale = params[:locale] if I18n.available_locales.include?(params[:locale])
-    I18n.locale = locale || I18n.default_locale
+    store_locale_to_cookie(params[:locale]) if locale
+    I18n.locale = cookies[:locale] || I18n.default_locale
   end
 
   def user_not_authorized
@@ -161,5 +157,14 @@ class ApplicationController < ActionController::Base
     else
       redirect_to fallback_location, **args
     end
+  end
+
+  def store_locale_to_cookie(locale)
+    cookies[:locale] = { value: locale,
+                         expires: Time.zone.now + 36_000 }
+  end
+
+  def locale
+    params[:locale] if params[:locale] && I18n.available_locales.include?(params[:locale].to_sym)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,10 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
 
+  def default_url_options
+    { locale: I18n.locale }
+  end
+
   def render_not_found
     respond_to do |format|
       format.html { render :template => "errors/not_found", layout: false, :status => 404 }
@@ -120,11 +124,12 @@ class ApplicationController < ActionController::Base
     is_logged_in?
   end
 
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
-  end
-
   private
+
+  def set_locale
+    locale = params[:locale] if I18n.available_locales.include?(params[:locale])
+    I18n.locale = locale || I18n.default_locale
+  end
 
   def user_not_authorized
     redirect_to(user_path, notice: 'You are not authorized to perform this action.')

--- a/app/views/dashboard/code.html.haml
+++ b/app/views/dashboard/code.html.haml
@@ -1,33 +1,38 @@
 .stripe.reverse#code-of-conduct
   .row
     .large-12.columns
-      %h2 Code of conduct
+      %h1
+        = t('code_of_conduct.title')
 .stripe.reverse
   .row
     .large-12.columns
-      %h3= t('code_of_conduct.summary.title')
+      %h2
+        = t('code_of_conduct.summary.title')
+
       %p.lead
         = t('code_of_conduct.summary.intro')
 
-      %h3 The Long Version
-      %p
-        = t('code_of_conduct.harassment')
+      %h2
+        = t('code_of_conduct.content.title')
 
       %p
-        = t('code_of_conduct.comply')
+        = t('code_of_conduct.content.harassment')
 
       %p
-        = t('code_of_conduct.sponsors')
+        = t('code_of_conduct.content.comply')
 
       %p
-        = t('code_of_conduct.sanctions')
+        = t('code_of_conduct.content.sponsors')
 
       %p
-        = t('code_of_conduct.concerns')
+        = t('code_of_conduct.content.sanctions')
 
       %p
-        = raw t('code_of_conduct.applies_to')
+        = t('code_of_conduct.content.concerns')
 
       %p
-        = t('code_of_conduct.questions')
-        =mail_to "hello@codebar.io", "contact us", subject: t('code_of_conduct.email_subject')
+        = raw t('code_of_conduct.content.applies_to')
+
+      %p
+        = t('code_of_conduct.content.questions')
+        =mail_to 'hello@codebar.io', t('code_of_conduct.content.contact'), subject: t('code_of_conduct.email_subject')

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,15 +22,6 @@ module Planner
     config.time_zone = 'London'
     config.active_record.default_timezone = :local
     config.active_record.raise_in_transactional_callbacks = true
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-    config.i18n.default_locale = :en
-    config.i18n.fallbacks = true
-    config.i18n.available_locales = [:en]
-    # config.i18n.enforce_available_locales = false
-    config.active_job.queue_adapter = :delayed_job
   end
 end
 

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,6 @@
+# The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+# config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+config.i18n.default_locale = :en
+config.i18n.fallbacks = true
+config.i18n.available_locales = [:en, :fr]
+#config.i18n.enforce_available_locales = false

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -2,5 +2,5 @@
 # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
 Rails.application.config.i18n.default_locale = :en
 Rails.application.config.i18n.fallbacks = true
-Rails.application.config.i18n.available_locales = [:en, :fr]
+Rails.application.config.i18n.available_locales = [:en, :fr, :de]
 #config.i18n.enforce_available_locales = false

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,6 +1,6 @@
 # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
 # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-config.i18n.default_locale = :en
-config.i18n.fallbacks = true
-config.i18n.available_locales = [:en, :fr]
+Rails.application.config.i18n.default_locale = :en
+Rails.application.config.i18n.fallbacks = true
+Rails.application.config.i18n.available_locales = [:en, :fr]
 #config.i18n.enforce_available_locales = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,19 +152,22 @@ en:
 
 
   code_of_conduct:
+    title: "Code on conduct"
     summary:
       title: "The Quick Version"
       intro: "Our events are dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of our members in any form. Sexual language and imagery is not appropriate for any of our events, including talks, workshops, parties, Twitter and any other online media. Members violating these rules may be sanctioned or expelled from the event and any future events at the discretion of the organisers."
 
-    title: "The Long Version"
-    harassment: "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
-    comply: "We expect any participants asked to stop any harassing behaviour to comply immediately."
-    sponsors: "Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment."
-    sanctions: "If a participant engages in harassing behaviour the organisers may take any action they deem appropriate. This includes warning the offender or expulsion."
-    concerns: "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact one of the organisers immediately."
-    applies_to: "We expect participants to follow these rules at all <b>codebar</b> events."
-    questions: "If you have any questions or concerns about this code please"
-    email_subject: "Regarding code of conduct"
+    content:
+      title: "The Long Version"
+      harassment: "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
+      comply: "We expect any participants asked to stop any harassing behaviour to comply immediately."
+      sponsors: "Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment."
+      sanctions: "If a participant engages in harassing behaviour the organisers may take any action they deem appropriate. This includes warning the offender or expulsion."
+      concerns: "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact one of the organisers immediately."
+      applies_to: "We expect participants to follow these rules at all <b>codebar</b> events."
+      questions: "If you have any questions or concerns about this code please"
+      contact: "contact us"
+      email_subject: "Regarding code of conduct"
 
   sponsors:
     sponsoring: "Sponsoring"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
 
 
   code_of_conduct:
-    title: "Code on conduct"
+    title: "Code of conduct"
     summary:
       title: "The Quick Version"
       intro: "Our events are dedicated to providing a harassment-free experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of our members in any form. Sexual language and imagery is not appropriate for any of our events, including talks, workshops, parties, Twitter and any other online media. Members violating these rules may be sanctioned or expelled from the event and any future events at the discretion of the organisers."
@@ -282,4 +282,3 @@ en:
         already_on_list: "%{name} is already on the list!"
         rsvp_error: "Something went wrong, %{name} has not been added."
         update_rsvp: 'Updated attendance of %{name}'
-

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,246 @@
+fr:
+  brand: "codebar.io"
+
+  date:
+      formats:
+        default: "%d/%m/%Y"
+        email: "%a, %d %B at %H:%M"
+        email_title: "%A, %d %b at %H:%M"
+        short: "%d/%m/%Y %H:%M "
+        date: "%d %b %Y"
+        website_format: "%a, %d %B %Y at %H:%M"
+        day_in_words: "%a"
+        day: "%d"
+        month: "%B"
+        meeting_format: "%a %d %B %H:%M"
+        time: "%H:%M"
+        year_month: "%Y-%B"
+        log: "at %H:%M on the %d/%m/%Y"
+        workshop: "%A, %e %B %Y at %R"
+        dashboard: "%a, %d %b %Y, %H:%M"
+  time:
+      formats:
+        default: "%a, %d %b %Y %H:%M"
+        email: "%a, %d %B at %H:%M"
+        email_title: "%A, %d %b at %H:%M"
+        short: "%d/%m/%Y %H:%M "
+        date: "%d %b %Y"
+        default_date: "%d/%m/%Y"
+        website_format: "%a, %d %B %Y at %H:%M"
+        day_in_words: "%a"
+        day: "%d"
+        month: "%B"
+        meeting_format: "%a %d %B %H:%M"
+        time: "%H:%M"
+        year_month: "%Y-%B"
+        log: "at %H:%M on the %d/%m/%Y"
+        workshop: "%A, %e %B %Y at %R"
+        dashboard: "%A, %b %d"
+
+  messages:
+    accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
+    rejected_invitation: "We are so sad you can't make it, but thanks for letting us know %{name}."
+    already_rsvped: "You have already confirmed you attendance!"
+    not_attending_already: "You have already confirmed you can't make it!"
+    no_available_seats: "Unfortunately there are no more spaces left :(. If you would like to join our waiting list send us an email at %{email}"
+    feedback_saved: "Thank you for taking the time to give us feedback!"
+    feedback_not_found: "You have already submitted feedback for this event."
+    updated_note: "Successfully updated note."
+
+  notifications:
+    provider_already_connected: 'You are already signed in!'
+    not_logged_in: "You must be logged in to access this page."
+
+  navigation:
+    dashboard: "Dashboard"
+    code_of_conduct: "Code of conduct"
+    coach_guide: "Coach guide"
+    student_guide: "Student guide"
+    tutorials: "Tutorials"
+    becoming_sponsor: "Becoming a sponsor"
+    faq: "FAQ"
+    blog: "Blog"
+
+  dashboard:
+    join_workshops_in: "Join our <i>free</i> workshops in"
+    workshops_goal: "to get to grips with the basics of programming and web development."
+    tweets_by: "Tweets by"
+    latest_sponsors: "Latest Sponsors"
+
+    policy:
+      intro: "There’s high demand for our workshops and we have a waiting list on most weeks. To make sure as many people as possible can come, we have a straightforward attendance policy."
+      rule1: "Before you RSVP make sure you are eligible to attend. If you’re not sure get in touch for a chat."
+      rule2: "You must sign up and RSVP to attend our workshops."
+      rule3: "If you RSVP then later realise you can’t make it, you must cancel. It only takes a few seconds to do through your confirmation email."
+      rule4: "Please try to cancel with at least 24 hours notice."
+      rule5: "We know that sometimes things come up last minute, but even if you only cancel an hour before the session, get in touch and let us know."
+      what_happens: "What happens if I don’t respect the policy?"
+      strikes_system: "We operate a three strikes system. That means if you don’t come in without cancelling an RSVP three times, we will take you off our invite list for four weeks. We’ll get in touch after your first absence to make sure you understand this."
+      removing: "If you fail to attend without cancelling another three times, we might have to remove you permanently from our invitation list."
+      rsvping: "There is no penalty for RSVP-ing and then cancelling on a regular basis, but please avoid it. If you always struggle to make it in on a certain day then let us know – that kind of feedback is really important to us."
+      eligibility_note: "Another note on eligibility"
+      abuse: "We’re a fairly relaxed bunch and we trust you, so we don’t police students as to their eligibility. However if it ever looks like this is being abused we may have to change that – which we really don’t want to do."
+      reminder: "So please remember what these workshops are for – to open up tech to people that are underrepresented in the industry."
+
+    teacher_guide:
+      laptop: "You don't need a laptop for our workshops. You are there to watch and guide the students. If you don't feel comfortable with the tutorial you should spend time on it before coming if you want to help out."
+      keyboard: "Do not take over the keyboard! This can be off-putting and scary."
+      typing: "Encourage the students to type and not copy paste."
+      questions: "Explain that there are no dumb questions."
+      mistakes: "Explain to students that it's OK to make mistakes."
+      introduction: "Always introduce yourself. Say why you want to help out and are spending your own time on this, why you like programming."
+      backgrounds: "Give your students the opportunity to get to know each other. Ask their names, why they are here, what they do in their day jobs. Encourage a brief discussion before starting."
+      limits: "Assume that anyone you're teaching has no knowledge but infinite intelligence."
+      colaboration: "Work collaboratively with your student. If you have two students, you should work with both. Don't focus all your attention on one of them."
+      discussion: "Let students have a go at answering the questions first. Help with open and leading questions. Encourage a discussion."
+      talk_slow: "Take it slow, you are the teacher, they are the student. Allow for time between questions."
+      mild_approach: "Don't say no when the students are not doing something right. Be gentle, approach it in a mild way."
+      paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
+      stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
+      suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+
+  events:
+    title: "Events"
+    past: "Past"
+    no_upcoming_events: "There are no upcoming events."
+    view_past_events: "View past events"
+    view_all: "View all"
+    hosted_by: "Hosted by"
+    organisers: "organisers"
+    venue_at: "at"
+    attend_as_student: "Attend as a student"
+    attend_as_coach: "Attend as a coach"
+    location: "Location"
+    sponsors: "Sponsors"
+    thx_to_sponsors: "A big thanks to all of our sponsors for making the event possible!"
+    coaches: "Coaches"
+    organisers: "Organisers"
+    schedule: "Schedule"
+    send_us_an_email: "send us an email"
+    not_open_for_rsvp: This event is not open for RSVP yet.
+    faq:
+      experience:
+        q: "How experienced should I be to join the workshop?"
+        a:
+      contribution:
+        q: "What kind of contributions can I make?"
+        a: "Your contributions can be tiny, as simple as fixing a typo, to something incredible. You can help with documentation, fix a bug that you found, improve the copy, help with design or even tackle bigger tasks and help introduce new features. Every little helps!"
+      laptop:
+        q: "Do I need to bring a laptop?"
+        a_html: "Yes, you should bring a laptop. If you don't have one %{link} as we may be able to help."
+      keyboard:
+        q: "Do I need to bring a keyboard?"
+        a_html: "A keyboard would help as you will spend the entire day pairing with someone on your laptop. If you don't have a keyboard, %{link} and we'll try to organise something for you."
+      travel_costs:
+        q: "I will be commuting. Can you help with my travel expenses?"
+        a: "We will be offering some travel grants. Just make sure you fill in the questionnaire after you RSVP and we will get in touch."
+
+
+  coaches:
+    want_to_coach: "Do you want to coach at our workshops?"
+    read_before: "If you have not attended our workshops before, make sure you read our"
+    code_of_conduct: "code of conduct"
+    policy: "as we have a zero tolerance policy and expect everyone to behave appropriately. You should also  go through our"
+    guide: "coaching guide"
+    unable_attend: "In case you are unable to attend after you RSVP, please make sure you come back and update your attendance as we rely on coaches showing up in order for our workshops to run smoothly."
+    food: "PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us email at"
+
+
+  code_of_conduct:
+    title: "Code de conduite"
+    summary:
+      title: "Version courte"
+      intro: "Nous nous engageons à fournir une expérience bienveillante et dépourvue de harcèlement pour tout le monde, indépendamment du genre, de l'orientation sexuelle, du handicap, de l'apparence physique, de la taille, de la race ou de la religion. Nous ne tolérons pas le harcèlement de nos membres sous quelque forme que ce soit. L'imagerie et le langage sexuels ne sont appropriés pour aucun de nos événements, y compris les conférences, les ateliers, les soirées, Twitter et tout autre média en ligne. Les membres qui enfreignent ces règles peuvent être sanctionnés ou expulsés de l'événement et de tout événement futur à la discrétion des organisateurs."
+
+    content:
+      title: "Version longue"
+      harassment: "Sont considérés comme harcèlement : les commentaires offensants liés au genre, à l'orientation sexuelle, au handicap, à l'apparence physique, à la taille, à la race ou à la religion, les images à caractère sexuel dans les espaces publics, les intimidations délibérées, le fait de suivre une personne de manière insistante et sans son accord, la prise de photos ou enregistrements sans consentement préalable des personnes concernées, les interruptions répétées lors de présentations ou autres événements, les contacts physiques inappropriés, ainsi que toute attention sexuelle non désirée."
+      comply: "Nous nous attendons à ce que tous les participants cessent immédiatement tout comportement de harcèlement en cas de signalement."
+      sponsors: "Les sponsors sont également soumis à la politique anti-harcèlement. En particulier, les sponsors ne doivent pas utiliser d'images, d'activités ou d'autres contenus à caractère sexuel. Le personnel (y compris les bénévoles) ne doivent pas porter de vêtements / uniformes / costumes sexualisés, ni créer un environnement sexualisé."
+      sanctions: "Si un participant se livre à un comportement de harcèlement, les organisateurs peuvent prendre toutes les mesures qu'ils jugent appropriées. Cela comprend l'avertissement du contrevenant, ou son expulsion."
+      concerns: "Si vous êtes harcelé·e, remarquez que quelqu'un d'autre est harcelé, ou avez d'autres préoccupations, veuillez contacter immédiatement l'un des organisateurs."
+      applies_to: "Nous attendons des participants qu'ils suivent ces règles lors de tous les événements <strong>codebar</strong>."
+      questions: "Si vous avez des questions ou des préoccupations concernant ce code de conduite,"
+      contact: "contactez-nous"
+      email_subject: "Regarding code of conduct"
+
+  sponsors:
+    sponsoring: "Sponsoring"
+
+  members:
+    sign_up: "Sign up"
+    sign_in_with_github: "Sign in with Github"
+    sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
+    sign_up_as_coach: "Sign up as a coach"
+    code_of_conduct: "code of conduct"
+    new:
+      intro: "We offer a welcoming, inclusive and learning-friendly environment, and have a zero tolerance policy towards any form of harassment or inappropriate behavior. Before you sign up, read our"
+      students:
+        intro: "If you would like to attend as a student, make sure you meet our"
+        criteria_link: "eligibility criteria"
+        criteria_brief: "as our workshops are only available to women, LGBTQ, people from underrepresented minority groups."
+        github: "Lastly, when you click the sign up button, you'll be taken to something called GitHub. After logging in with a GitHub account, you'll be taken back to the codebar website. If you don't have an account yet, you'll need to create one. It doesn't take long and it's something that will come in handy when you get started with coding!"
+      invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
+
+  footer:
+    email_us: "Send us an email at"
+    contact_info: "Contact Info:"
+
+  faq:
+    payment:
+      q: "Do I need to pay to attend codebar?"
+      a_p1: "Absolutely not! We are lucky enough to have some great companies who are able to host the workshops and/or kindly provide food. And our"
+      awesome_coaches: "awesome coaches"
+      a_p2: "give their time freely to help the community."
+    technologies:
+      q: "What technologies do you teach?"
+      a: "We have a variety of available tutorials in HTML, CSS, JavaScript and Ruby. If you want to learn something else don't hesitate to <a href=\"mailto:contact@codebar.io\">send us an email</a> as we might still be able to find someone to help you out."
+    eligibility:
+      q: "I want to attend a workshop. Am I eligible?"
+      a: "Our workshops are available to women, LGBTQ and people who are underrepresented in the tech industry. If you belong to one of these groups, you are more than welcome to attend. If not, there are some other great initiatives like <a href='https://www.meetup.com/opentechschool-london/'>Open Tech School London</a> where you can learn in a collaborative environment. Please see our <a href='http://codebar.io/student-guide'>student guide</a> for more information."
+    career:
+      q: "Is codebar only aimed at people who want to move into a career as a developer?"
+      a: "No! codebar is about getting people excited about programming. We'll help them learn some basic coding skills, as well as how to explore and do things on their own. For those who do want to become developers, we will provide help and guidance to help them achieve their goal."
+    format:
+      q: "What is the format of the workshops?"
+      a: "We try to have one coach for every two students. We will pair up students who want to work on the same tutorial, and assign them a coach. The rest just happens."
+    laptop:
+      q: "Do I need to bring a laptop with me at the workshops?"
+      a: "Yes, we suggest that you bring a laptop as it will be easier for you to carry on working on things after the workshops. It you don't have one, <a href=\"mailto:contact@codebar.io\">send us an email</a> so we can try and help out."
+    online_resources:
+      q: "There are so many online resources, why should I come to codebar?"
+      a: "Coding can be intimidating and a lot of people find it hard to get started. By putting you in touch with people who can help and guide you we make the experience and learning process easier and more enjoyable."
+    preperations:
+      q: "I would like to coach at codebar. Is there anything I should do besides signing up?"
+      a_p1: "Yes. First you should read our"
+      coaching_guide_tutorials: "coaching guide tutorials"
+      a_p2: ". Then spend sometime familiarising yourself with the"
+      a_p3: "<a href='http://tutorials.codebar.io'>tutorials</a>. The tutorials are open source so if there is something that you want to improve open an issue on the GitHub repository or send a pull request."
+      a_p4: "We don't expect the coaches to be familiar with all the technologies and languages we have material on."
+    location:
+      q: "Where do the workshops take place?"
+      a: "As we don't have a permanent venue, our workshops are hosted by different companies in various locations around London. So far we've run workshops in Shoreditch, London Bridge, Holborn and Kings Cross."
+    disabled_access:
+      q: "Is there disabled access at the workshops?"
+      a: "Unfortunately, that depends entirely on where we are hosting our workshops and if the venue has disabled access. If you would like to attend, send us an email at <a href='mailto:meetings@codebar.io'>meetings[at]codebar.io</a> so we can enquire about it and let you know."
+    bring_codebar_to_my_city:
+      q: "I would like to bring codebar to my city. Can I do that?"
+      a: "Of course. codebar is about building a community of experienced developers that are able to give up some of their time to help others. If you are keen on running codebar where you live, we would love to speak to you about it and see how we can help make this happen, so send <a href=\"mailto:contact@codebar.io\">us an email</a>."
+    our_coaches:
+      q: "Our coaches"
+      a_p1: "You can see all the coaches have helped out in our workshops on the"
+      a_p2: ". They are ordered by number of attendances. This is our way of showing our appreciation to them, as without them, we wouldn't be able to exist."
+
+  chapters:
+    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    sign_up: "to be invited to our workshops."
+    no_incoming: "There are no workshops coming up."
+    contact: "To contact the %{city} team, send an email to %{email}"
+
+  admin:
+    workshop:
+      manage_rsvps:
+        text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'
+      destroy:
+        success: "Workshop deleted successfully"
+        failure: "Workshop cannot be deleted. This is because it has invitees and/or workshop information is on the website for a while long enough that it cannot be deleted."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,8 @@
 Planner::Application.routes.draw do
-  get '/:locale' => 'dashboard#show'
   root 'dashboard#show'
 
   scope controller: 'dashboard' do
-    scope '(:locale)', locale: /#{I18n.available_locales.join("|")}/ do
-      get 'code-of-conduct', action: 'code'
-    end
+    get 'code-of-conduct', action: 'code'
     get 'coaches', action: 'wall_of_fame'
     get 'effective-teacher-guide', action: 'effective-teacher-guide', as: :teaching_guide
     get 'faq', action: 'faq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Planner::Application.routes.draw do
+  get '/:locale' => 'dashboard#show'
   root 'dashboard#show'
 
   scope controller: 'dashboard' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Planner::Application.routes.draw do
   root 'dashboard#show'
 
   scope controller: 'dashboard' do
-    get 'code-of-conduct', action: 'code'
+    scope '(:locale)', locale: /#{I18n.available_locales.join("|")}/ do
+      get 'code-of-conduct', action: 'code'
+    end
     get 'coaches', action: 'wall_of_fame'
     get 'effective-teacher-guide', action: 'effective-teacher-guide', as: :teaching_guide
     get 'faq', action: 'faq'

--- a/spec/features/internationalization_spec.rb
+++ b/spec/features/internationalization_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+feature 'Internationalization' do
+  context 'a visitor to the website' do
+    context 'views the website in English' do
+      scenario 'by default' do
+        visit code_of_conduct_path
+
+        expect(page).to have_content('Our events are dedicated to providing a harassment-free experience for everyone')
+      end
+    end
+
+    context 'can configure another language by setting `locale=en|gr|de`' do
+      scenario 'can view the code of conduct in French' do
+        visit root_path(locale: 'fr')
+        visit code_of_conduct_path
+
+        expect(page).to have_content('Nous nous engageons à fournir une expérience bienveillante et dépourvue de harcèlement pour tout le monde')
+      end
+    end
+
+    context 'can not configure a non existing language' do
+      scenario 'by setting `locale=it`' do
+        visit code_of_conduct_path(locale: 'it')
+
+        expect(page).to have_content('Our events are dedicated to providing a harassment-free experience for everyone')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR is the beginning of the internationalization work as per #173. I have added support for en, fr and de translations and it currently supports the French translation of the code of conduct (all other pages fall back to the English version for now). I have decided to go with the `codebar.io/locale/example` construct and use scoped routes. I have added a set_locale method to the application_controller which is required to set the locale. The problem is currently only the code-of-conduct route is wrapped in a scope. set_locale works fine on this URL, e.g. when I change `codebar.io/en/code-of-conduct` to `codebar.io/fr/code-of-conduct` it correctly serves the French version, but on all other URLs it appends a `?local=en` param to the URL. I would like all other URLs to fall back onto the English version and for the app not to append the param to the URLs. Not sure how to achieve this exactly.

## Status
Ready to Review

## Related Github issue
#173 