### PR TITLE
Use find_by helper instead of `where(...).first`

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -21,7 +21,7 @@ class Admin::InvitationsController < Admin::ApplicationController
 
         message = "You have removed #{@invitation.member.full_name} from the workshop."
       end
-      waiting_listed = WaitingList.where(invitation: @invitation).first
+      waiting_listed = WaitingList.find_by(invitation: @invitation)
       waiting_listed.destroy if waiting_listed
 
     elsif params.has_key?(:attended)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,8 @@ class ApplicationController < ActionController::Base
 
   def current_service
     if session.has_key?(:service_id)
-      @current_service ||= Service.where(member_id: session[:member_id],
-                                         id: session[:service_id]).first
+      @current_service ||= Service.find_by(member_id: session[:member_id],
+                                         id: session[:service_id])
     end
   rescue ActiveRecord::RecordNotFound
     session[:service_id] = nil

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -9,8 +9,8 @@ class AuthServicesController < ApplicationController
 
   def create
     member_type = cookies[:member_type]
-    current_service = AuthService.where(provider: omnihash[:provider],
-                                        uid: omnihash[:uid]).first
+    current_service = AuthService.find_by(provider: omnihash[:provider],
+                                          uid: omnihash[:uid])
 
     if logged_in?
       if current_service

--- a/app/controllers/concerns/admin/sponsor_concerns.rb
+++ b/app/controllers/concerns/admin/sponsor_concerns.rb
@@ -20,13 +20,13 @@ module Admin::SponsorConcerns
 
     def destroy_sponsor
       @sponsor = Sponsor.find(params[:sponsor_id])
-      @workshop.workshop_sponsors.where(sponsor: @sponsor).first.destroy
+      @workshop.workshop_sponsors.find_by(sponsor: @sponsor).destroy
       redirect_to :back
     end
 
     def host
       set_sponsor
-      @workshop_sponsor = WorkshopSponsor.where(workshop: @workshop, sponsor: @sponsor).first_or_create
+      @workshop_sponsor = WorkshopSponsor.find_or_create_by(workshop: @workshop, sponsor: @sponsor)
       @workshop_sponsor.update_attribute(:host, true)
       flash[:notice] = 'Host set successfully'
 
@@ -34,7 +34,7 @@ module Admin::SponsorConcerns
     end
 
     def destroy_host
-      @workshop.workshop_sponsors.where(host: true).first.update_attribute(:host, false)
+      @workshop.workshop_sponsors.find_by(host: true).update_attribute(:host, false)
 
       redirect_to :back
     end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,7 +2,7 @@ class CoursesController < ApplicationController
   before_action :set_course
 
   def rsvp
-    invitation = CourseInvitation.where(course: @course, member: current_user).first_or_create
+    invitation = CourseInvitation.find_or_create_by(course: @course, member: current_user)
     redirect_to course_invitation_path(invitation)
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -29,7 +29,7 @@ class EventsController < ApplicationController
     @host_address = AddressDecorator.new(@event.venue.address)
 
     if logged_in?
-      invitation = Invitation.where(member: current_user, event: event, attending: true).try(:first)
+      invitation = Invitation.find_by(member: current_user, event: event, attending: true)
       if invitation
         redirect_to event_invitation_path(@event, invitation) and return
       end
@@ -59,16 +59,11 @@ class EventsController < ApplicationController
 
   def find_invitation_and_redirect_to_event(role)
     set_event
-    @invitation = Invitation.where(event: @event, member: current_user, role: role).try(:first)
-    if @invitation.nil?
-      @invitation = Invitation.new(event: @event, member: current_user, role: role)
-      @invitation.save
-    end
-
+    @invitation = Invitation.find_or_create_by(event: @event, member: current_user, role: role)
     redirect_to event_invitation_path(@event, @invitation)
   end
 
   def set_event
-    @event = Event.find_by_slug(params[:event_id])
+    @event = Event.find_by(slug: params[:event_id])
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -59,7 +59,7 @@ class InvitationsController < ApplicationController
 
     meeting = Meeting.find_by_slug(params[:meeting_id])
 
-    invitation = MeetingInvitation.where(meeting: meeting, member: current_user, role: 'Participant').first_or_create
+    invitation = MeetingInvitation.find_or_create_by(meeting: meeting, member: current_user, role: 'Participant')
 
     invitation.update_attribute(:attending, true)
 

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -11,11 +11,11 @@ class WorkshopsController < ApplicationController
     redirect_to :back, notice: 'This workshop is not open for registrations' unless @workshop.invitable_yet?
 
     if role_params.nil?
-      @invitation = SessionInvitation.where(workshop: @workshop, member: current_user, attending: true).first
+      @invitation = SessionInvitation.find_by(workshop: @workshop, member: current_user, attending: true)
     else
       return redirect_to :back, notice: 'You have already RSVPd or joined the waitlist for this workshop.' if @workshop.attendee?(current_user) || @workshop.waitlisted?(current_user)
 
-      @invitation = SessionInvitation.where(workshop: @workshop, member: current_user, role: role_params).first_or_create
+      @invitation = SessionInvitation.find_or_create_by(workshop: @workshop, member: current_user, role: role_params)
     end
 
     redirect_to invitation_path(@invitation)


### PR DESCRIPTION
We had some `where(...).first` queries where `find_by(my: thing, another: var)` would be clearer.

I've also moved any existing `find_by_my_variable` dynamic methods to keep it consistent. Initially, I thought they'd been deprecated but after googling it seems they're just not used as commonly as they used to be. eg: https://github.com/bbatsov/rails-style-guide#find_by

It's in two separate commits so I can leave the existing finders intact if needed
  