### PR TITLE
Add time zones to chapters. (Mostly) fixes #559

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,12 +27,12 @@
 
 $(function(){
   $(document).foundation();
-  $('#sessions_date_and_time, #event_date_and_time, #workshop_rsvp_open_date').pickadate({
+  $('#workshop_local_date, #event_date_and_time, #workshop_rsvp_open_date').pickadate({
     format: 'dd/mm/yyyy'
   });
 
   $('#announcement_expires_at, #ban_expires_at').pickadate();
-  $('#sessions_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_time').pickatime({
+  $('#workshop_local_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_time').pickatime({
     format: 'HH:i'
   });
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,12 +27,12 @@
 
 $(function(){
   $(document).foundation();
-  $('#workshop_local_date, #event_date_and_time, #workshop_rsvp_open_date').pickadate({
+  $('#workshop_local_date, #event_date_and_time, #workshop_rsvp_open_local_date').pickadate({
     format: 'dd/mm/yyyy'
   });
 
   $('#announcement_expires_at, #ban_expires_at').pickadate();
-  $('#workshop_local_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_time').pickatime({
+  $('#workshop_local_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_local_time').pickatime({
     format: 'HH:i'
   });
 

--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -64,6 +64,6 @@ class Admin::ChaptersController < Admin::ApplicationController
   private
 
   def chapter_params
-    params.require(:chapter).permit(:name, :email, :city, :twitter)
+    params.require(:chapter).permit(:name, :email, :city, :time_zone, :twitter)
   end
 end

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -113,8 +113,9 @@ class Admin::WorkshopsController < Admin::ApplicationController
   end
 
   def workshop_params
-    params.require(:workshop).permit(:date_and_time, :time, :chapter_id,
-    :invitable, :seats, :rsvp_open_time, :rsvp_open_date, sponsor_ids: [])
+    params.require(:workshop).permit(:local_date, :local_time, :chapter_id,
+                                     :invitable, :seats, :rsvp_open_time,
+                                     :rsvp_open_date, sponsor_ids: [])
   end
 
   def sponsor_id

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -24,7 +24,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
     if @workshop.save
       grant_organiser_access(@workshop.chapter.organisers.map(&:id))
       set_host(host_id)
-      update_rsvp_open_time if auto_rsvps_set?
 
       redirect_to admin_workshop_path(@workshop), notice: 'The workshop has been created.'
     else
@@ -35,9 +34,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   def edit
     authorize @workshop
-
-    @rsvp_open_time = @workshop.rsvp_open_time.try(:strftime, '%H:%M')
-    @rsvp_open_date = @workshop.rsvp_open_date.try(:strftime, '%d/%m/%Y')
   end
 
   def show
@@ -58,7 +54,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
     set_organisers(organiser_ids)
     set_host(host_id)
-    update_rsvp_open_time if auto_rsvps_set?
 
     redirect_to admin_workshop_path(@workshop), notice: 'Workshops updated successfully'
   end
@@ -103,19 +98,10 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   private
 
-  def auto_rsvps_set?
-    @workshop.rsvp_open_time.present? && @workshop.rsvp_open_date.present?
-  end
-
-  def update_rsvp_open_time
-    updated_time = DateTime.new(@workshop.rsvp_open_date.year, @workshop.rsvp_open_date.month, @workshop.rsvp_open_date.day, @workshop.rsvp_open_time.hour, @workshop.rsvp_open_time.min)
-    @workshop.update_attribute(:rsvp_open_time, updated_time)
-  end
-
   def workshop_params
     params.require(:workshop).permit(:local_date, :local_time, :chapter_id,
-                                     :invitable, :seats, :rsvp_open_time,
-                                     :rsvp_open_date, sponsor_ids: [])
+                                     :invitable, :seats, :rsvp_open_local_date,
+                                     :rsvp_open_local_time, sponsor_ids: [])
   end
 
   def sponsor_id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,10 +15,6 @@ module ApplicationHelper
     current_user.groups.include?(group)
   end
 
-  def can_access?(resource)
-    current_user.has_role?(:admin) || current_user.has_role?(:organiser) || current_user.has_role?(:organiser, resource)
-  end
-
   def has_permission?
     current_user.has_role?(:admin) || current_user.has_role?(:organiser) || Chapter.find_roles(:organiser, current_user).any?
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,10 @@
 module ApplicationHelper
-  def humanize_date(date)
+  def humanize_date(date, with_time: false)
     human_date = "#{I18n.l(date, format: :day_in_words)}, "
     human_date << "#{ActiveSupport::Inflector.ordinalize(date.day)} "
     human_date << I18n.l(date, format: :month)
-  end
-
-  def humanize_date_with_time(date, time = date)
-    human_date = humanize_date(date)
-    human_date << " at #{I18n.l(time, format: :time)}"
+    human_date << " at #{I18n.l(date.time, format: :time)}" if with_time
+    human_date
   end
 
   def dot_markdown(text)

--- a/app/mailers/session_invitation_mailer.rb
+++ b/app/mailers/session_invitation_mailer.rb
@@ -10,7 +10,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Invitation #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Workshop Invitation #{humanize_date(@session.date_and_time, with_time: true)}"
 
     mail(mail_args(member, subject, 'no-reply@codebar.io')) do |format|
       format.html
@@ -22,7 +22,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Coach Invitation #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Workshop Coach Invitation #{humanize_date(@session.date_and_time, with_time: true)}"
 
     mail(mail_args(member, subject, 'no-reply@codebar.io')) do |format|
       format.html
@@ -37,7 +37,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @invitation = invitation
     @waiting_list = waiting_list
 
-    subject = "Attendance Confirmation for #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Attendance Confirmation for #{humanize_date(@session.date_and_time, with_time: true)}"
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
                                    content: WorkshopCalendar.new(@session).calendar.to_ical }
@@ -55,7 +55,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "#{title}: #{@session.title} by codebar - #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "#{title}: #{@session.title} by codebar - #{humanize_date(@session.date_and_time, with_time: true)}"
 
     mail(mail_args(member, subject, @session.chapter.email)) do |format|
       format.html
@@ -70,7 +70,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Reminder #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Workshop Reminder #{humanize_date(@session.date_and_time, with_time: true)}"
     mail(mail_args(member, subject, @session.chapter.email)) do |format|
       format.html
     end
@@ -83,7 +83,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(@session.date_and_time, @session.time)})"
+    subject = "Reminder: you're on the codebar waiting list (#{humanize_date(@session.date_and_time, with_time: true)})"
     mail(mail_args(member, subject, @session.chapter.email)) do |format|
       format.html
     end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -20,7 +20,6 @@ class Chapter < ActiveRecord::Base
   def self.available_to_user(user)
     return Chapter.all if user.has_role?(:organiser) || user.has_role?(:admin) || user.has_role?(:organiser, Chapter)
     return Chapter.find_roles(:organiser, user).map(&:resource)
-    []
   end
 
   def organisers

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -3,6 +3,8 @@ class Chapter < ActiveRecord::Base
 
   validates :name, :email, uniqueness: true, presence: true
   validates :city, presence: true
+  validates :time_zone, presence: true
+  validate :time_zone_exists
 
   has_many :workshops
   has_and_belongs_to_many :events
@@ -34,6 +36,12 @@ class Chapter < ActiveRecord::Base
   end
 
   private
+
+  def time_zone_exists
+    if time_zone && ActiveSupport::TimeZone[time_zone].nil?
+      errors.add(:time_zone, 'does not exist')
+    end
+  end
 
   def set_slug
     self.slug ||= self.name.parameterize

--- a/app/models/session_invitation.rb
+++ b/app/models/session_invitation.rb
@@ -14,9 +14,7 @@ class SessionInvitation < ActiveRecord::Base
   scope :to_coaches, -> { where(role: 'Coach') }
   scope :by_member, -> { group(:member_id) }
   scope :order_by_latest, -> { joins(:workshop).order('workshops.date_and_time desc') }
-  scope :past, -> { joins(:workshop).where('workshops.date_and_time < ?', Date.today) }
-  scope :last_six_months, -> { joins(:workshop).where('workshops.date_and_time < ? AND workshops.date_and_time > ?',
-                                                      Date.today, Date.today - 6.months)}
+  scope :last_six_months, -> { joins(:workshop).where(workshops: { date_and_time: 6.months.ago...Time.zone.now}) }
 
   def waiting_list_position
     @waiting_list_position ||= WaitingList.by_workshop(self.workshop).where_role(self.role).where(auto_rsvp: true).order(:created_at).map(&:invitation_id).index(self.id) + 1

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -2,6 +2,9 @@ class Workshop < ActiveRecord::Base
   include Invitable
   include Listable
 
+  attr_accessor :local_date
+  attr_accessor :local_time
+
   resourcify :permissions, role_cname: 'Permission', role_table_name: :permission
 
   has_many :invitations, class_name: 'SessionInvitation'
@@ -106,10 +109,17 @@ class Workshop < ActiveRecord::Base
     I18n.l(date_and_time, format: :dashboard)
   end
 
+  def time
+    date_and_time.try(:time)
+  end
+
   private
 
   def combine_date_and_time
-    self.date_and_time = date_and_time.change(hour: time.hour, min: time.min)
+    return unless local_date && local_time
+    date = Date.parse(local_date)
+    time = Time.parse(local_time)
+    self.date_and_time = Time.zone.local(date.year, date.month, date.day, time.hour, time.min)
   end
 
   def set_rsvp_close_time

--- a/app/views/admin/chapters/edit.html.haml
+++ b/app/views/admin/chapters/edit.html.haml
@@ -14,6 +14,9 @@
             = f.input :city, required: true
         .row
           .large-6.columns
+            = f.input :time_zone, required: true
+        .row
+          .large-6.columns
             = f.input :twitter, required: false
         .row
           .large-12.columns.text-right

--- a/app/views/admin/chapters/new.html.haml
+++ b/app/views/admin/chapters/new.html.haml
@@ -13,5 +13,8 @@
           .large-6.columns
             = f.input :city, required: true
         .row
+          .large-6.columns
+            = f.input :time_zone, required: true
+        .row
           .large-12.columns.text-right
             = f.submit 'Create chapter', class: 'button'

--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -38,7 +38,7 @@
         - @workshops.each do |workshop|
           %li
             = link_to admin_workshop_path(workshop) do
-              = humanize_date_with_time(workshop.date_and_time, workshop.time)
+              = humanize_date(workshop.date_and_time, with_time: true)
               - if workshop.invitable?
                 (#{workshop.invitations.accepted.count})
     .large-8.columns

--- a/app/views/admin/portal/index.html.haml
+++ b/app/views/admin/portal/index.html.haml
@@ -13,7 +13,7 @@
             = link_to admin_workshop_path(workshop) do
               %strong= workshop.chapter.name
               %br
-              = humanize_date_with_time(workshop.date_and_time, workshop.time)
+              = humanize_date(workshop.date_and_time, with_time: true)
     .large-4.columns
       = link_to 'View all sponsors', admin_sponsors_path, class: 'button expand round'
       = link_to 'Admin Guide', admin_guide_path, class: 'button expand round'

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -24,4 +24,4 @@
             = link_to admin_workshop_path(workshop) do
               %strong=workshop.chapter.name
               %br
-              = humanize_date_with_time(workshop.date_and_time, workshop.time)
+              = humanize_date(workshop.date_and_time, with_time: true)

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -4,10 +4,10 @@
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .row
     .large-3.columns
-      = f.input :local_date, as: :string, required: true, label: 'Date', input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
+      = f.input :local_date, as: :string, required: true, input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .row
     .large-3.columns
-      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') }}
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
@@ -19,8 +19,8 @@
     .large-6.columns
       .panel.callout
         %p Fill out these fields if you want RSVPs to open automatically at a future time. Leave blank if you'll handle it manually later.
-        = f.input :rsvp_open_date, as: :string, input_html: { id: 'workshop_rsvp_open_date', value: @rsvp_open_date }
-        = f.input :rsvp_open_time, as: :string, input_html: { id: 'workshop_rsvp_open_time', value: @rsvp_open_time }
+        = f.input :rsvp_open_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
+        = f.input :rsvp_open_local_time, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       %label Organisers

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -4,10 +4,10 @@
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .row
     .large-3.columns
-      = f.input :date_and_time, as: :string, required: true, label: 'Date', input_html: { id: 'sessions_date_and_time', data: { value: @workshop.date_and_time.strftime('%d/%m/%Y') } }
+      = f.input :local_date, as: :string, required: true, label: 'Date', input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .row
     .large-3.columns
-      = f.input :time, as: :string, required: true, input_html: { id: 'sessions_time', data: { value: (@workshop.time).strftime('%H:%M') }}
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') }}
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -4,10 +4,10 @@
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .row
     .large-3.columns
-      = f.input :date_and_time, as: :string, required: true, label: 'Date', input_html: { id: 'sessions_date_and_time', data: { value: @workshop.date_and_time } }
+      = f.input :local_date, as: :string, required: true, label: 'Date', input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .row
     .large-3.columns
-      = f.input :time, as: :string, required: true, input_html: { id: 'sessions_time'}
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') }}
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -4,10 +4,10 @@
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .row
     .large-3.columns
-      = f.input :local_date, as: :string, required: true, label: 'Date', input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
+      = f.input :local_date, as: :string, required: true, input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .row
     .large-3.columns
-      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') }}
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
@@ -19,8 +19,8 @@
     .large-6.columns
       .panel.callout
         %p Fill out these fields if you want RSVPs to open automatically at a future time. Leave blank if you'll handle it manually later.
-        = f.input :rsvp_open_date, as: :string, input_html: { id: 'workshop_rsvp_open_date' }
-        = f.input :rsvp_open_time, as: :string, input_html: { id: 'workshop_rsvp_open_time' }
+        = f.input :rsvp_open_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
+        = f.input :rsvp_open_local_time, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       = f.input :invitable

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -18,7 +18,7 @@
           %tr
             %td
               = link_to admin_workshop_path(workshop) do
-                = humanize_date_with_time(workshop.date_and_time, workshop.time)
+                = humanize_date(workshop.date_and_time, with_time: true)
             %td
               = workshop.invitations.accepted.count
             %td
@@ -27,5 +27,3 @@
             %td
               - if workshop.date_and_time.future?
                 %label.label upcoming
-
-

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -38,9 +38,9 @@
             %small=@workshop.chapter.name
         %h3
           %small #{l(@workshop.date_and_time)}
-        - if @workshop.rsvp_open_time_set?
+        - if @workshop.rsvp_opens_at
           RSVPs will open at
-          = @workshop.rsvp_open_time.strftime('%H:%M on %d/%m/%Y.')
+          = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')
           %br
           %br
         - if @workshop.venue.present?

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: humanize_date_with_time(@invitation.course.date_and_time) }
+= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: humanize_date(@invitation.course.date_and_time, with_time: true) }
 
 %section
   .inner-nav{ "data-magellan-expedition" => "fixed" }

--- a/app/views/course_invitation_mailer/invite_student.html.haml
+++ b/app/views/course_invitation_mailer/invite_student.html.haml
@@ -39,7 +39,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@course.date_and_time)}
+                  %small #{humanize_date(@course.date_and_time, with_time: true)}
                 %p
                   %b Venue
                   #{@course.venue.name}

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         = @course.title
         %br
-        %small #{humanize_date_with_time(@course.date_and_time)}
+        %small #{humanize_date(@course.date_and_time, with_time: true)}
       - if @course.date_and_time.past?
         %label.label.warning This event has already taken place.
 

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: "Workshop Feedback" , date:  humanize_date_with_time(@session.date_and_time) }
+= render partial: 'shared/title', locals: { title: "Workshop Feedback" , date:  humanize_date(@session.date_and_time, with_time: true) }
 %section#banner
   .row
     .large-12.columns

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         Workshop at #{@workshop.host.name}
         %br
-        %small #{humanize_date_with_time(@workshop.date_and_time)} #{@workshop.distance_of_time}
+        %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning This event has already taken place.
 .alert-box.secondary

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -25,7 +25,7 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{humanize_date_with_time(invitation.parent.date_and_time, invitation.parent.time)}
+                      .date #{humanize_date(invitation.parent.date_and_time, with_time: true)}
                   %br
                   - if invitation.is_a? SessionInvitation
                     =link_to attendance_status(invitation), invitation_path(invitation), class: "button round expand"
@@ -51,6 +51,6 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{humanize_date_with_time(invitation.parent.date_and_time, invitation.parent.time)}
+                      .date #{humanize_date(invitation.parent.date_and_time, with_time: true)}
                   %br
                   =link_to "View", invitation_path(invitation), class: "button round expand"

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@meeting.date_and_time)}
+                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br
@@ -53,4 +53,3 @@
         .content
           = render partial: 'shared_mailers/social'
       %td
-

--- a/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
+++ b/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
@@ -36,7 +36,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@meeting.date_and_time)}
+                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi, #{@member.name}
                 %p.lead
-                  You're confirmed for the next codebar Monthly! 
+                  You're confirmed for the next codebar Monthly!
                 %h4
                   Agenda
                 %p
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@meeting.date_and_time)}
+                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br
@@ -53,4 +53,3 @@
         .content
           = render partial: 'shared_mailers/social'
       %td
-

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   Details
-                %small #{humanize_date_with_time(@meeting.date_and_time)}
+                %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         =@meeting.name
       %h3
-        %small=humanize_date_with_time(@meeting.date_and_time)
+        %small=humanize_date(@meeting.date_and_time, with_time: true)
 
   .row
     .medium-4.columns#host

--- a/app/views/session_invitation_mailer/attending.html.haml
+++ b/app/views/session_invitation_mailer/attending.html.haml
@@ -42,7 +42,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@session.date_and_time, @session.time)}
+                  %small #{humanize_date(@session.date_and_time, with_time: true)}
                 %p
                   #{@session.host.name}
                   %br

--- a/app/views/session_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/session_invitation_mailer/attending_reminder.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   Workshop
-                  %small= humanize_date_with_time(@session.date_and_time, @session.time)
+                  %small= humanize_date(@session.date_and_time, with_time: true)
                 %p
                   #{@session.host.name}
                   %br

--- a/app/views/session_invitation_mailer/invite_coach.html.haml
+++ b/app/views/session_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name}
                 %p.lead
-                  Invites for our next workshop are now open and we are looking for coaches. The workshop that will take place on #{humanize_date_with_time(@session.date_and_time, @session.time)}.
+                  Invites for our next workshop are now open and we are looking for coaches. The workshop that will take place on #{humanize_date(@session.date_and_time, with_time: true)}.
 
                 %p At the workshop you will be helping students as they work their way through one of our tutorials or a personal project they need help. Don't worry we'll only match you with someone who you'll be able to help.
 
@@ -34,7 +34,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@session.date_and_time, @session.time)}
+                  %small #{humanize_date(@session.date_and_time, with_time: true)}
                 %p
                   %b Venue
                   #{@session.host.name}

--- a/app/views/session_invitation_mailer/invite_student.html.haml
+++ b/app/views/session_invitation_mailer/invite_student.html.haml
@@ -31,7 +31,7 @@
               %td
                 %h4
                   Workshop
-                  %small= humanize_date_with_time(@session.date_and_time, @session.time)
+                  %small= humanize_date(@session.date_and_time, with_time: true)
                 %p
                   %b Venue
                   #{@session.host.name}

--- a/app/views/session_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/session_invitation_mailer/notify_waiting_list.html.haml
@@ -24,7 +24,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@session.date_and_time, @session.time)}
+                  %small #{humanize_date(@session.date_and_time, with_time: true)}
                 %p
                   #{@workshop.venue.name}
                   %br

--- a/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi, #{@member.name}
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date_with_time(@session.date_and_time, @session.time)}.
+                  This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(@session.date_and_time, with_time: true)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place.
                   We'll email you if this happens.
@@ -34,7 +34,7 @@
               %td
                 %h4
                   Workshop
-                  %small= humanize_date_with_time(@session.date_and_time, @session.time)
+                  %small= humanize_date(@session.date_and_time, with_time: true)
                 %p
                   #{@session.host.name}
                   %br

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -5,7 +5,7 @@
         %h2
           Workshop at #{@workshop.host.name}
           %br
-          %small #{humanize_date_with_time(@workshop.date_and_time)} #{@workshop.distance_of_time}
+          %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
         - if @workshop.date_and_time.past?
           %label.label.warning This event has already taken place.
     %section#banner

--- a/db/migrate/20180108210921_remove_time_from_workshops.rb
+++ b/db/migrate/20180108210921_remove_time_from_workshops.rb
@@ -1,0 +1,5 @@
+class RemoveTimeFromWorkshops < ActiveRecord::Migration
+  def change
+    remove_column :workshops, :time, :datetime
+  end
+end

--- a/db/migrate/20180109024411_add_rsvp_opens_at_to_workshops.rb
+++ b/db/migrate/20180109024411_add_rsvp_opens_at_to_workshops.rb
@@ -1,0 +1,7 @@
+class AddRsvpOpensAtToWorkshops < ActiveRecord::Migration
+  def change
+    rename_column :workshops, :rsvp_open_time, :rsvp_opens_at
+    remove_column :workshops, :rsvp_open_date, :datetime
+    rename_column :workshops, :rsvp_close_time, :rsvp_closes_at
+  end
+end

--- a/db/migrate/20180110212924_add_time_zone_to_chapters.rb
+++ b/db/migrate/20180110212924_add_time_zone_to_chapters.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToChapters < ActiveRecord::Migration
+  def change
+    add_column :chapters, :time_zone, :string, null: false, default: "London"
+  end
+end

--- a/db/migrate/20180110212924_add_time_zone_to_chapters.rb
+++ b/db/migrate/20180110212924_add_time_zone_to_chapters.rb
@@ -1,5 +1,5 @@
 class AddTimeZoneToChapters < ActiveRecord::Migration
   def change
-    add_column :chapters, :time_zone, :string, null: false, default: "London"
+    add_column :chapters, :time_zone, :string, null: false, default: 'London'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,16 +73,17 @@ ActiveRecord::Schema.define(version: 20180108210921) do
   add_index 'bans', ['added_by_id'], name: 'index_bans_on_added_by_id', using: :btree
   add_index 'bans', ['member_id'], name: 'index_bans_on_member_id', using: :btree
 
-  create_table 'chapters', force: :cascade do |t|
-    t.string   'name'
-    t.string   'city'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'email'
-    t.string   'twitter'
-    t.string   'twitter_id'
-    t.string   'slug'
-    t.boolean  'active', default: true
+  create_table "chapters", force: :cascade do |t|
+    t.string   "name"
+    t.string   "city"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "email"
+    t.string   "twitter"
+    t.string   "twitter_id"
+    t.string   "slug"
+    t.boolean  "active",     default: true
+    t.string   "time_zone",  default: "London", null: false
   end
 
   create_table 'chapters_events', force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161228121833) do
+ActiveRecord::Schema.define(version: 20180108210921) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -518,19 +519,18 @@ ActiveRecord::Schema.define(version: 20161228121833) do
   add_index 'workshop_sponsors', ['sponsor_id'], name: 'index_workshop_sponsors_on_sponsor_id', using: :btree
   add_index 'workshop_sponsors', ['workshop_id'], name: 'index_workshop_sponsors_on_workshop_id', using: :btree
 
-  create_table 'workshops', force: :cascade do |t|
-    t.string   'title'
-    t.text     'description'
-    t.datetime 'date_and_time'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.boolean  'invitable', default: true
-    t.string   'sign_up_url'
-    t.integer  'chapter_id'
-    t.datetime 'time'
-    t.datetime 'rsvp_close_time'
-    t.datetime 'rsvp_open_time'
-    t.datetime 'rsvp_open_date'
+  create_table "workshops", force: :cascade do |t|
+    t.string   "title"
+    t.text     "description"
+    t.datetime "date_and_time"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean  "invitable",       default: true
+    t.string   "sign_up_url"
+    t.integer  "chapter_id"
+    t.datetime "rsvp_close_time"
+    t.datetime "rsvp_open_time"
+    t.datetime "rsvp_open_date"
   end
 
   add_index 'workshops', ['chapter_id'], name: 'index_workshops_on_chapter_id', using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,67 +11,67 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180108210921) do
+ActiveRecord::Schema.define(version: 20180110212924) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'addresses', force: :cascade do |t|
-    t.string   'flat'
-    t.string   'street'
-    t.string   'postal_code'
-    t.integer  'sponsor_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'city'
-    t.string   'latitude'
-    t.string   'longitude'
+  create_table "addresses", force: :cascade do |t|
+    t.string   "flat"
+    t.string   "street"
+    t.string   "postal_code"
+    t.integer  "sponsor_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "city"
+    t.string   "latitude"
+    t.string   "longitude"
   end
 
-  create_table 'announcements', force: :cascade do |t|
-    t.datetime 'expires_at'
-    t.text     'message'
-    t.integer  'created_by_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "announcements", force: :cascade do |t|
+    t.datetime "expires_at"
+    t.text     "message"
+    t.integer  "created_by_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'announcements', ['created_by_id'], name: 'index_announcements_on_created_by_id', using: :btree
+  add_index "announcements", ["created_by_id"], name: "index_announcements_on_created_by_id", using: :btree
 
-  create_table 'attendance_warnings', force: :cascade do |t|
-    t.integer  'member_id'
-    t.integer  'sent_by_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "attendance_warnings", force: :cascade do |t|
+    t.integer  "member_id"
+    t.integer  "sent_by_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'attendance_warnings', ['member_id'], name: 'index_attendance_warnings_on_member_id', using: :btree
-  add_index 'attendance_warnings', ['sent_by_id'], name: 'index_attendance_warnings_on_sent_by_id', using: :btree
+  add_index "attendance_warnings", ["member_id"], name: "index_attendance_warnings_on_member_id", using: :btree
+  add_index "attendance_warnings", ["sent_by_id"], name: "index_attendance_warnings_on_sent_by_id", using: :btree
 
-  create_table 'auth_services', force: :cascade do |t|
-    t.integer  'member_id'
-    t.string   'provider'
-    t.string   'uid'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "auth_services", force: :cascade do |t|
+    t.integer  "member_id"
+    t.string   "provider"
+    t.string   "uid"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'auth_services', ['member_id'], name: 'index_auth_services_on_member_id', using: :btree
+  add_index "auth_services", ["member_id"], name: "index_auth_services_on_member_id", using: :btree
 
-  create_table 'bans', force: :cascade do |t|
-    t.integer  'member_id'
-    t.datetime 'expires_at'
-    t.string   'reason'
-    t.text     'note'
-    t.integer  'added_by_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.boolean  'permanent', default: false
-    t.text     'explanation'
+  create_table "bans", force: :cascade do |t|
+    t.integer  "member_id"
+    t.datetime "expires_at"
+    t.string   "reason"
+    t.text     "note"
+    t.integer  "added_by_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean  "permanent",   default: false
+    t.text     "explanation"
   end
 
-  add_index 'bans', ['added_by_id'], name: 'index_bans_on_added_by_id', using: :btree
-  add_index 'bans', ['member_id'], name: 'index_bans_on_member_id', using: :btree
+  add_index "bans", ["added_by_id"], name: "index_bans_on_added_by_id", using: :btree
+  add_index "bans", ["member_id"], name: "index_bans_on_member_id", using: :btree
 
   create_table "chapters", force: :cascade do |t|
     t.string   "name"
@@ -86,439 +86,439 @@ ActiveRecord::Schema.define(version: 20180108210921) do
     t.string   "time_zone",  default: "London", null: false
   end
 
-  create_table 'chapters_events', force: :cascade do |t|
-    t.integer 'chapter_id'
-    t.integer 'event_id'
+  create_table "chapters_events", force: :cascade do |t|
+    t.integer "chapter_id"
+    t.integer "event_id"
   end
 
-  add_index 'chapters_events', ['chapter_id'], name: 'index_chapters_events_on_chapter_id', using: :btree
-  add_index 'chapters_events', ['event_id'], name: 'index_chapters_events_on_event_id', using: :btree
+  add_index "chapters_events", ["chapter_id"], name: "index_chapters_events_on_chapter_id", using: :btree
+  add_index "chapters_events", ["event_id"], name: "index_chapters_events_on_event_id", using: :btree
 
-  create_table 'chapters_meetings', force: :cascade do |t|
-    t.integer 'chapter_id'
-    t.integer 'meeting_id'
+  create_table "chapters_meetings", force: :cascade do |t|
+    t.integer "chapter_id"
+    t.integer "meeting_id"
   end
 
-  add_index 'chapters_meetings', ['chapter_id'], name: 'index_chapters_meetings_on_chapter_id', using: :btree
-  add_index 'chapters_meetings', ['meeting_id'], name: 'index_chapters_meetings_on_meeting_id', using: :btree
+  add_index "chapters_meetings", ["chapter_id"], name: "index_chapters_meetings_on_chapter_id", using: :btree
+  add_index "chapters_meetings", ["meeting_id"], name: "index_chapters_meetings_on_meeting_id", using: :btree
 
-  create_table 'contacts', force: :cascade do |t|
-    t.integer  'sponsor_id'
-    t.integer  'member_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "contacts", force: :cascade do |t|
+    t.integer  "sponsor_id"
+    t.integer  "member_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'contacts', ['member_id'], name: 'index_contacts_on_member_id', using: :btree
-  add_index 'contacts', ['sponsor_id'], name: 'index_contacts_on_sponsor_id', using: :btree
+  add_index "contacts", ["member_id"], name: "index_contacts_on_member_id", using: :btree
+  add_index "contacts", ["sponsor_id"], name: "index_contacts_on_sponsor_id", using: :btree
 
-  create_table 'course_invitations', force: :cascade do |t|
-    t.integer  'course_id'
-    t.integer  'member_id'
-    t.boolean  'attending'
-    t.boolean  'attended'
-    t.text     'note'
-    t.string   'token'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "course_invitations", force: :cascade do |t|
+    t.integer  "course_id"
+    t.integer  "member_id"
+    t.boolean  "attending"
+    t.boolean  "attended"
+    t.text     "note"
+    t.string   "token"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'course_invitations', ['course_id'], name: 'index_course_invitations_on_course_id', using: :btree
-  add_index 'course_invitations', ['member_id'], name: 'index_course_invitations_on_member_id', using: :btree
+  add_index "course_invitations", ["course_id"], name: "index_course_invitations_on_course_id", using: :btree
+  add_index "course_invitations", ["member_id"], name: "index_course_invitations_on_member_id", using: :btree
 
-  create_table 'course_tutors', force: :cascade do |t|
-    t.integer  'course_id'
-    t.integer  'tutor_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "course_tutors", force: :cascade do |t|
+    t.integer  "course_id"
+    t.integer  "tutor_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'course_tutors', ['course_id'], name: 'index_course_tutors_on_course_id', using: :btree
-  add_index 'course_tutors', ['tutor_id'], name: 'index_course_tutors_on_tutor_id', using: :btree
+  add_index "course_tutors", ["course_id"], name: "index_course_tutors_on_course_id", using: :btree
+  add_index "course_tutors", ["tutor_id"], name: "index_course_tutors_on_tutor_id", using: :btree
 
-  create_table 'courses', force: :cascade do |t|
-    t.string   'title'
-    t.string   'short_description'
-    t.text     'description'
-    t.integer  'tutor_id'
-    t.datetime 'date_and_time'
-    t.integer  'seats', default: 0
-    t.string   'slug'
-    t.string   'url'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.integer  'sponsor_id'
-    t.string   'ticket_url'
-    t.integer  'chapter_id'
+  create_table "courses", force: :cascade do |t|
+    t.string   "title"
+    t.string   "short_description"
+    t.text     "description"
+    t.integer  "tutor_id"
+    t.datetime "date_and_time"
+    t.integer  "seats",             default: 0
+    t.string   "slug"
+    t.string   "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "sponsor_id"
+    t.string   "ticket_url"
+    t.integer  "chapter_id"
   end
 
-  add_index 'courses', ['chapter_id'], name: 'index_courses_on_chapter_id', using: :btree
-  add_index 'courses', ['sponsor_id'], name: 'index_courses_on_sponsor_id', using: :btree
-  add_index 'courses', ['tutor_id'], name: 'index_courses_on_tutor_id', using: :btree
+  add_index "courses", ["chapter_id"], name: "index_courses_on_chapter_id", using: :btree
+  add_index "courses", ["sponsor_id"], name: "index_courses_on_sponsor_id", using: :btree
+  add_index "courses", ["tutor_id"], name: "index_courses_on_tutor_id", using: :btree
 
-  create_table 'delayed_jobs', force: :cascade do |t|
-    t.integer  'priority',   default: 0, null: false
-    t.integer  'attempts',   default: 0, null: false
-    t.text     'handler',                null: false
-    t.text     'last_error'
-    t.datetime 'run_at'
-    t.datetime 'locked_at'
-    t.datetime 'failed_at'
-    t.string   'locked_by'
-    t.string   'queue'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'delayed_jobs', ['priority', 'run_at'], name: 'delayed_jobs_priority', using: :btree
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
-  create_table 'eligibility_inquiries', force: :cascade do |t|
-    t.integer  'member_id'
-    t.integer  'sent_by_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "eligibility_inquiries", force: :cascade do |t|
+    t.integer  "member_id"
+    t.integer  "sent_by_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'eligibility_inquiries', ['member_id'], name: 'index_eligibility_inquiries_on_member_id', using: :btree
-  add_index 'eligibility_inquiries', ['sent_by_id'], name: 'index_eligibility_inquiries_on_sent_by_id', using: :btree
+  add_index "eligibility_inquiries", ["member_id"], name: "index_eligibility_inquiries_on_member_id", using: :btree
+  add_index "eligibility_inquiries", ["sent_by_id"], name: "index_eligibility_inquiries_on_sent_by_id", using: :btree
 
-  create_table 'events', force: :cascade do |t|
-    t.string   'name'
-    t.text     'description'
-    t.datetime 'date_and_time'
-    t.datetime 'ends_at'
-    t.integer  'venue_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'slug'
-    t.text     'schedule'
-    t.integer  'coach_spaces'
-    t.integer  'student_spaces'
-    t.string   'coach_questionnaire'
-    t.string   'student_questionnaire'
-    t.text     'coach_description'
-    t.string   'info'
-    t.boolean  'announce_only'
-    t.string   'url'
-    t.string   'email'
-    t.boolean  'invitable', default: false
-    t.string   'tito_url'
-    t.boolean  'show_faq'
-    t.boolean  'display_students'
-    t.boolean  'display_coaches'
-    t.string   'external_url'
-    t.boolean  'confirmation_required', default: false
-    t.boolean  'surveys_required',      default: false
-    t.string   'audience'
+  create_table "events", force: :cascade do |t|
+    t.string   "name"
+    t.text     "description"
+    t.datetime "date_and_time"
+    t.datetime "ends_at"
+    t.integer  "venue_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "slug"
+    t.text     "schedule"
+    t.integer  "coach_spaces"
+    t.integer  "student_spaces"
+    t.string   "coach_questionnaire"
+    t.string   "student_questionnaire"
+    t.text     "coach_description"
+    t.string   "info"
+    t.boolean  "announce_only"
+    t.string   "url"
+    t.string   "email"
+    t.boolean  "invitable",             default: false
+    t.string   "tito_url"
+    t.boolean  "show_faq"
+    t.boolean  "display_students"
+    t.boolean  "display_coaches"
+    t.string   "external_url"
+    t.boolean  "confirmation_required", default: false
+    t.boolean  "surveys_required",      default: false
+    t.string   "audience"
   end
 
-  add_index 'events', ['venue_id'], name: 'index_events_on_venue_id', using: :btree
+  add_index "events", ["venue_id"], name: "index_events_on_venue_id", using: :btree
 
-  create_table 'feedback_requests', force: :cascade do |t|
-    t.integer  'member_id'
-    t.integer  'workshop_id'
-    t.string   'token'
-    t.boolean  'submited'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "feedback_requests", force: :cascade do |t|
+    t.integer  "member_id"
+    t.integer  "workshop_id"
+    t.string   "token"
+    t.boolean  "submited"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'feedback_requests', ['member_id'], name: 'index_feedback_requests_on_member_id', using: :btree
-  add_index 'feedback_requests', ['workshop_id'], name: 'index_feedback_requests_on_workshop_id', using: :btree
+  add_index "feedback_requests", ["member_id"], name: "index_feedback_requests_on_member_id", using: :btree
+  add_index "feedback_requests", ["workshop_id"], name: "index_feedback_requests_on_workshop_id", using: :btree
 
-  create_table 'feedbacks', force: :cascade do |t|
-    t.integer  'tutorial_id'
-    t.text     'request'
-    t.integer  'coach_id'
-    t.text     'suggestions'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.integer  'rating'
-    t.integer  'workshop_id'
+  create_table "feedbacks", force: :cascade do |t|
+    t.integer  "tutorial_id"
+    t.text     "request"
+    t.integer  "coach_id"
+    t.text     "suggestions"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "rating"
+    t.integer  "workshop_id"
   end
 
-  add_index 'feedbacks', ['coach_id'], name: 'index_feedbacks_on_coach_id', using: :btree
-  add_index 'feedbacks', ['tutorial_id'], name: 'index_feedbacks_on_tutorial_id', using: :btree
+  add_index "feedbacks", ["coach_id"], name: "index_feedbacks_on_coach_id", using: :btree
+  add_index "feedbacks", ["tutorial_id"], name: "index_feedbacks_on_tutorial_id", using: :btree
 
-  create_table 'group_announcements', force: :cascade do |t|
-    t.integer  'announcement_id'
-    t.integer  'group_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "group_announcements", force: :cascade do |t|
+    t.integer  "announcement_id"
+    t.integer  "group_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'group_announcements', ['announcement_id'], name: 'index_group_announcements_on_announcement_id', using: :btree
-  add_index 'group_announcements', ['group_id'], name: 'index_group_announcements_on_group_id', using: :btree
+  add_index "group_announcements", ["announcement_id"], name: "index_group_announcements_on_announcement_id", using: :btree
+  add_index "group_announcements", ["group_id"], name: "index_group_announcements_on_group_id", using: :btree
 
-  create_table 'groups', force: :cascade do |t|
-    t.integer  'chapter_id'
-    t.string   'name'
-    t.text     'description'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'mailing_list_id'
+  create_table "groups", force: :cascade do |t|
+    t.integer  "chapter_id"
+    t.string   "name"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "mailing_list_id"
   end
 
-  add_index 'groups', ['chapter_id'], name: 'index_groups_on_chapter_id', using: :btree
+  add_index "groups", ["chapter_id"], name: "index_groups_on_chapter_id", using: :btree
 
-  create_table 'invitations', force: :cascade do |t|
-    t.integer  'event_id'
-    t.boolean  'attending'
-    t.integer  'member_id'
-    t.string   'role'
-    t.text     'note'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'token'
-    t.boolean  'verified'
-    t.integer  'verified_by_id'
+  create_table "invitations", force: :cascade do |t|
+    t.integer  "event_id"
+    t.boolean  "attending"
+    t.integer  "member_id"
+    t.string   "role"
+    t.text     "note"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "token"
+    t.boolean  "verified"
+    t.integer  "verified_by_id"
   end
 
-  add_index 'invitations', ['event_id'], name: 'index_invitations_on_event_id', using: :btree
-  add_index 'invitations', ['member_id'], name: 'index_invitations_on_member_id', using: :btree
-  add_index 'invitations', ['verified_by_id'], name: 'index_invitations_on_verified_by_id', using: :btree
+  add_index "invitations", ["event_id"], name: "index_invitations_on_event_id", using: :btree
+  add_index "invitations", ["member_id"], name: "index_invitations_on_member_id", using: :btree
+  add_index "invitations", ["verified_by_id"], name: "index_invitations_on_verified_by_id", using: :btree
 
-  create_table 'jobs', force: :cascade do |t|
-    t.string   'title'
-    t.text     'description'
-    t.string   'location'
-    t.datetime 'expiry_date'
-    t.string   'email'
-    t.string   'link_to_job'
-    t.integer  'created_by_id'
-    t.boolean  'approved',       default: false
-    t.boolean  'submitted',      default: false
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'company'
-    t.integer  'approved_by_id'
+  create_table "jobs", force: :cascade do |t|
+    t.string   "title"
+    t.text     "description"
+    t.string   "location"
+    t.datetime "expiry_date"
+    t.string   "email"
+    t.string   "link_to_job"
+    t.integer  "created_by_id"
+    t.boolean  "approved",       default: false
+    t.boolean  "submitted",      default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "company"
+    t.integer  "approved_by_id"
   end
 
-  add_index 'jobs', ['created_by_id'], name: 'index_jobs_on_created_by_id', using: :btree
+  add_index "jobs", ["created_by_id"], name: "index_jobs_on_created_by_id", using: :btree
 
-  create_table 'meeting_invitations', force: :cascade do |t|
-    t.integer  'meeting_id'
-    t.boolean  'attending'
-    t.integer  'member_id'
-    t.string   'role'
-    t.text     'note'
-    t.string   'token'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.boolean  'attended', default: false
+  create_table "meeting_invitations", force: :cascade do |t|
+    t.integer  "meeting_id"
+    t.boolean  "attending"
+    t.integer  "member_id"
+    t.string   "role"
+    t.text     "note"
+    t.string   "token"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean  "attended",   default: false
   end
 
-  add_index 'meeting_invitations', ['meeting_id'], name: 'index_meeting_invitations_on_meeting_id', using: :btree
-  add_index 'meeting_invitations', ['member_id'], name: 'index_meeting_invitations_on_member_id', using: :btree
+  add_index "meeting_invitations", ["meeting_id"], name: "index_meeting_invitations_on_meeting_id", using: :btree
+  add_index "meeting_invitations", ["member_id"], name: "index_meeting_invitations_on_member_id", using: :btree
 
-  create_table 'meeting_talks', force: :cascade do |t|
-    t.integer  'meeting_id'
-    t.string   'title'
-    t.string   'description'
-    t.text     'abstract'
-    t.integer  'speaker_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "meeting_talks", force: :cascade do |t|
+    t.integer  "meeting_id"
+    t.string   "title"
+    t.string   "description"
+    t.text     "abstract"
+    t.integer  "speaker_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'meeting_talks', ['meeting_id'], name: 'index_meeting_talks_on_meeting_id', using: :btree
-  add_index 'meeting_talks', ['speaker_id'], name: 'index_meeting_talks_on_speaker_id', using: :btree
+  add_index "meeting_talks", ["meeting_id"], name: "index_meeting_talks_on_meeting_id", using: :btree
+  add_index "meeting_talks", ["speaker_id"], name: "index_meeting_talks_on_speaker_id", using: :btree
 
-  create_table 'meetings', force: :cascade do |t|
-    t.datetime 'date_and_time'
-    t.integer  'venue_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'name'
-    t.text     'description'
-    t.string   'slug'
-    t.boolean  'invitable'
-    t.integer  'spaces'
-    t.integer  'sponsor_id'
-    t.boolean  'invites_sent', default: false
+  create_table "meetings", force: :cascade do |t|
+    t.datetime "date_and_time"
+    t.integer  "venue_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "name"
+    t.text     "description"
+    t.string   "slug"
+    t.boolean  "invitable"
+    t.integer  "spaces"
+    t.integer  "sponsor_id"
+    t.boolean  "invites_sent",  default: false
   end
 
-  add_index 'meetings', ['venue_id'], name: 'index_meetings_on_venue_id', using: :btree
+  add_index "meetings", ["venue_id"], name: "index_meetings_on_venue_id", using: :btree
 
-  create_table 'member_contacts', force: :cascade do |t|
-    t.integer  'sponsor_id'
-    t.integer  'member_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "member_contacts", force: :cascade do |t|
+    t.integer  "sponsor_id"
+    t.integer  "member_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table 'member_notes', force: :cascade do |t|
-    t.integer  'member_id'
-    t.integer  'author_id'
-    t.text     'note'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "member_notes", force: :cascade do |t|
+    t.integer  "member_id"
+    t.integer  "author_id"
+    t.text     "note"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'member_notes', ['author_id'], name: 'index_member_notes_on_author_id', using: :btree
-  add_index 'member_notes', ['member_id'], name: 'index_member_notes_on_member_id', using: :btree
+  add_index "member_notes", ["author_id"], name: "index_member_notes_on_author_id", using: :btree
+  add_index "member_notes", ["member_id"], name: "index_member_notes_on_member_id", using: :btree
 
-  create_table 'members', force: :cascade do |t|
-    t.string   'name'
-    t.string   'surname'
-    t.string   'email'
-    t.string   'twitter'
-    t.string   'about_you'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.boolean  'unsubscribed'
-    t.boolean  'can_log_in', default: false, null: false
-    t.string   'mobile'
-    t.boolean  'received_coach_welcome_email',   default: false
-    t.boolean  'received_student_welcome_email', default: false
-    t.string   'pronouns'
+  create_table "members", force: :cascade do |t|
+    t.string   "name"
+    t.string   "surname"
+    t.string   "email"
+    t.string   "twitter"
+    t.string   "about_you"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean  "unsubscribed"
+    t.boolean  "can_log_in",                     default: false, null: false
+    t.string   "mobile"
+    t.boolean  "received_coach_welcome_email",   default: false
+    t.boolean  "received_student_welcome_email", default: false
+    t.string   "pronouns"
   end
 
-  create_table 'members_permissions', id: false, force: :cascade do |t|
-    t.integer 'member_id'
-    t.integer 'permission_id'
+  create_table "members_permissions", id: false, force: :cascade do |t|
+    t.integer "member_id"
+    t.integer "permission_id"
   end
 
-  add_index 'members_permissions', ['member_id', 'permission_id'], name: 'index_members_permissions_on_member_id_and_permission_id', using: :btree
+  add_index "members_permissions", ["member_id", "permission_id"], name: "index_members_permissions_on_member_id_and_permission_id", using: :btree
 
-  create_table 'members_roles', id: false, force: :cascade do |t|
-    t.integer 'member_id'
-    t.integer 'role_id'
+  create_table "members_roles", id: false, force: :cascade do |t|
+    t.integer "member_id"
+    t.integer "role_id"
   end
 
-  add_index 'members_roles', ['member_id', 'role_id'], name: 'index_members_roles_on_member_id_and_role_id', using: :btree
-  add_index 'members_roles', ['member_id'], name: 'index_members_roles_on_member_id', using: :btree
+  add_index "members_roles", ["member_id", "role_id"], name: "index_members_roles_on_member_id_and_role_id", using: :btree
+  add_index "members_roles", ["member_id"], name: "index_members_roles_on_member_id", using: :btree
 
-  create_table 'permissions', force: :cascade do |t|
-    t.string   'name'
-    t.integer  'resource_id'
-    t.string   'resource_type'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "permissions", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "resource_id"
+    t.string   "resource_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'permissions', ['name', 'resource_type', 'resource_id'], name: 'index_permissions_on_name_and_resource_type_and_resource_id', using: :btree
-  add_index 'permissions', ['name'], name: 'index_permissions_on_name', using: :btree
+  add_index "permissions", ["name", "resource_type", "resource_id"], name: "index_permissions_on_name_and_resource_type_and_resource_id", using: :btree
+  add_index "permissions", ["name"], name: "index_permissions_on_name", using: :btree
 
-  create_table 'roles', force: :cascade do |t|
-    t.string   'name'
-    t.string   'description'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "roles", force: :cascade do |t|
+    t.string   "name"
+    t.string   "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table 'session_invitations', force: :cascade do |t|
-    t.integer  'workshop_id'
-    t.integer  'member_id'
-    t.boolean  'attending'
-    t.boolean  'attended'
-    t.text     'note'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'token'
-    t.string   'role'
-    t.datetime 'reminded_at'
-    t.datetime 'rsvp_time'
+  create_table "session_invitations", force: :cascade do |t|
+    t.integer  "workshop_id"
+    t.integer  "member_id"
+    t.boolean  "attending"
+    t.boolean  "attended"
+    t.text     "note"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "token"
+    t.string   "role"
+    t.datetime "reminded_at"
+    t.datetime "rsvp_time"
   end
 
-  add_index 'session_invitations', ['member_id'], name: 'index_session_invitations_on_member_id', using: :btree
-  add_index 'session_invitations', ['token'], name: 'index_session_invitations_on_token', unique: true, using: :btree
-  add_index 'session_invitations', ['workshop_id'], name: 'index_session_invitations_on_workshop_id', using: :btree
+  add_index "session_invitations", ["member_id"], name: "index_session_invitations_on_member_id", using: :btree
+  add_index "session_invitations", ["token"], name: "index_session_invitations_on_token", unique: true, using: :btree
+  add_index "session_invitations", ["workshop_id"], name: "index_session_invitations_on_workshop_id", using: :btree
 
-  create_table 'sponsors', force: :cascade do |t|
-    t.string   'name'
-    t.text     'description'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string   'avatar'
-    t.string   'website'
-    t.integer  'seats', default: 15
-    t.string   'image_cache'
-    t.integer  'number_of_coaches'
-    t.string   'email'
-    t.string   'contact_first_name'
-    t.string   'contact_surname'
+  create_table "sponsors", force: :cascade do |t|
+    t.string   "name"
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "avatar"
+    t.string   "website"
+    t.integer  "seats",              default: 15
+    t.string   "image_cache"
+    t.integer  "number_of_coaches"
+    t.string   "email"
+    t.string   "contact_first_name"
+    t.string   "contact_surname"
   end
 
-  create_table 'sponsorships', force: :cascade do |t|
-    t.integer  'event_id'
-    t.integer  'sponsor_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "sponsorships", force: :cascade do |t|
+    t.integer  "event_id"
+    t.integer  "sponsor_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'sponsorships', ['event_id'], name: 'index_sponsorships_on_event_id', using: :btree
-  add_index 'sponsorships', ['sponsor_id'], name: 'index_sponsorships_on_sponsor_id', using: :btree
+  add_index "sponsorships", ["event_id"], name: "index_sponsorships_on_event_id", using: :btree
+  add_index "sponsorships", ["sponsor_id"], name: "index_sponsorships_on_sponsor_id", using: :btree
 
-  create_table 'subscriptions', force: :cascade do |t|
-    t.integer  'group_id'
-    t.integer  'member_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "subscriptions", force: :cascade do |t|
+    t.integer  "group_id"
+    t.integer  "member_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'subscriptions', ['group_id'], name: 'index_subscriptions_on_group_id', using: :btree
-  add_index 'subscriptions', ['member_id'], name: 'index_subscriptions_on_member_id', using: :btree
+  add_index "subscriptions", ["group_id"], name: "index_subscriptions_on_group_id", using: :btree
+  add_index "subscriptions", ["member_id"], name: "index_subscriptions_on_member_id", using: :btree
 
-  create_table 'taggings', force: :cascade do |t|
-    t.integer  'tag_id'
-    t.integer  'taggable_id'
-    t.string   'taggable_type'
-    t.integer  'tagger_id'
-    t.string   'tagger_type'
-    t.string   'context', limit: 128
-    t.datetime 'created_at'
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.integer  "taggable_id"
+    t.string   "taggable_type"
+    t.integer  "tagger_id"
+    t.string   "tagger_type"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
   end
 
-  add_index 'taggings', ['tag_id', 'taggable_id', 'taggable_type', 'context', 'tagger_id', 'tagger_type'], name: 'taggings_idx', unique: true, using: :btree
-  add_index 'taggings', ['taggable_id', 'taggable_type', 'context'], name: 'index_taggings_on_taggable_id_and_taggable_type_and_context', using: :btree
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
 
-  create_table 'tags', force: :cascade do |t|
-    t.string  'name'
-    t.integer 'taggings_count', default: 0
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
   end
 
-  add_index 'tags', ['name'], name: 'index_tags_on_name', unique: true, using: :btree
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
-  create_table 'testimonials', force: :cascade do |t|
-    t.integer  'member_id'
-    t.text     'text'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "testimonials", force: :cascade do |t|
+    t.integer  "member_id"
+    t.text     "text"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'testimonials', ['member_id'], name: 'index_testimonials_on_member_id', using: :btree
+  add_index "testimonials", ["member_id"], name: "index_testimonials_on_member_id", using: :btree
 
-  create_table 'tutorials', force: :cascade do |t|
-    t.string   'title'
-    t.text     'description'
-    t.string   'url'
-    t.integer  'workshop_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "tutorials", force: :cascade do |t|
+    t.string   "title"
+    t.text     "description"
+    t.string   "url"
+    t.integer  "workshop_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'tutorials', ['workshop_id'], name: 'index_tutorials_on_workshop_id', using: :btree
+  add_index "tutorials", ["workshop_id"], name: "index_tutorials_on_workshop_id", using: :btree
 
-  create_table 'waiting_lists', force: :cascade do |t|
-    t.integer  'invitation_id'
-    t.boolean  'auto_rsvp', default: true
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "waiting_lists", force: :cascade do |t|
+    t.integer  "invitation_id"
+    t.boolean  "auto_rsvp",     default: true
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'waiting_lists', ['invitation_id'], name: 'index_waiting_lists_on_invitation_id', using: :btree
+  add_index "waiting_lists", ["invitation_id"], name: "index_waiting_lists_on_invitation_id", using: :btree
 
-  create_table 'workshop_sponsors', force: :cascade do |t|
-    t.integer  'sponsor_id'
-    t.integer  'workshop_id'
-    t.boolean  'host', default: false
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "workshop_sponsors", force: :cascade do |t|
+    t.integer  "sponsor_id"
+    t.integer  "workshop_id"
+    t.boolean  "host",        default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'workshop_sponsors', ['sponsor_id'], name: 'index_workshop_sponsors_on_sponsor_id', using: :btree
-  add_index 'workshop_sponsors', ['workshop_id'], name: 'index_workshop_sponsors_on_workshop_id', using: :btree
+  add_index "workshop_sponsors", ["sponsor_id"], name: "index_workshop_sponsors_on_sponsor_id", using: :btree
+  add_index "workshop_sponsors", ["workshop_id"], name: "index_workshop_sponsors_on_workshop_id", using: :btree
 
   create_table "workshops", force: :cascade do |t|
     t.string   "title"
@@ -526,13 +526,13 @@ ActiveRecord::Schema.define(version: 20180108210921) do
     t.datetime "date_and_time"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "invitable",       default: true
+    t.boolean  "invitable",      default: true
     t.string   "sign_up_url"
     t.integer  "chapter_id"
-    t.datetime "rsvp_close_time"
-    t.datetime "rsvp_open_time"
-    t.datetime "rsvp_open_date"
+    t.datetime "rsvp_closes_at"
+    t.datetime "rsvp_opens_at"
   end
 
-  add_index 'workshops', ['chapter_id'], name: 'index_workshops_on_chapter_id', using: :btree
+  add_index "workshops", ["chapter_id"], name: "index_workshops_on_chapter_id", using: :btree
+
 end

--- a/spec/fabricators/chapter_fabricator.rb
+++ b/spec/fabricators/chapter_fabricator.rb
@@ -4,6 +4,7 @@ Fabricator(:chapter) do
   name { Fabricate.sequence(:name) }
   city { Faker::Lorem.word }
   email { Faker::Internet.email }
+  time_zone { 'London' }
 
   after_save do |chapter|
     member = Fabricate(:member)
@@ -16,6 +17,7 @@ Fabricator(:chapter_with_groups, from: :chapter) do
   name { Fabricate.sequence(:name) }
   city { Faker::Lorem.word }
   email { Faker::Internet.email }
+  time_zone { 'London' }
 
   after_save do |chapter|
     Fabricate(:students, chapter: chapter)

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -1,6 +1,5 @@
 Fabricator(:workshop) do
-  date_and_time Time.zone.now + 2.days
-  time Time.zone.now
+  date_and_time Time.zone.now+2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
@@ -10,21 +9,18 @@ Fabricator(:workshop) do
 end
 
 Fabricator(:workshop_no_sponsor, class_name: :workshop) do
-  date_and_time Time.zone.now + 2.days
-  time Time.zone.now
+  date_and_time Time.zone.now+2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
 end
 
 Fabricator(:workshop_auto_rsvp_in_past, class_name: :workshop) do
-  date_and_time Time.zone.now + 2.days
-  time Time.zone.now
+  date_and_time Time.zone.now+2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
-  rsvp_open_time Time.zone.now
-  rsvp_open_date Time.zone.now - 1.days
+  rsvp_opens_at Time.zone.now-1.days
   invitable false
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
@@ -32,13 +28,11 @@ Fabricator(:workshop_auto_rsvp_in_past, class_name: :workshop) do
 end
 
 Fabricator(:workshop_auto_rsvp_in_future, class_name: :workshop) do
-  date_and_time Time.zone.now + 2.days
-  time Time.zone.now
+  date_and_time Time.zone.now+2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
-  rsvp_open_time Time.zone.now + 1.days
-  rsvp_open_date Time.zone.now + 1.days
+  rsvp_opens_at Time.zone.now+1.days
   invitable false
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
@@ -46,8 +40,7 @@ Fabricator(:workshop_auto_rsvp_in_future, class_name: :workshop) do
 end
 
 Fabricator(:workshop_no_spots, class_name: :workshop) do
-  date_and_time Time.zone.now + 2.days
-  time Time.zone.now
+  date_and_time Time.zone.now+2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:workshop) do
-  date_and_time Time.zone.now+2.days
+  date_and_time Time.zone.now + 2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
@@ -9,18 +9,18 @@ Fabricator(:workshop) do
 end
 
 Fabricator(:workshop_no_sponsor, class_name: :workshop) do
-  date_and_time Time.zone.now+2.days
+  date_and_time Time.zone.now + 2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
 end
 
 Fabricator(:workshop_auto_rsvp_in_past, class_name: :workshop) do
-  date_and_time Time.zone.now+2.days
+  date_and_time Time.zone.now + 2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
-  rsvp_opens_at Time.zone.now-1.days
+  rsvp_opens_at Time.zone.now - 1.days
   invitable false
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
@@ -28,11 +28,11 @@ Fabricator(:workshop_auto_rsvp_in_past, class_name: :workshop) do
 end
 
 Fabricator(:workshop_auto_rsvp_in_future, class_name: :workshop) do
-  date_and_time Time.zone.now+2.days
+  date_and_time Time.zone.now + 2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
-  rsvp_opens_at Time.zone.now+1.days
+  rsvp_opens_at Time.zone.now + 1.days
   invitable false
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
@@ -40,7 +40,7 @@ Fabricator(:workshop_auto_rsvp_in_future, class_name: :workshop) do
 end
 
 Fabricator(:workshop_no_spots, class_name: :workshop) do
-  date_and_time Time.zone.now+2.days
+  date_and_time Time.zone.now + 2.days
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -14,8 +14,8 @@ feature 'Managing workshops' do
     visit new_admin_workshop_path
 
     select chapter.name
-    fill_in 'Date', with: Date.current
-    fill_in 'Time', with: '11:30'
+    fill_in 'Local date', with: Date.current
+    fill_in 'Local time', with: '11:30'
 
     click_on 'Save'
 

--- a/spec/lib/tasks/reminders_workshop_rake_spec.rb
+++ b/spec/lib/tasks/reminders_workshop_rake_spec.rb
@@ -4,7 +4,7 @@ describe 'reminders:workshop' do
   include_context 'rake'
 
   its(:prerequisites) { should include('environment') }
-  let!(:workshop) { Fabricate(:workshop, date_and_time: Time.zone.now + 29.hours, time: Time.zone.now + 29.hours) }
+  let!(:workshop) { Fabricate(:workshop, date_and_time: Time.zone.now + 29.hours) }
 
   before do
     allow(STDOUT).to receive(:puts)

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -7,28 +7,28 @@ describe SessionInvitationMailer do
   let(:invitation) { Fabricate(:session_invitation, workshop: workshop, member: member) }
 
   it '#invite_student' do
-    email_subject = "Workshop Invitation #{humanize_date_with_time(workshop.date_and_time, workshop.time)}"
+    email_subject = "Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
     SessionInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it '#attending_reminder' do
-    email_subject = "Workshop Reminder #{humanize_date_with_time(workshop.date_and_time, workshop.time)}"
+  it "#attending_reminder" do
+    email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
     SessionInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it '#waitlist_reminder' do
-    email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(workshop.date_and_time, workshop.time)})"
+  it "#waitlist_reminder" do
+    email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date(workshop.date_and_time, with_time: true)})"
     SessionInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match('you should keep your laptop with you and check your email during the afternoon on the day of the workshop.')
-    expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date_with_time(workshop.date_and_time, workshop.time)}")
+    expect(email.body.encoded).to match("you should keep your laptop with you and check your email during the afternoon on the day of the workshop.")
+    expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -14,20 +14,20 @@ describe SessionInvitationMailer do
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it "#attending_reminder" do
+  it '#attending_reminder' do
     email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
     SessionInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it "#waitlist_reminder" do
+  it '#waitlist_reminder' do
     email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date(workshop.date_and_time, with_time: true)})"
     SessionInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match("you should keep your laptop with you and check your email during the afternoon on the day of the workshop.")
+    expect(email.body.encoded).to match('you should keep your laptop with you and check your email during the afternoon on the day of the workshop.')
     expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -16,16 +16,27 @@ describe Chapter do
 
         expect(chapter.slug).to eq('new-york')
       end
+    end
 
-      context 'scopes' do
-        context '#default_scope' do
-          it 'only returns active Chapters' do
-            2.times { Fabricate(:chapter) }
-            3.times { Fabricate(:chapter, active: false) }
+    context '#time_zone' do
+      it 'requires a time zone' do
+        chapter = Fabricate(:chapter)
+        expect(chapter).to be_valid
+        chapter.time_zone = nil
+        expect(chapter).not_to be_valid
+        chapter.time_zone = 'Fake time'
+        expect(chapter).not_to be_valid
+      end
+    end
+  end
 
-            expect(Chapter.all.count).to eq(2)
-          end
-        end
+  context 'scopes' do
+    context '#default_scope' do
+      it 'only returns active Chapters' do
+        2.times { Fabricate(:chapter) }
+        3.times { Fabricate(:chapter, active: false) }
+
+        expect(Chapter.all.count).to eq(2)
       end
     end
   end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -11,16 +11,47 @@ describe Workshop do
   it { should respond_to(:rsvp_opens_at) }
   it { should respond_to(:time_zone) }
 
-  context '#before_save' do
-    let(:workshop) { Fabricate.build(:workshop, chapter: Fabricate(:chapter)) }
+  context 'time zone fields' do
+    let(:workshop) { Fabricate.build(:workshop, chapter: Fabricate(:chapter, time_zone: 'Pacific Time (US & Canada)')) }
+    let(:pacific_time) { ActiveSupport::TimeZone['Pacific Time (US & Canada)'].local(2015, 11, 12, 18, 30) }
+    let(:utc_time) { pacific_time.in_time_zone('UTC') }
 
-    it 'merges date_and_time and time' do
-      workshop.date_and_time = Time.zone.local(2015, 11, 12, 12, 0)
-      workshop.time = Time.utc(2000, 01, 01, 18, 30)
+    context 'date_and_time' do
+      it 'saves the local time in UTC' do
+        workshop.update_attributes!(
+          local_date: '12/11/2015',
+          local_time: '18:30'
+        )
 
-      workshop.save
+        expect(workshop.read_attribute(:date_and_time)).to eq(utc_time)
+      end
 
-      expect(workshop.date_and_time).to eq(Time.zone.local(2015, 11, 12, 18, 30))
+      it 'retrieves the local time from the saved UTC value' do
+        workshop.save
+        workshop.update_column(:date_and_time, utc_time)
+
+        expect(workshop.date_and_time).to eq(pacific_time)
+        expect(workshop.date_and_time.zone).to eq('PST')
+      end
+    end
+
+    context 'rsvp_opens_at' do
+      it 'saves the local time in UTC' do
+        workshop.update_attributes!(
+          rsvp_open_local_date: '12/11/2015',
+          rsvp_open_local_time: '18:30'
+        )
+
+        expect(workshop.read_attribute(:rsvp_opens_at)).to eq(utc_time)
+      end
+
+      it 'retrieves the local time from the saved UTC value' do
+        workshop.save
+        workshop.update_column(:rsvp_opens_at, utc_time)
+
+        expect(workshop.rsvp_opens_at).to eq(pacific_time)
+        expect(workshop.rsvp_opens_at.zone).to eq('PST')
+      end
     end
   end
 
@@ -37,13 +68,18 @@ describe Workshop do
     context 'rsvp is available' do
       it 'when the event is in the future' do
         workshop.date_and_time = 1.day.from_now
-        workshop.save
 
         expect(workshop.rsvp_available?).to be(true)
       end
 
-      it 'when rsvp_close_time is in the future' do
-        workshop.rsvp_close_time = 2.hours.from_now
+      it 'when rsvp_closes_at is in the future' do
+        workshop.rsvp_closes_at = 2.hours.from_now
+
+        expect(workshop.rsvp_available?).to be(true)
+      end
+
+      it 'when rsvp_closes_at is in another timezone' do
+        workshop.rsvp_closes_at = 2.hours.from_now.in_time_zone('Pacific Time (US & Canada)')
 
         expect(workshop.rsvp_available?).to be(true)
       end
@@ -51,7 +87,7 @@ describe Workshop do
 
     context 'rsvp is not available' do
       it 'when the rsvp_close_time is in the past' do
-        workshop.rsvp_close_time = 2.hours.ago
+        workshop.rsvp_closes_at = 2.hours.ago
 
         expect(workshop.rsvp_available?).to be(false)
       end
@@ -163,17 +199,17 @@ describe Workshop do
     end
 
     it 'is invitable if RSVP open date/time in past, and invitable set to false' do
-      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now-1.days)
+      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now - 1.days)
       expect(workshop.invitable_yet?).to be true
     end
 
     it 'is invitable if RSVP open date/time in future, and invitable set to true' do
-      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: true, rsvp_opens_at: Time.zone.now-1.days)
+      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: true, rsvp_opens_at: Time.zone.now - 1.days)
       expect(workshop.invitable_yet?).to be true
     end
 
     it 'is NOT invitable if RSVP open date/time in future, and invitable set to false' do
-      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now+1.days)
+      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now + 1.days)
       expect(workshop.invitable_yet?).to be false
     end
   end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -8,8 +8,8 @@ describe Workshop do
   it { should respond_to(:date_and_time) }
   it { should respond_to(:sponsors) }
   it { should respond_to(:workshop_sponsors) }
-  it { should respond_to(:rsvp_open_date) }
-  it { should respond_to(:rsvp_open_time) }
+  it { should respond_to(:rsvp_opens_at) }
+  it { should respond_to(:time_zone) }
 
   context '#before_save' do
     let(:workshop) { Fabricate.build(:workshop, chapter: Fabricate(:chapter)) }
@@ -162,18 +162,18 @@ describe Workshop do
       expect(workshop.invitable_yet?).to be true
     end
 
-    it 'is invitable if RSVP open date/time in past, and invitable set to false' do
-      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_open_time: Time.zone.now - 1.days)
+    it "is invitable if RSVP open date/time in past, and invitable set to false" do
+      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now-1.days)
       expect(workshop.invitable_yet?).to be true
     end
 
-    it 'is invitable if RSVP open date/time in future, and invitable set to true' do
-      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: true, rsvp_open_time: Time.zone.now - 1.days)
+    it "is invitable if RSVP open date/time in future, and invitable set to true" do
+      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: true, rsvp_opens_at: Time.zone.now-1.days)
       expect(workshop.invitable_yet?).to be true
     end
 
-    it 'is NOT invitable if RSVP open date/time in future, and invitable set to false' do
-      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_open_time: Time.zone.now + 1.days)
+    it "is NOT invitable if RSVP open date/time in future, and invitable set to false" do
+      workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now+1.days)
       expect(workshop.invitable_yet?).to be false
     end
   end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -162,17 +162,17 @@ describe Workshop do
       expect(workshop.invitable_yet?).to be true
     end
 
-    it "is invitable if RSVP open date/time in past, and invitable set to false" do
+    it 'is invitable if RSVP open date/time in past, and invitable set to false' do
       workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now-1.days)
       expect(workshop.invitable_yet?).to be true
     end
 
-    it "is invitable if RSVP open date/time in future, and invitable set to true" do
+    it 'is invitable if RSVP open date/time in future, and invitable set to true' do
       workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: true, rsvp_opens_at: Time.zone.now-1.days)
       expect(workshop.invitable_yet?).to be true
     end
 
-    it "is NOT invitable if RSVP open date/time in future, and invitable set to false" do
+    it 'is NOT invitable if RSVP open date/time in future, and invitable set to false' do
       workshop = Fabricate.build(:workshop, chapter: Fabricate(:chapter), invitable: false, rsvp_opens_at: Time.zone.now+1.days)
       expect(workshop.invitable_yet?).to be false
     end


### PR DESCRIPTION
## The problem

#559 describes an issue where the New York chapter were creating events with GMT times. These times displayed correctly on the site but were broken in the application logic. When people tried to RSVP on the day, the cut-off time had already passed in the UK

## The solution

- Each chapter now has a time zone, defaulting to GMT (London). 

- When creating or editing an event, the workshop's `date_and_time` field is a date using the chapter's correct time zone. This means that application logic will do the right conversions when comparing and sorting dates. Dates get saved to the database in the UTC time zone (a Rails feature)

- `Workshop.date_and_time` wraps the `date_and_time` attribute so that's it's always converted to the chapter's time zone when read. This means it's printed correctly on the site rather than printed as that time in the UK

- I've done the same for the RSVP open date field

## Tidying

- On master there are places where we have a datetime AND a time field (saved as a datetime field) on a record. I'm assuming this was to have separate date and time fields in forms, but it's very very confusing and hopefully the new approach is better. For example, `rsvp_open_date` and `rsvp_open_time` had the same value but only one was used. I've replaced it with a single `rsvp_opens_at`

## Caveats

- I haven't done this for other event types, like meetings, courses, and events. It shouldn't be much work but workshops are the first priority

- If you change the time zone of a chapter then the existing workshop times will shift by a few hours. A clever fix would be to store an individual time zone for each workshop but it's overkill. It means we'll need to re-enter the times for any New York workshops already on the site as a one-off (should only take 5 mins).