### PR TITLE
Remove redundant humanize_date_with_time helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,10 @@
 module ApplicationHelper
-  def humanize_date(date)
+  def humanize_date(date, with_time: false)
     human_date = "#{I18n.l(date, format: :day_in_words)}, "
     human_date << "#{ActiveSupport::Inflector.ordinalize(date.day)} "
     human_date << I18n.l(date, format: :month)
-  end
-
-  def humanize_date_with_time(date, time = date)
-    human_date = humanize_date(date)
-    human_date << " at #{I18n.l(time, format: :time)}"
+    human_date << " at #{I18n.l(date.time, format: :time)}" if with_time
+    human_date
   end
 
   def dot_markdown(text)

--- a/app/mailers/session_invitation_mailer.rb
+++ b/app/mailers/session_invitation_mailer.rb
@@ -10,7 +10,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Invitation #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Workshop Invitation #{humanize_date(@session.date_and_time, with_time: true)}"
 
     mail(mail_args(member, subject, 'no-reply@codebar.io')) do |format|
       format.html
@@ -22,7 +22,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Coach Invitation #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Workshop Coach Invitation #{humanize_date(@session.date_and_time, with_time: true)}"
 
     mail(mail_args(member, subject, 'no-reply@codebar.io')) do |format|
       format.html
@@ -37,7 +37,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @invitation = invitation
     @waiting_list = waiting_list
 
-    subject = "Attendance Confirmation for #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Attendance Confirmation for #{humanize_date(@session.date_and_time, with_time: true)}"
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
                                    content: WorkshopCalendar.new(@session).calendar.to_ical }
@@ -55,7 +55,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "#{title}: #{@session.title} by codebar - #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "#{title}: #{@session.title} by codebar - #{humanize_date(@session.date_and_time, with_time: true)}"
 
     mail(mail_args(member, subject, @session.chapter.email)) do |format|
       format.html
@@ -70,7 +70,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Reminder #{humanize_date_with_time(@session.date_and_time, @session.time)}"
+    subject = "Workshop Reminder #{humanize_date(@session.date_and_time, with_time: true)}"
     mail(mail_args(member, subject, @session.chapter.email)) do |format|
       format.html
     end
@@ -83,7 +83,7 @@ class SessionInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(@session.date_and_time, @session.time)})"
+    subject = "Reminder: you're on the codebar waiting list (#{humanize_date(@session.date_and_time, with_time: true)})"
     mail(mail_args(member, subject, @session.chapter.email)) do |format|
       format.html
     end

--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -38,7 +38,7 @@
         - @workshops.each do |workshop|
           %li
             = link_to admin_workshop_path(workshop) do
-              = humanize_date_with_time(workshop.date_and_time, workshop.time)
+              = humanize_date(workshop.date_and_time, with_time: true)
               - if workshop.invitable?
                 (#{workshop.invitations.accepted.count})
     .large-8.columns

--- a/app/views/admin/portal/index.html.haml
+++ b/app/views/admin/portal/index.html.haml
@@ -13,7 +13,7 @@
             = link_to admin_workshop_path(workshop) do
               %strong= workshop.chapter.name
               %br
-              = humanize_date_with_time(workshop.date_and_time, workshop.time)
+              = humanize_date(workshop.date_and_time, with_time: true)
     .large-4.columns
       = link_to 'View all sponsors', admin_sponsors_path, class: 'button expand round'
       = link_to 'Admin Guide', admin_guide_path, class: 'button expand round'

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -24,4 +24,4 @@
             = link_to admin_workshop_path(workshop) do
               %strong=workshop.chapter.name
               %br
-              = humanize_date_with_time(workshop.date_and_time, workshop.time)
+              = humanize_date(workshop.date_and_time, with_time: true)

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -18,7 +18,7 @@
           %tr
             %td
               = link_to admin_workshop_path(workshop) do
-                = humanize_date_with_time(workshop.date_and_time, workshop.time)
+                = humanize_date(workshop.date_and_time, with_time: true)
             %td
               = workshop.invitations.accepted.count
             %td

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: humanize_date_with_time(@invitation.course.date_and_time) }
+= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: humanize_date(@invitation.course.date_and_time, with_time: true) }
 
 %section
   .inner-nav{ "data-magellan-expedition" => "fixed" }

--- a/app/views/course_invitation_mailer/invite_student.html.haml
+++ b/app/views/course_invitation_mailer/invite_student.html.haml
@@ -39,7 +39,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@course.date_and_time)}
+                  %small #{humanize_date(@course.date_and_time, with_time: true)}
                 %p
                   %b Venue
                   #{@course.venue.name}

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         = @course.title
         %br
-        %small #{humanize_date_with_time(@course.date_and_time)}
+        %small #{humanize_date(@course.date_and_time, with_time: true)}
       - if @course.date_and_time.past?
         %label.label.warning This event has already taken place.
 

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: "Workshop Feedback" , date:  humanize_date_with_time(@session.date_and_time) }
+= render partial: 'shared/title', locals: { title: "Workshop Feedback" , date:  humanize_date(@session.date_and_time, with_time: true) }
 %section#banner
   .row
     .large-12.columns

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         Workshop at #{@workshop.host.name}
         %br
-        %small #{humanize_date_with_time(@workshop.date_and_time)} #{@workshop.distance_of_time}
+        %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning This event has already taken place.
 .alert-box.secondary

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -25,7 +25,7 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{humanize_date_with_time(invitation.parent.date_and_time, invitation.parent.time)}
+                      .date #{humanize_date(invitation.parent.date_and_time, with_time: true)}
                   %br
                   - if invitation.is_a? SessionInvitation
                     =link_to attendance_status(invitation), invitation_path(invitation), class: "button round expand"
@@ -51,6 +51,6 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{humanize_date_with_time(invitation.parent.date_and_time, invitation.parent.time)}
+                      .date #{humanize_date(invitation.parent.date_and_time, with_time: true)}
                   %br
                   =link_to "View", invitation_path(invitation), class: "button round expand"

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@meeting.date_and_time)}
+                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br

--- a/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
+++ b/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
@@ -36,7 +36,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@meeting.date_and_time)}
+                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@meeting.date_and_time)}
+                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   Details
-                %small #{humanize_date_with_time(@meeting.date_and_time)}
+                %small #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         =@meeting.name
       %h3
-        %small=humanize_date_with_time(@meeting.date_and_time)
+        %small=humanize_date(@meeting.date_and_time, with_time: true)
 
   .row
     .medium-4.columns#host

--- a/app/views/session_invitation_mailer/attending.html.haml
+++ b/app/views/session_invitation_mailer/attending.html.haml
@@ -42,7 +42,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@session.date_and_time, @session.time)}
+                  %small #{humanize_date(@session.date_and_time, with_time: true)}
                 %p
                   #{@session.host.name}
                   %br

--- a/app/views/session_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/session_invitation_mailer/attending_reminder.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   Workshop
-                  %small= humanize_date_with_time(@session.date_and_time, @session.time)
+                  %small= humanize_date(@session.date_and_time, with_time: true)
                 %p
                   #{@session.host.name}
                   %br

--- a/app/views/session_invitation_mailer/invite_coach.html.haml
+++ b/app/views/session_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name}
                 %p.lead
-                  Invites for our next workshop are now open and we are looking for coaches. The workshop that will take place on #{humanize_date_with_time(@session.date_and_time, @session.time)}.
+                  Invites for our next workshop are now open and we are looking for coaches. The workshop that will take place on #{humanize_date(@session.date_and_time, with_time: true)}.
 
                 %p At the workshop you will be helping students as they work their way through one of our tutorials or a personal project they need help. Don't worry we'll only match you with someone who you'll be able to help.
 
@@ -34,7 +34,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@session.date_and_time, @session.time)}
+                  %small #{humanize_date(@session.date_and_time, with_time: true)}
                 %p
                   %b Venue
                   #{@session.host.name}

--- a/app/views/session_invitation_mailer/invite_student.html.haml
+++ b/app/views/session_invitation_mailer/invite_student.html.haml
@@ -31,7 +31,7 @@
               %td
                 %h4
                   Workshop
-                  %small= humanize_date_with_time(@session.date_and_time, @session.time)
+                  %small= humanize_date(@session.date_and_time, with_time: true)
                 %p
                   %b Venue
                   #{@session.host.name}

--- a/app/views/session_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/session_invitation_mailer/notify_waiting_list.html.haml
@@ -24,7 +24,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date_with_time(@session.date_and_time, @session.time)}
+                  %small #{humanize_date(@session.date_and_time, with_time: true)}
                 %p
                   #{@workshop.venue.name}
                   %br

--- a/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/session_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi, #{@member.name}
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date_with_time(@session.date_and_time, @session.time)}.
+                  This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(@session.date_and_time, with_time: true)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place.
                   We'll email you if this happens.
@@ -34,7 +34,7 @@
               %td
                 %h4
                   Workshop
-                  %small= humanize_date_with_time(@session.date_and_time, @session.time)
+                  %small= humanize_date(@session.date_and_time, with_time: true)
                 %p
                   #{@session.host.name}
                   %br

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -5,7 +5,7 @@
         %h2
           Workshop at #{@workshop.host.name}
           %br
-          %small #{humanize_date_with_time(@workshop.date_and_time)} #{@workshop.distance_of_time}
+          %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
         - if @workshop.date_and_time.past?
           %label.label.warning This event has already taken place.
     %section#banner

--- a/spec/mailers/session_invitation_mailer_spec.rb
+++ b/spec/mailers/session_invitation_mailer_spec.rb
@@ -7,28 +7,28 @@ describe SessionInvitationMailer do
   let(:invitation) { Fabricate(:session_invitation, workshop: workshop, member: member) }
 
   it '#invite_student' do
-    email_subject = "Workshop Invitation #{humanize_date_with_time(workshop.date_and_time, workshop.time)}"
+    email_subject = "Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
     SessionInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it '#attending_reminder' do
-    email_subject = "Workshop Reminder #{humanize_date_with_time(workshop.date_and_time, workshop.time)}"
+  it "#attending_reminder" do
+    email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
     SessionInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it '#waitlist_reminder' do
-    email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date_with_time(workshop.date_and_time, workshop.time)})"
+  it "#waitlist_reminder" do
+    email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date(workshop.date_and_time, with_time: true)})"
     SessionInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
     expect(email.body.encoded).to match('you should keep your laptop with you and check your email during the afternoon on the day of the workshop.')
-    expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date_with_time(workshop.date_and_time, workshop.time)}")
+    expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end


### PR DESCRIPTION
I came across this in my timezone PR. We never need to display a different time from the time in the DateTime object so it was a little overcomplicated