### PR TITLE
Improve date time forms

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,12 +27,12 @@
 
 $(function(){
   $(document).foundation();
-  $('#sessions_date_and_time, #event_date_and_time, #workshop_rsvp_open_date').pickadate({
+  $('#workshop_local_date, #event_date_and_time, #workshop_rsvp_open_local_date').pickadate({
     format: 'dd/mm/yyyy'
   });
 
   $('#announcement_expires_at, #ban_expires_at').pickadate();
-  $('#sessions_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_time').pickatime({
+  $('#workshop_local_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_local_time').pickatime({
     format: 'HH:i'
   });
 

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -24,7 +24,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
     if @workshop.save
       grant_organiser_access(@workshop.chapter.organisers.map(&:id))
       set_host(host_id)
-      update_rsvp_open_time if auto_rsvps_set?
 
       redirect_to admin_workshop_path(@workshop), notice: 'The workshop has been created.'
     else
@@ -35,9 +34,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   def edit
     authorize @workshop
-
-    @rsvp_open_time = @workshop.rsvp_open_time.try(:strftime, '%H:%M')
-    @rsvp_open_date = @workshop.rsvp_open_date.try(:strftime, '%d/%m/%Y')
   end
 
   def show
@@ -58,7 +54,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
     set_organisers(organiser_ids)
     set_host(host_id)
-    update_rsvp_open_time if auto_rsvps_set?
 
     redirect_to admin_workshop_path(@workshop), notice: 'Workshops updated successfully'
   end
@@ -103,18 +98,10 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   private
 
-  def auto_rsvps_set?
-    @workshop.rsvp_open_time.present? && @workshop.rsvp_open_date.present?
-  end
-
-  def update_rsvp_open_time
-    updated_time = DateTime.new(@workshop.rsvp_open_date.year, @workshop.rsvp_open_date.month, @workshop.rsvp_open_date.day, @workshop.rsvp_open_time.hour, @workshop.rsvp_open_time.min)
-    @workshop.update_attribute(:rsvp_open_time, updated_time)
-  end
-
   def workshop_params
-    params.require(:workshop).permit(:date_and_time, :time, :chapter_id,
-    :invitable, :seats, :rsvp_open_time, :rsvp_open_date, sponsor_ids: [])
+    params.require(:workshop).permit(:local_date, :local_time, :chapter_id,
+                                     :invitable, :seats, :rsvp_open_local_date,
+                                     :rsvp_open_local_time, sponsor_ids: [])
   end
 
   def sponsor_id

--- a/app/models/session_invitation.rb
+++ b/app/models/session_invitation.rb
@@ -14,9 +14,7 @@ class SessionInvitation < ActiveRecord::Base
   scope :to_coaches, -> { where(role: 'Coach') }
   scope :by_member, -> { group(:member_id) }
   scope :order_by_latest, -> { joins(:workshop).order('workshops.date_and_time desc') }
-  scope :past, -> { joins(:workshop).where('workshops.date_and_time < ?', Date.today) }
-  scope :last_six_months, -> { joins(:workshop).where('workshops.date_and_time < ? AND workshops.date_and_time > ?',
-                                                      Date.today, Date.today - 6.months)}
+  scope :last_six_months, -> { joins(:workshop).where(workshops: { date_and_time: 6.months.ago...Time.zone.now}) }
 
   def waiting_list_position
     @waiting_list_position ||= WaitingList.by_workshop(self.workshop).where_role(self.role).where(auto_rsvp: true).order(:created_at).map(&:invitation_id).index(self.id) + 1

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -4,10 +4,10 @@
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .row
     .large-3.columns
-      = f.input :date_and_time, as: :string, required: true, label: 'Date', input_html: { id: 'sessions_date_and_time', data: { value: @workshop.date_and_time.strftime('%d/%m/%Y') } }
+      = f.input :local_date, as: :string, required: true, input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .row
     .large-3.columns
-      = f.input :time, as: :string, required: true, input_html: { id: 'sessions_time', data: { value: (@workshop.time).strftime('%H:%M') }}
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
@@ -19,8 +19,8 @@
     .large-6.columns
       .panel.callout
         %p Fill out these fields if you want RSVPs to open automatically at a future time. Leave blank if you'll handle it manually later.
-        = f.input :rsvp_open_date, as: :string, input_html: { id: 'workshop_rsvp_open_date', value: @rsvp_open_date }
-        = f.input :rsvp_open_time, as: :string, input_html: { id: 'workshop_rsvp_open_time', value: @rsvp_open_time }
+        = f.input :rsvp_open_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
+        = f.input :rsvp_open_local_time, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       %label Organisers

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -4,10 +4,10 @@
       = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .row
     .large-3.columns
-      = f.input :date_and_time, as: :string, required: true, label: 'Date', input_html: { id: 'sessions_date_and_time', data: { value: @workshop.date_and_time } }
+      = f.input :local_date, as: :string, required: true, input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .row
     .large-3.columns
-      = f.input :time, as: :string, required: true, input_html: { id: 'sessions_time'}
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @workshop.time.try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
@@ -19,8 +19,8 @@
     .large-6.columns
       .panel.callout
         %p Fill out these fields if you want RSVPs to open automatically at a future time. Leave blank if you'll handle it manually later.
-        = f.input :rsvp_open_date, as: :string, input_html: { id: 'workshop_rsvp_open_date' }
-        = f.input :rsvp_open_time, as: :string, input_html: { id: 'workshop_rsvp_open_time' }
+        = f.input :rsvp_open_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
+        = f.input :rsvp_open_local_time, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }
   .row
     .large-6.columns
       = f.input :invitable

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -27,5 +27,3 @@
             %td
               - if workshop.date_and_time.future?
                 %label.label upcoming
-
-

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -38,9 +38,9 @@
             %small=@workshop.chapter.name
         %h3
           %small #{l(@workshop.date_and_time)}
-        - if @workshop.rsvp_open_time_set?
+        - if @workshop.rsvp_opens_at
           RSVPs will open at
-          = @workshop.rsvp_open_time.strftime('%H:%M on %d/%m/%Y.')
+          = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')
           %br
           %br
         - if @workshop.venue.present?

--- a/db/migrate/20180108210921_remove_time_from_workshops.rb
+++ b/db/migrate/20180108210921_remove_time_from_workshops.rb
@@ -1,0 +1,5 @@
+class RemoveTimeFromWorkshops < ActiveRecord::Migration
+  def change
+    remove_column :workshops, :time, :datetime
+  end
+end

--- a/db/migrate/20180109024411_add_rsvp_opens_at_to_workshops.rb
+++ b/db/migrate/20180109024411_add_rsvp_opens_at_to_workshops.rb
@@ -1,0 +1,7 @@
+class AddRsvpOpensAtToWorkshops < ActiveRecord::Migration
+  def change
+    rename_column :workshops, :rsvp_open_time, :rsvp_opens_at
+    remove_column :workshops, :rsvp_open_date, :datetime
+    rename_column :workshops, :rsvp_close_time, :rsvp_closes_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106023135) do
+ActiveRecord::Schema.define(version: 20180109024411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -525,13 +525,11 @@ ActiveRecord::Schema.define(version: 20180106023135) do
     t.datetime "date_and_time"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "invitable",       default: true
+    t.boolean  "invitable",      default: true
     t.string   "sign_up_url"
     t.integer  "chapter_id"
-    t.datetime "time"
-    t.datetime "rsvp_close_time"
-    t.datetime "rsvp_open_time"
-    t.datetime "rsvp_open_date"
+    t.datetime "rsvp_closes_at"
+    t.datetime "rsvp_opens_at"
   end
 
   add_index "workshops", ["chapter_id"], name: "index_workshops_on_chapter_id", using: :btree

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -1,6 +1,5 @@
 Fabricator(:workshop) do
   date_and_time Time.zone.now + 2.days
-  time Time.zone.now
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
@@ -11,7 +10,6 @@ end
 
 Fabricator(:workshop_no_sponsor, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
-  time Time.zone.now
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
@@ -19,12 +17,10 @@ end
 
 Fabricator(:workshop_auto_rsvp_in_past, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
-  time Time.zone.now
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
-  rsvp_open_time Time.zone.now
-  rsvp_open_date Time.zone.now - 1.days
+  rsvp_opens_at Time.zone.now - 1.days
   invitable false
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
@@ -33,12 +29,10 @@ end
 
 Fabricator(:workshop_auto_rsvp_in_future, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
-  time Time.zone.now
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter
-  rsvp_open_time Time.zone.now + 1.days
-  rsvp_open_date Time.zone.now + 1.days
+  rsvp_opens_at Time.zone.now + 1.days
   invitable false
   after_build do |workshop|
     Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
@@ -47,7 +41,6 @@ end
 
 Fabricator(:workshop_no_spots, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
-  time Time.zone.now
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -14,8 +14,8 @@ feature 'Managing workshops' do
     visit new_admin_workshop_path
 
     select chapter.name
-    fill_in 'Date', with: Date.current
-    fill_in 'Time', with: '11:30'
+    fill_in 'Local date', with: Date.current
+    fill_in 'Local time', with: '11:30'
 
     click_on 'Save'
 

--- a/spec/lib/tasks/reminders_workshop_rake_spec.rb
+++ b/spec/lib/tasks/reminders_workshop_rake_spec.rb
@@ -4,7 +4,7 @@ describe 'reminders:workshop' do
   include_context 'rake'
 
   its(:prerequisites) { should include('environment') }
-  let!(:workshop) { Fabricate(:workshop, date_and_time: Time.zone.now + 29.hours, time: Time.zone.now + 29.hours) }
+  let!(:workshop) { Fabricate(:workshop, date_and_time: Time.zone.now + 29.hours) }
 
   before do
     allow(STDOUT).to receive(:puts)


### PR DESCRIPTION
When working on the timezone PR I came across this. There is a `date_and_time` DateTime column as well as a `time` column for just the time. Then there's a callback to merge them after save. I assume this was so there could be a separate date and time picker in the form but the redundancy is very confusing so I fixed it

This is dependent on other PRs which need to merge, so just look at the last commit here