### PR TITLE
#632 Add organisers to workshop attendees CSV download

### DIFF
--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -68,6 +68,12 @@ class WorkshopPresenter < EventPresenter
     end.join("\n\n")
   end
 
+  def attending_organisers
+    organisers.map do |o|
+      [o.full_name, 'ORGANISER']
+    end
+  end
+
   def attendee_array
     model.attendances.map do |i|
       if organisers.include?(i.member)
@@ -75,7 +81,7 @@ class WorkshopPresenter < EventPresenter
       else
         [i.member.full_name, i.role.upcase]
       end
-    end
+    end.concat(attending_organisers).uniq
   end
 
   def model


### PR DESCRIPTION
Solves Issue #632 

Previously, the method attendee_array was only making sure that the correct role was assigned to an organiser within the CSV if they had also clicked attending to the workshop. 

This ensures that any organiser of the workshop (but not clicked attending) is also added to the CSV at the end. 