### PR TITLE
Order students and coaches by name, not button click order

### DIFF
--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -11,11 +11,11 @@ module Invitable
     end
 
     def attending_students
-      invitations.where(role: 'Student').accepted
+      invitations.where(role: 'Student').accepted.includes(:member).order('members.name, members.surname')
     end
 
     def attending_coaches
-      invitations.where(role: 'Coach').accepted
+      invitations.where(role: 'Coach').accepted.includes(:member).order('members.name, members.surname')
     end
   end
 end


### PR DESCRIPTION
It's a small enhancements, based on experience signing people in with @MarckK and Rosa Fox.

It works in every context, in particular event invitation management page, admin event page, attendees_checklist text page.

Hopefully it will smooth things out a little bit.

Here's a screenshot (with randomly generated users, signing up in random order):

![screen shot 2018-02-25 at 22 35 30](https://user-images.githubusercontent.com/17444/36647359-425ef3fe-1a7c-11e8-8a66-a9083eed65ad.png)
