### PR TITLE
Add large avatar version to Sponsors

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -27,6 +27,10 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # end
   #
 
+  version :large do
+    process resize_to_fit: [460, 240]
+  end
+
   version :thumb do
     process resize_to_fit: [178, 65]
   end

--- a/app/views/sponsors/index.html.haml
+++ b/app/views/sponsors/index.html.haml
@@ -17,4 +17,4 @@
       %ul.small-block-grid-2.medium-block-grid-3.large-block-grid-4#sponsors
         - @sponsors.each do |sponsor|
           %li.text-center
-            = link_to image_tag(sponsor.avatar, class: "sponsor-logo-image", alt: sponsor.name), sponsor.website
+            = link_to image_tag(sponsor.avatar.large, class: "sponsor-logo-image", alt: sponsor.name), sponsor.website


### PR DESCRIPTION
Fixes #687 

You should run `Sponsor.find_each {|s| s.avatar.recreate_versions!(:large) }` in the console to build these image variants