### PR TITLE
Fix n-plus-1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development, :test do
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'timecop'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
+    bullet (5.7.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11.0)
     byebug (2.7.0)
       columnize (~> 0.3)
       debugger-linecache (~> 1.2)
@@ -411,6 +414,7 @@ GEM
     unf_ext (0.0.7.1)
     unicode-display_width (1.3.0)
     unicode_utils (1.4.0)
+    uniform_notifier (1.11.0)
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -424,6 +428,7 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on (~> 3.4)
   better_errors
+  bullet
   capybara
   carrierwave
   carrierwave-ftp

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -10,7 +10,7 @@ class Admin::JobsController < Admin::ApplicationController
   end
 
   def all
-    @jobs = Job.unscoped.ordered
+    @jobs = Job.unscoped.ordered.includes(:approved_by)
     authorize @jobs
   end
 

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -5,8 +5,8 @@ class Admin::MembersController < Admin::ApplicationController
 
   def show
     @member = Member.includes(:member_notes).find(params[:id])
-    @invitations = @member.session_invitations.accepted_or_attended.order_by_latest rescue nil
-    @monthly_invitations = @member.meeting_invitations.order(:created_at) rescue nil
+    @invitations = @member.session_invitations.accepted_or_attended.order_by_latest.includes(workshop: :chapter)
+    @monthly_invitations = @member.meeting_invitations.order(:created_at).includes(:meeting)
     @last_attendance = @invitations.first.workshop if @invitations.any?
     @member_note = MemberNote.new
   end

--- a/app/controllers/admin/portal_controller.rb
+++ b/app/controllers/admin/portal_controller.rb
@@ -6,8 +6,8 @@ class Admin::PortalController < Admin::ApplicationController
     @sponsors = Sponsor.last(5)
     @chapters = Chapter.all
     @workshops = Workshop.upcoming
-    @groups = Group.all
-    @subscribers = Subscription.last(20).reverse
+    @groups = Group.includes(:chapter)
+    @subscribers = Subscription.order('created_at DESC').limit(20).includes(:member, :group)
   end
 
   def guide

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
     events = [Workshop.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)]
     events << Course.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events << Meeting.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
-    events << Event.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
+    events << Event.past.includes(:venue, :sponsors).limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events = events.compact.flatten.sort_by(&:date_and_time).reverse.first(RECENT_EVENTS_DISPLAY_LIMIT)
     events_hash_grouped_by_date = events.group_by(&:date)
     @past_events = events_hash_grouped_by_date.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash }
@@ -17,7 +17,7 @@ class EventsController < ApplicationController
     events = [Workshop.upcoming.all]
     events << Course.upcoming.all
     events << Meeting.upcoming.all
-    events << Event.upcoming.all
+    events << Event.upcoming.includes(:venue, :sponsors).all
     events = events.compact.flatten.sort_by(&:date_and_time).group_by(&:date)
     @events = events.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash }
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,11 +5,11 @@ class InvitationsController < ApplicationController
   def index
     @upcoming_session = Workshop.next
 
-    workshop_invitations = SessionInvitation.where(member: current_user).joins(:workshop).where('date_and_time >= ?', Time.zone.now)
-    course_invitations = CourseInvitation.where(member: current_user).joins(:course).where('date_and_time >= ?', Time.zone.now)
-    @upcoming_invitations = InvitationPresenter.decorate_collection(workshop_invitations + course_invitations)
+    upcoming_invitations = SessionInvitation.where(member: current_user).joins(:workshop).merge(Workshop.upcoming).includes(workshop: :chapter)
+    upcoming_invitations += CourseInvitation.where(member: current_user).joins(:course).merge(Course.upcoming).includes(:course)
+    @upcoming_invitations = InvitationPresenter.decorate_collection(upcoming_invitations)
 
-    @attended_invitations = SessionInvitation.where(member: current_user).attended
+    @attended_invitations = SessionInvitation.where(member: current_user).attended.includes(workshop: :chapter)
   end
 
   def show

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,7 +2,7 @@ class SubscriptionsController < ApplicationController
   before_action :has_access?
 
   def index
-    @groups = Group.joins(:chapter).order('chapters.city')
+    @groups = Group.includes(:chapter).references(:chapter).order('chapters.city')
   end
 
   def create

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -29,6 +29,10 @@ class Sponsor < ActiveRecord::Base
     number_of_coaches || (seats / 2.0).round
   end
 
+  def self.latest
+    WorkshopSponsor.order('created_at desc').limit(15).includes(:sponsor).map(&:sponsor).uniq
+  end
+
   private
 
   def website_is_url

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,4 +32,11 @@ Planner::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,4 +37,10 @@ Planner::Application.configure do
 
   # Fake omniauth for testing
   OmniAuth.config.test_mode = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+feature 'when visiting the coaches page' do
+  let!(:coach) { Fabricate(:coach_session_invitation, attended: true).member }
+
+  scenario 'I can see the most active coaches' do
+    visit coaches_path
+    expect(page).to have_content coach.name
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,15 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  if Bullet.enable?
+    config.around(:each) do |example|
+      Bullet.start_request
+      example.run
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
When we load records from the database we want to include all the data we're going to need. If we haven't 'eager loaded' all the records needed by the views, Rails will automatically fetch the extra records one-by-one which is slow.

Imagine a page that shows 30 workshops and a chapter name and sponsor logos for each one. Normally we'd fetch those workshops with one database call. If we forget to 'eager load' the chapters and sponsors we turn 1 query into 61 queries.

```ruby
Workshop.limit(30)
```

vs

```ruby
Workshop.limit(30).includes(:chapter, :sponsors)
```

To detect these I added [Bullet](https://github.com/flyerhzm/bullet) and made tests fail if it detects this happening