### PR TITLE
Reduce number of calls on wall of fame page (/coaches)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'sass-rails', '~> 5.0.1'
 gem 'simple_form'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
+gem 'will_paginate'
 
 gem 'icalendar'
 gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,6 +412,7 @@ GEM
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.1.6)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.9.12)
@@ -480,6 +481,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
+  will_paginate
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -26,11 +26,8 @@ class DashboardController < ApplicationController
   end
 
   def wall_of_fame
-    @coaches = order_by_attendance(attendance_stats_by_coach).map do |member_id, attendances|
-      member = Member.unscoped.find(member_id)
-      member.attendance = attendances
-      member
-    end
+    @top_coaches = Member.where(id: top_coach_query.limit(60))
+    @total_coaches = top_coach_query.length
   end
 
   def participant_guide
@@ -38,12 +35,12 @@ class DashboardController < ApplicationController
 
   private
 
-  def attendance_stats_by_coach
-    WorkshopInvitation.to_coaches.attended.by_member.count(:member_id)
-  end
-
-  def order_by_attendance(member_stats)
-    member_stats.sort_by { |member_id, attendance| attendance }.reverse
+  def top_coach_query
+    WorkshopInvitation.to_coaches
+                     .attended
+                     .group(:member_id)
+                     .order('COUNT(member_id) DESC')
+                     .select(:member_id)
   end
 
   def upcoming_events

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -26,14 +26,16 @@ class DashboardController < ApplicationController
   end
 
   def wall_of_fame
-    @top_coaches = Member.where(id: top_coach_query.limit(60))
-    @total_coaches = top_coach_query.length
+    @coaches = Member.where(id: top_coach_query).paginate(page: page, per_page: 60)
   end
 
   def participant_guide
   end
 
   private
+  def page
+    params.permit(:page)[:page]
+  end
 
   def top_coach_query
     WorkshopInvitation.to_coaches

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -12,7 +12,6 @@ class WorkshopInvitation < ActiveRecord::Base
   scope :attended, -> { where(attended: true) }
   scope :to_students, -> { where(role: 'Student') }
   scope :to_coaches, -> { where(role: 'Coach') }
-  scope :by_member, -> { group(:member_id) }
   scope :order_by_latest, -> { joins(:workshop).order('workshops.date_and_time desc') }
   scope :last_six_months, -> { joins(:workshop).where(workshops: { date_and_time: 6.months.ago...Time.zone.now}) }
 

--- a/app/views/coach/_coach.html.haml
+++ b/app/views/coach/_coach.html.haml
@@ -1,20 +1,27 @@
 .stripe.reverse
   .row
     .large-12.columns
-      %ul.small-block-grid-1.medium-block-grid-2.large-block-grid-3
+      .text-right
+        = will_paginate(@coaches)
+        %br
+        %br
+      %ul.small-block-grid-2.medium-block-grid-5.large-block-grid-5
         - coaches.each do |coach|
           %li.coach
             .row
-              .small-2.columns
-                =link_to twitter_url_for(coach.twitter), class: 'user-link' do
-                  =image_tag(coach.avatar(96), class: 'th radius', title: coach.full_name, alt: coach.full_name)
+              .small-12.columns
+                .text-center
+                  =link_to twitter_url_for(coach.twitter), class: 'user-link' do
+                    =image_tag(coach.avatar(50), class: 'th radius', title: coach.full_name, alt: coach.full_name)
 
-              .small-10.columns
+                %br
                 =link_to twitter_url_for(coach.twitter) do
                   = coach.full_name
-                %p= coach.about_you
+                %p.small= coach.about_you
                 - if coach.skills.any?
                   %p
                     skills:
                     - coach.skills.each do |skill|
                       = link_to skill.name, skill_url(skill.name), class: "skill"
+      .text-right
+        = will_paginate(@coaches)

--- a/app/views/dashboard/wall_of_fame.html.haml
+++ b/app/views/dashboard/wall_of_fame.html.haml
@@ -3,8 +3,9 @@
     .large-12.columns
       %h2 Coaches
       %p.lead
-        The people below are just a handful of our #{ @total_coaches } volunteer coaches.
+        Here you can find a list of the #{ @coaches.total_entries } volunteers who have coached at codebar.
 
+      %p.lead
         If you’d like to start coaching at a workshop near you, read our #{ link_to "teaching guide", teaching_guide_path } and then #{ link_to "sign up", new_member_path } as a coach. It’s easier than you think!
 
-= render partial: '/coach/coach', locals: { coaches: @top_coaches }
+= render partial: '/coach/coach', locals: { coaches: @coaches }

--- a/app/views/dashboard/wall_of_fame.html.haml
+++ b/app/views/dashboard/wall_of_fame.html.haml
@@ -3,5 +3,8 @@
     .large-12.columns
       %h2 Coaches
       %p.lead
-        Would you like to help out by coaching at one of our workshops? Read our #{ link_to "teaching guide", teaching_guide_path } then sign up as a coach.
-= render partial: '/coach/coach', locals: { coaches: @coaches }
+        The people below are just a handful of our #{ @total_coaches } volunteer coaches.
+
+        If you’d like to start coaching at a workshop near you, read our #{ link_to "teaching guide", teaching_guide_path } and then #{ link_to "sign up", new_member_path } as a coach. It’s easier than you think!
+
+= render partial: '/coach/coach', locals: { coaches: @top_coaches }

--- a/spec/fabricators/auth_service_fabricator.rb
+++ b/spec/fabricators/auth_service_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:auth_service) do
   provider { Faker::Company.name }
-  uid { Fabricate.sequence(:uid) }
+  uid { Fabricate.sequence(:uid)  { |n| "sq#{n}" }}
 end


### PR DESCRIPTION
Fixes #695 

There are 1040 coaches and at the moment we're showing a name, image, and bio for each one. This limits it to 30 and shows the total number instead. I'm not sure if it's the best approach, maybe we could list the names of the less active coaches just so they're on the site?

I'd like to check the look of this on staging as I don't have enough seed data to really see it properly