### PR TITLE
Add Sentry exception tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'gibbon', '~> 1.1.5'
 
 gem 'stripe'
 
+gem "sentry-raven"
+
 group :development do
   gem 'better_errors'
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (2.7.2)
+      faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.0)
       activesupport (>= 4.0.0)
     simple_form (3.5.0)
@@ -474,6 +476,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.52.0)
   sass-rails (~> 5.0.1)
+  sentry-raven
   shoulda-matchers (~> 3.1)
   simple_form
   stripe

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,12 @@
+# Be sure to restart your server when you modify this file.
+# Sentry Exception tracking
+# 
+# NOTE: When the better_errors gem is installed/enabled (e.g in development) excpetions will be caught by
+# better_errors and not be seen by raven.
+
+
+Raven.configure do |config|
+	config.dsn = ENV['SENTRY_DSN']
+	config.environments = ['production']
+	config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end


### PR DESCRIPTION
Any exceptions in production can now be sent to [sentry](https://sentry.io/features/), which makes it easy to summarise and see exceptions as they happen (and in the past) instead of searching through heroku logs.

To enable capturing the exceptions the `SENTRY_DSN` enviroment variable needs to be set in heroku. To get a sentry DSN you'll need to [create an account](https://docs.sentry.io/quickstart/) with sentry (they have a free tier of about 10K events per month).

I haven't done anything fancy like add extra context info (e.g username) to the information that goes to sentry, but the basic info it provides should be a good starting point.

![screenshot-2018-4-8 runtimeerror error](https://user-images.githubusercontent.com/260919/38469248-66c1b6bc-3b49-11e8-938a-151c979d8475.png)
