### PR TITLE
Add unique index to meeting slug and optimise queries based on bullet feedback

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -113,7 +113,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
   end
 
   def set_and_decorate_workshop
-    workshop = Workshop.find(params[:workshop_id])
+    workshop = Workshop.includes(:invitations).find(params[:workshop_id])
     @workshop = WorkshopPresenter.new(workshop)
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -81,9 +81,9 @@ class DashboardController < ApplicationController
   end
 
   def all_events(workshops)
-    course = Course.next
-    meeting = Meeting.next
-    events = Event.future(DEFAULT_UPCOMING_EVENTS)
+    course = Course.includes(:sponsor).next
+    meeting = Meeting.includes(:venue).next
+    events = Event.includes(:venue, :sponsors).future(DEFAULT_UPCOMING_EVENTS)
 
     [*workshops, course, *events, meeting].compact
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,7 @@ class EventsController < ApplicationController
   RECENT_EVENTS_DISPLAY_LIMIT = 40
 
   def index
-    events = [Workshop.past.includes(:chapter, :sponsors).limit(RECENT_EVENTS_DISPLAY_LIMIT)]
+    events = [Workshop.past.includes(:chapter).limit(RECENT_EVENTS_DISPLAY_LIMIT)]
     events << Course.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events << Meeting.past.includes(:venue).limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events << Event.past.includes(:venue, :sponsors).limit(RECENT_EVENTS_DISPLAY_LIMIT)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,9 +6,9 @@ class EventsController < ApplicationController
   RECENT_EVENTS_DISPLAY_LIMIT = 40
 
   def index
-    events = [Workshop.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)]
+    events = [Workshop.past.includes(:chapter, :sponsors).limit(RECENT_EVENTS_DISPLAY_LIMIT)]
     events << Course.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
-    events << Meeting.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
+    events << Meeting.past.includes(:venue).limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events << Event.past.includes(:venue, :sponsors).limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events = events.compact.flatten.sort_by(&:date_and_time).reverse.first(RECENT_EVENTS_DISPLAY_LIMIT)
     events_hash_grouped_by_date = events.group_by(&:date)

--- a/db/migrate/20180430001328_add_unique_index_to_meeting_slug.rb
+++ b/db/migrate/20180430001328_add_unique_index_to_meeting_slug.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMeetingSlug < ActiveRecord::Migration
+  def change
+    add_index :meetings, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313165054) do
+ActiveRecord::Schema.define(version: 20180430001328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -338,6 +338,7 @@ ActiveRecord::Schema.define(version: 20180313165054) do
     t.boolean  "invites_sent",  default: false
   end
 
+  add_index "meetings", ["slug"], name: "index_meetings_on_slug", unique: true, using: :btree
   add_index "meetings", ["venue_id"], name: "index_meetings_on_venue_id", using: :btree
 
   create_table "member_contacts", force: :cascade do |t|

--- a/spec/fabricators/meeting_fabricator.rb
+++ b/spec/fabricators/meeting_fabricator.rb
@@ -1,13 +1,12 @@
 Fabricator(:meeting) do
   name        { Faker::Lorem.sentence }
-    description { Faker::Lorem.paragraph }
-    date_and_time { Time.zone.now + 1.week }
-    # sponsor
-    venue { Fabricate(:sponsor) }
-    invitable true
-    # invites_sent
-    slug 'some-slug'
-    spaces 20
-    # created_at
-    # updated_at
+  description { Faker::Lorem.paragraph }
+  date_and_time { Time.zone.now + 1.week }
+  # sponsor
+  venue { Fabricate(:sponsor) }
+  invitable true
+  # invites_sent
+  spaces 20
+  # created_at
+  # updated_at
 end

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'viewing a meeting' do
-  let!(:meeting) { create_meeting }
+  let!(:meeting) { Fabricate(:meeting) }
 
   scenario "i can view a meeting's information" do
     visit meeting_path(meeting)
@@ -9,12 +9,4 @@ feature 'viewing a meeting' do
     expect(page).to have_content meeting.name
     expect(page).to have_content meeting.venue.name
   end
-end
-
-def create_meeting
-  Meeting.create(venue: Fabricate(:sponsor),
-                 name: 'codebar Monthly - March',
-                 date_and_time: Time.zone.now + 1.year - 11.months,
-                 spaces: 10,
-                 description: 'Join us for an evening of talks')
 end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -13,11 +13,28 @@ describe Meeting do
     end
   end
 
+  it '#slug' do
+    meeting = Fabricate(:meeting, slug: 'meeting')
+    new_meeting = Fabricate.build(:meeting, slug: 'meeting')
+    new_meeting.valid?
+
+    expect(new_meeting.errors.messages[:slug].first).to eq("has already been taken")
+  end
+
   context '#title' do
     subject(:meeting) { Meeting.new(date_and_time: Time.zone.local(2014, 8, 20, 18, 30)) }
 
     it 'is formatted correctly' do
       expect(meeting.title).to eq('August Meeting')
+    end
+  end
+
+  context '#set_slug' do
+    it 'loops until it finds an available slug' do
+      Fabricate.times(4, :meeting, name: 'monthly')
+      meeting = Fabricate(:meeting, name: 'monthly')
+      expect(meeting.slug)
+        .to eq("#{I18n.l(meeting.date_and_time, format: :year_month).downcase}-monthly-5")
     end
   end
 end


### PR DESCRIPTION
resolves bug noticed on the website last week where an old meeting was retrieved because the new meeting slug was identical.