### PR TITLE
This change Facebook text color to more visible

### DIFF
--- a/app/assets/stylesheets/partials/_social_media.scss
+++ b/app/assets/stylesheets/partials/_social_media.scss
@@ -8,11 +8,11 @@ li.slack a {
 }
 
 li.facebook a {
-  color: #4e69a2;
-  color: rgba(78, 105, 162, 0.8);
+  color: #5279cc;
+  color: rgba(82, 121, 204, 0.8);
 
   &:hover {
-    color: rgba(78, 105, 162, 1);
+    color: rgba(82, 121, 204, 1);
   }
 }
 


### PR DESCRIPTION
This change is related with this https://github.com/codebar/planner/issues/724.

<img width="1150" src="https://user-images.githubusercontent.com/7561969/39608879-921128f0-4f3c-11e8-8c68-eea292bf4093.png">
