### PR TITLE
Handle expired jobs better

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -4,7 +4,7 @@ class JobsController < ApplicationController
   before_filter :has_access?, only: %i[edit update submit]
 
   def index
-    @jobs = Job.approved.ordered
+    @jobs = Job.active.approved.ordered
   end
 
   def pending

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -7,7 +7,7 @@ class Job < ActiveRecord::Base
   scope :not_submitted, -> { where(submitted: false, approved: false) }
 
   scope :ordered, -> { order('created_at desc') }
-  default_scope -> { where('expiry_date > ?', Time.zone.today) }
+  scope :active, -> { where('expiry_date > ?', Time.zone.today) }
 
   def expired?
     self.expiry_date.past?

--- a/app/views/jobs/_show.html.haml
+++ b/app/views/jobs/_show.html.haml
@@ -1,10 +1,13 @@
+- if @job.expiry_date.past?
+  .alert-box.alert
+    .row
+      .large-12.columns
+        =t('job.expired')
 .stripe.reverse
   .row
     .large-12.columns
       %h1
         #{@job.title}
-        - if @job.expiry_date.past?
-          %label.label.alert Expired
       %p.lead
         = link_to(@job.company, @job.link_to_job)
         %i.fa.fa-location-arrow

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,6 +239,9 @@ en:
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"
 
+  job:
+    expired: 'This job post has expired'
+
   admin:
     workshop:
       manage_rsvps:
@@ -258,3 +261,4 @@ en:
         already_on_list: "%{name} is already on the list!"
         rsvp_error: "Something went wrong, %{name} has not been added."
         update_rsvp: 'Updated attendance of %{name}'
+

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -2,102 +2,122 @@ require 'spec_helper'
 
 feature 'Jobs' do
   context 'Listing' do
-    context 'a non-logged in visitor to the website' do
-      scenario 'to be able to access the job listing' do
+    context 'a visit to the website' do
+      scenario 'is able to access /jobs' do
+        jobs = Fabricate.times(3, :job)
         visit jobs_path
+
+        expect(page).to have_content('Jobs')
+        jobs.each do |job|
+          expect(page).to have_content(job.title)
+        end
+      end
+
+      context 'viewing individual job posts' do
+        it 'when a job post is active' do
+          job = Fabricate(:job)
+          visit job_path(job)
+
+          expect(page).to have_content(job.title)
+        end
+
+        it 'when a job post has expired' do
+          job = Fabricate(:job, expiry_date: 1.week.ago)
+          visit job_path(job)
+
+          expect(page).to have_content(job.title)
+          expect(page).to have_content('This job post has expired')
+        end
+      end
+    end
+
+    context 'a member' do
+      let(:member) { Fabricate(:member) }
+
+      before do
+        login(member)
+      end
+
+      scenario 'can see a message when there are no available jobs' do
+        visit root_path
+        click_link('Jobs', match: :first)
 
         expect(page).to have_content('Jobs')
         expect(page).to have_content('There are no jobs available at the moment')
       end
 
-      context 'a member' do
-        let(:member) { Fabricate(:member) }
 
-        before do
-          login(member)
+      scenario 'can see a listing of all non expired job posts' do
+        jobs = 2.times.map { |i| Fabricate.create(:job, title: "Current Dev #{i}") }
+        expired = 3.times.map { |i| Fabricate.create(:job, title: "Expired Dev #{i}", expiry_date: Time.zone.today - 2.days) }
+
+        visit root_path
+        click_link('Jobs', match: :first)
+        jobs.each do |job|
+          expect(page).to have_content(job.title)
         end
+        expect(page).to_not have_content(expired.first.title)
+      end
 
-        scenario 'can see a message when there are no available jobs' do
-          visit root_path
-          click_link('Jobs', match: :first)
+      scenario 'can view an approved job listing' do
+        job = Fabricate.create(:job)
 
-          expect(page).to have_content('Jobs')
-          expect(page).to have_content('There are no jobs available at the moment')
-        end
+        visit root_path
+        click_link('Jobs', match: :first)
+        click_on job.title
 
+        expect(page).to have_content(job.description)
+        expect(page).to have_content("Posted by #{job.created_by.full_name}")
+      end
 
-        scenario 'can see a listing of all non expired job posts' do
-          jobs = 2.times.map { |i| Fabricate.create(:job, title: "Current Dev #{i}") }
-          expired = 3.times.map { |i| Fabricate.create(:job, title: "Expired Dev #{i}", expiry_date: Time.zone.today - 2.days) }
+      scenario 'can preview and list a new job' do
+        visit new_job_path
 
-          visit root_path
-          click_link('Jobs', match: :first)
-          jobs.each do |job|
-            expect(page).to have_content(job.title)
-          end
-          expect(page).to_not have_content(expired.first.title)
-        end
+        fill_in 'Job title', with: 'Internship'
+        fill_in 'Company', with: 'codebar'
+        fill_in 'Location', with: 'London'
+        fill_in 'Description', with: Faker::Lorem.paragraph
+        fill_in 'Link to job post', with: Faker::Internet.url
 
-        scenario 'can view an approved job listing' do
-          job = Fabricate.create(:job)
+        click_on 'Submit job'
 
-          visit root_path
-          click_link('Jobs', match: :first)
-          click_on job.title
+        expect(page).to have_content('This is a preview. Submit to verify your post or Edit to amend.')
 
-          expect(page).to have_content(job.description)
-          expect(page).to have_content("Posted by #{job.created_by.full_name}")
-        end
+        click_on 'Submit'
+        expect(page).to have_content('Job submitted. You will receive an email when the job has ben approved.')
+      end
 
-        scenario 'can preview and list a new job' do
-          visit new_job_path
+      scenario 'can preview, edit and list a new job' do
+        visit new_job_path
 
-          fill_in 'Job title', with: 'Internship'
-          fill_in 'Company', with: 'codebar'
-          fill_in 'Location', with: 'London'
-          fill_in 'Description', with: Faker::Lorem.paragraph
-          fill_in 'Link to job post', with: Faker::Internet.url
+        fill_in 'Job title', with: 'Internship'
+        fill_in 'Company', with: 'codebar'
+        fill_in 'Location', with: 'London'
+        fill_in 'Description', with: Faker::Lorem.paragraph
+        fill_in 'Link to job post', with: Faker::Internet.url
 
-          click_on 'Submit job'
+        click_on 'Submit job'
 
-          expect(page).to have_content('This is a preview. Submit to verify your post or Edit to amend.')
+        expect(page).to have_content('This is a preview. Submit to verify your post or Edit to amend.')
+        expect(page).to have_content('Internship')
 
-          click_on 'Submit'
-          expect(page).to have_content('Job submitted. You will receive an email when the job has ben approved.')
-        end
+        click_on 'Edit'
 
-        scenario 'can preview, edit and list a new job' do
-          visit new_job_path
+        fill_in 'Job title', with: 'Junior developer'
+        click_on 'Submit job'
 
-          fill_in 'Job title', with: 'Internship'
-          fill_in 'Company', with: 'codebar'
-          fill_in 'Location', with: 'London'
-          fill_in 'Description', with: Faker::Lorem.paragraph
-          fill_in 'Link to job post', with: Faker::Internet.url
+        expect(page).to have_content('Junior developer')
 
-          click_on 'Submit job'
+        click_on 'Submit'
 
-          expect(page).to have_content('This is a preview. Submit to verify your post or Edit to amend.')
-          expect(page).to have_content('Internship')
+        expect(page).to have_content('Job submitted. You will receive an email when the job has ben approved.')
+      end
 
-          click_on 'Edit'
+      scenario 'can not edit their listing after it''s approved' do
+        approved_job =  Fabricate(:job, created_by: member)
+        visit edit_job_path(approved_job)
 
-          fill_in 'Job title', with: 'Junior developer'
-          click_on 'Submit job'
-
-          expect(page).to have_content('Junior developer')
-
-          click_on 'Submit'
-
-          expect(page).to have_content('Job submitted. You will receive an email when the job has ben approved.')
-        end
-
-        scenario 'can not edit their listing after it''s approved' do
-          approved_job =  Fabricate(:job, created_by: member)
-          visit edit_job_path(approved_job)
-
-          expect(page).to have_content('As the post has already been approved if you need to make any amendments please get in touch with the organisers at london@codebar.io.')
-        end
+        expect(page).to have_content('As the post has already been approved if you need to make any amendments please get in touch with the organisers at london@codebar.io.')
       end
     end
   end

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -20,14 +20,14 @@ describe Job do
     let!(:approved_jobs) { 2.times.map { Fabricate(:job) } }
     let!(:unsubmitted) { 1.times.map { Fabricate(:job, submitted: false, approved: false) } }
     let!(:pending_approval) { 4.times.map { Fabricate(:job, approved: false) } }
-    let!(:expired) { 2.times.map { Fabricate(:job, expiry_date: Time.zone.today - 1.week) } }
+    let!(:expired) { 2.times.map { Fabricate(:job, expiry_date: 1.week.ago) } }
 
     it '#default_scope does not return expired jobs' do
       expect(Job.submitted.all).to eq(pending_approval)
     end
 
     it '#approved returns all approved jobs' do
-      expect(Job.approved.all).to eq(approved_jobs)
+      expect(Job.approved.all).to eq(approved_jobs + expired)
     end
 
     it '#not_submitted returns all jobs who have not yet been previed' do
@@ -37,11 +37,15 @@ describe Job do
     it '#submitted returns all submitted jobs' do
       expect(Job.submitted.all).to eq(pending_approval)
     end
+
+    it '#active returns all active jobs' do
+      expect(Job.active.all).to eq(approved_jobs + unsubmitted + pending_approval)
+    end
   end
 
   context '#expired?' do
     it 'checks if the job post has past its expiry_date' do
-      job = Job.new(expiry_date: Time.zone.today - 1.day)
+      job = Job.new(expiry_date: 1.day.ago)
 
       expect(job.expired?).to eq(true)
     end


### PR DESCRIPTION
When a visitor attempts to access an expired job, render the job with an alert letting them know that this post has expired.