### PR TITLE
This will have consistency between attending and attending_reminder

### DIFF
--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -44,9 +44,9 @@
                 %p
                   If you have any trouble finding the venue call
                   - @workshop.organisers.each do |organiser|
-                    = organiser.full_name
-                    =organiser.mobile
-                    %br
+                    %p
+                      = organiser.full_name
+                      = organiser.mobile
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -41,8 +41,7 @@
                     - if organiser.mobile.present?
                       %p
                         = organiser.full_name
-                        =organiser.mobile
-                        %br
+                        = organiser.mobile
 
         .content
           = render partial: 'shared_mailers/social'


### PR DESCRIPTION
## Description of the issue 📄

The section with organisers name and mobile is not presented the same on attending and attending_reminder email.

## Screenshots 📷

**OLD**

<img width="361" src="https://user-images.githubusercontent.com/7561969/40887057-805e7494-673a-11e8-83cd-72bf10d36975.png">

**NEW**

<img width="550" src="https://user-images.githubusercontent.com/7561969/40887056-804b5f08-673a-11e8-90a1-d16b490f3252.png">

## Steps to fix 🛠

The only difference is that `organiser.full_name` and `organiser.mobile` is under a paragraph tag. It can be moved to partial but not sure if it worth doing it
