### PR TITLE
Extra address info for sponsors

### DIFF
--- a/app/assets/stylesheets/partials/_events.scss
+++ b/app/assets/stylesheets/partials/_events.scss
@@ -41,6 +41,6 @@
   color: #138cd3;
 }
 
-.monthly_host_logo {
-  margin-bottom: 50px;
+.monthly-host-logo {
+  margin-bottom: 1.4rem;
 }

--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -39,8 +39,12 @@ class Admin::SponsorsController < Admin::ApplicationController
   end
 
   private
+
   def sponsor_params
-    params.require(:sponsor).permit(:name, :avatar, :website, :seats, :accessibility_info, :number_of_coaches, :level, :email, :contact_first_name, :contact_surname, contact_ids: [], address_attributes: %i[flat street postal_code city latitude longitude directions])
+    params.require(:sponsor).permit(:name, :avatar, :website, :seats, :accessibility_info,
+                                    :number_of_coaches, :level, :email, :contact_first_name,
+                                    :contact_surname, contact_ids: [], address_attributes:
+                                    %i[flat street postal_code city latitude longitude directions])
   end
 
   def set_sponsor

--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -40,7 +40,7 @@ class Admin::SponsorsController < Admin::ApplicationController
 
   private
   def sponsor_params
-    params.require(:sponsor).permit(:name, :avatar, :website, :seats, :accessibility_info, :number_of_coaches, :level, :email, :contact_first_name, :contact_surname, contact_ids: [], address_attributes: %i[flat street postal_code city latitude longitude])
+    params.require(:sponsor).permit(:name, :avatar, :website, :seats, :accessibility_info, :number_of_coaches, :level, :email, :contact_first_name, :contact_surname, contact_ids: [], address_attributes: %i[flat street postal_code city latitude longitude directions])
   end
 
   def set_sponsor

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -8,6 +8,7 @@ class EventInvitationMailer < ActionMailer::Base
     @event = event
     @member = member
     @invitation = invitation
+    @host_address = AddressPresenter.new(@event.venue.address)
 
     subject = "Invitation: #{@event.name}"
 
@@ -20,6 +21,7 @@ class EventInvitationMailer < ActionMailer::Base
     @event = event
     @member = member
     @invitation = invitation
+    @host_address = AddressPresenter.new(@event.venue.address)
 
     subject = "Coach Invitation: #{@event.name}"
 

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -91,7 +91,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
     subject = 'A spot just became available'
 
-    mail(mail_args(member, subject, @workshop.chapter.email)) do |format|
+    mail(mail_args(@member, subject, @workshop.chapter.email)) do |format|
       format.html
     end
   end

--- a/app/views/admin/sponsors/_form.html.haml
+++ b/app/views/admin/sponsors/_form.html.haml
@@ -13,7 +13,7 @@
       = f.input :seats, label: 'Student Spots'
     .large-3.columns
       = f.input :number_of_coaches, label: 'Coaches Spots'
- 
+
   .row
     .large-6.columns
       = f.input :level, collection: Sponsor.levels.keys, label_method: :humanize, disabled: !current_user.has_role?(:admin)
@@ -31,6 +31,8 @@
           = a.input :city
           = a.input :latitude
           = a.input :longitude
+          = a.input :directions
+
     .large-6.columns
       .panel
         %strong Contact Details

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -1,22 +1,26 @@
 %section#banner
   .row
-    .large-9.columns
+    .medium-6.large-9.columns
       %h1= @sponsor.name
-    .large-3.columns
-      = link_to 'Edit', edit_admin_sponsor_path(@sponsor), class: 'button round'
+    .medium-6.large-3.columns
+      = link_to 'Edit', edit_admin_sponsor_path(@sponsor), class: 'button small'
 
   .row
-    .large-3.columns
+    .medium-6.large-3.columns
       %h4 Address
-      = AddressPresenter.new(@sponsor.address).to_html
+      %p= AddressPresenter.new(@sponsor.address).to_html
+      %span Directions:
+      %p= @sponsor.address.directions
 
-    .large-3.columns
+    .medium-6.large-3.columns
       %h4 Logo
       = image_tag(@sponsor.avatar, alt: @sponsor.name)
-    .large-3.columns
+
+    .medium-6.large-3.columns
       %h4 Contacts
       = SponsorPresenter.new(@sponsor).contact_info
-    .large-3.columns
+
+    .medium-6.large-3.columns
       %h4 Sponsored
       %ul.no-bullet
         - @sponsor.workshops.each do |workshop|
@@ -25,7 +29,7 @@
               %strong=workshop.chapter.name
               %br
               = humanize_date(workshop.date_and_time, with_time: true)
-  .row
-    .large-6.columns
+
+    .medium-6.large-3.columns
       %h4 Accessibility information
       %p= @sponsor.accessibility_info

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -9,8 +9,10 @@
     .medium-6.large-3.columns
       %h4 Address
       %p= AddressPresenter.new(@sponsor.address).to_html
-      %span Directions:
-      %p= @sponsor.address.directions
+      - if @sponsor.address.directions
+        %p
+          %strong Directions:
+          = @sponsor.address.directions
 
     .medium-6.large-3.columns
       %h4 Logo
@@ -30,6 +32,7 @@
               %br
               = humanize_date(workshop.date_and_time, with_time: true)
 
+  .row
     .medium-6.large-3.columns
       %h4 Accessibility information
       %p= @sponsor.accessibility_info

--- a/app/views/event_invitation_mailer/attending.html.haml
+++ b/app/views/event_invitation_mailer/attending.html.haml
@@ -1,59 +1,46 @@
-=render partial: 'shared_mailers/header', locals: { title: "Attendance Confirmation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Event Attendance Confirmation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Attendance Confirmation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Event Attendance Confirmation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
-
+                %h3 Hi #{@member.name},
                 %p
                   Your spot for the <strong>#{@event.name}</strong> event has been confirmed.
-
                 %p
                   If you have any questions send us an email at #{mail_to(@event.email, @event.email)}.
-
                 %p
                   See you at the event!
 
-
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "50%", style: "vertical-align: top; padding-right:10px;"}
-                %h5 When?
-                #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time) }
-                %br
-                %br
-                %h5 Venue
-                =link_to @event.venue.website do
-                  = @event.venue.name
-                %p
-                  #{@host_address.to_html}
-              %td{ width: "50%", style: "text-align: center;"}
+              %td
                 %h4
-                = link_to "Can't make it anymore?", full_url_for(event_invitation_url(@event.id, @invitation.token)),
-                class: 'btn'
+                  #{@event.name}
+                  %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time)}
+                = link_to 'Update your attendance', full_url_for(event_invitation_url(@event.id, @invitation.token)), class: 'btn'
 
         .content
           %table
+            = render partial: 'shared_mailers/venue', locals: { host: @event.venue, address: @host_address }
             %tr
               %td
-                %p
-                  If you have any trouble finding the venue, give us a call:
-                  %ul
-                    - @event.organisers.each do |organiser|
-                      - if organiser.mobile.present?
-                        %li
-                          = organiser.full_name
-                          =organiser.mobile
+                %p If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
+                  - @event.organisers.each do |organiser|
+                    - if organiser.mobile.present?
+                      %li
+                        = organiser.full_name
+                        = organiser.mobile
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/event_invitation_mailer/invite_coach.html.haml
+++ b/app/views/event_invitation_mailer/invite_coach.html.haml
@@ -1,43 +1,43 @@
-=render partial: 'shared_mailers/header', locals: { title: "Coach Invitation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Coach Event Invitation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  = render partial: 'shared_mailers/body_header', locals: { title: "Coach Invitation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Coach Event Invitation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   We'd like to invite you to #{@event.name}. If you can come, please RSVP using the link in this email.
                 %p
                   #{@event.description.html_safe}.
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "50%", style: "vertical-align: top; padding-right:10px;"}
-                %h5 When?
-                #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time) }
-                %br
-                %br
-                %h5 Venue
-                =link_to @event.venue.website do
-                  =image_tag(@event.venue.avatar, style: 'max-height: 100px', alt: @event.venue.name)
-                %br
-                %br
-              %td{ width: "50%", style: "text-align: center;"}
-                =link_to "RSVP", full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
+              %td
+                %h4
+                  #{@event.name}
+                  %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time)}
+                = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
+
+        .content
+          %table
+            = render partial: 'shared_mailers/venue', locals: { host: @event.venue, address: @host_address }
+
+        .content
+          %table
             %tr
-              %td{ width: "50%", style: "vertical-align: top; padding-right:10px;"}
-                %h5 Sponsors
+              %td
+                %h4 Sponsors
                 - @event.sponsors.each do |sponsor|
-                  =link_to sponsor.website do
+                  = link_to sponsor.website do
                     = image_tag(sponsor.avatar, style: 'max-height: 100px;', alt: sponsor.name)
 
         .content

--- a/app/views/event_invitation_mailer/invite_student.html.haml
+++ b/app/views/event_invitation_mailer/invite_student.html.haml
@@ -1,48 +1,47 @@
-=render partial: 'shared_mailers/header', locals: { title: "Event invitation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Event Invitation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Event invitation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Event Invitation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   We'd like to invite you to #{@event.name}. If you can come, please RSVP using the link in this email.
                 %p
                   #{@event.description.html_safe}.
 
+        .content
+          %table{ bgcolor: '#FFFFFF' }
+            %tr
+              %td
+                %h4
+                  #{@event.name}
+                  %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time)}
+                = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table
+            = render partial: 'shared_mailers/venue', locals: { host: @event.venue, address: @host_address }
+
+        .content
+          %table
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                %h5 When?
-                #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time) }
-                %br
-                %br
-                %h5 Venue
-                =image_tag(@event.venue.avatar, style: 'max-height: 100px', alt: @event.venue.name)
-                %p
-                  #{@event.venue.name}
-              %td{ width: "50%", style: "text-align: center;"}
-                = link_to "RSVP", full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
-            %tr
-              %td{ width: "50%", style: "vertical-align: top; padding-right:10px;"}
-                %h5 Sponsors
+              %td
+                %h4 Sponsors
                 - @event.sponsors.each do |sponsor|
-                  =link_to sponsor.website do
+                  = link_to sponsor.website do
                     = image_tag(sponsor.avatar, style: 'max-height: 100px;', alt: sponsor.name)
 
         .content
           = render partial: 'shared_mailers/social'
-
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -9,35 +9,21 @@
   .row
     .large-10.columns
       = render partial: 'event_actions'
-      %br
-      %br
 
-%br
-%br
 .stripe.reverse
   .row
-    .large-7.columns
+    = render partial: 'shared/venue', locals: { venue: @event.venue, address: @host_address}
+
+  .row
+    .small-12.column
       - if @event.announce_only
         %a{ name: "information" }
-        %h4{ "data-magellan-destination" => "information"} Information
+        %h3{ "data-magellan-destination" => "information"} Information
       - else
         %a{ name: "schedule" }
-        %h4{ "data-magellan-destination" => "schedule"}
+        %h3{ "data-magellan-destination" => "schedule"}
           = t('events.schedule')
       = dot_markdown(@event.schedule)
-    .large-5.columns
-      %h4= t('events.location')
-      .row
-        .medium-8.columns
-          %p
-            = @host_address.to_html
-        .medium-4.columns
-          = image_tag(@event.venue.avatar, class: 'sponsor-logo-image', alt: @event.venue.name)
-      .row
-        .large-12.columns
-          %iframe{ width: '100%', height: '250', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
-          =link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
-        .medium-6.columns
 
 - if @event.show_faq?
   .stripe.reverse
@@ -73,6 +59,7 @@
                   =link_to sponsor.name, sponsor.website
                   %p
                     = sponsor.description
+
 - if @event.verified_coaches.any?
   .stripe.reverse
     .row

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -13,25 +13,24 @@
       This link can be accessed without authentication so please don't share it with others. You can access and share the <strong> #{link_to("public listing", workshop_url(@workshop))}</strong> of the workshop.
 
 
-.stripe
-  .row
-    .large-12.columns
-      %br
-        - if @announcements.present?
+.stripe.reverse
+  - if @announcements.present?
+    .row
+      .large-12.columns
+        %br
           .alert-box.info{ "data-alert" => true }
             =link_to "#", class: 'close' do
               &times;
             %ul.no-bullet
               - @announcements.each do |announcement|
                 %li= dot_markdown(announcement.message)
-  %br
   .row
-    .large-8.columns
+    .medium-7.large-8.columns
       %p
         Hi #{@invitation.member.name},
         = render partial: @invitation.role.downcase
 
-    .large-4.columns
+    .medium-5.large-4.columns
       .panel
         - if @workshop.past?
           %em This workshop has already taken place.
@@ -43,10 +42,9 @@
                 = form_tag update_note_invitation_path(@invitation) do
                   = select_tag :note, options_for_select(@tutorial_titles, @invitation.note)
                   %br
-                  %br
                   = submit_tag 'Update note', class: "expand button small"
             - if @workshop.rsvp_available?
-              =link_to "I can no longer attend", reject_invitation_url(@invitation), class: "expand button small alert"
+              = link_to "I can no longer attend", reject_invitation_url(@invitation), class: "expand button small alert"
             - else
               %p
                 If you can't make it or plan to arrive late please let us know by sending an email to #{@invitation.workshop.chapter.email}
@@ -75,43 +73,26 @@
                   = f.button :submit, "Attend",  class: "button expand round"
               - else
                 = render partial: 'invitation/waiting_list', locals: { invitation: @invitation }
-          Read our #{link_to "attendance policy", attendance_policy_path}
+          Read our #{link_to "attendance policy", attendance_policy_path}.
 
 
-.stripe
+.stripe.reverse
   .row
-    .medium-8.columns
-      %a{ name: "location" }
-      %h4{ "data-magellan-destination" => "location"} Venue
-      %p
-        %strong= @workshop.host.name
-        %br
-          = @host_address.to_html
-        %br
-      %iframe{ width: '100%', height: '350', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
-      =link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
-    .large-4.columns
-      %h4 Sponsors
-      %ul.no-bullet
+    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @host_address}
+
+    .small-12.column
+      %h3 Sponsors
+      %ul.row.no-bullet
         - @workshop.sponsors.each do |sponsor|
-          %li
-            .row
-              .large-4.columns
-                = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
-              .large-8.columns
-                =link_to sponsor.name, sponsor.website
-                %p
-                  = sponsor.description
-          %br
+          %li.small-4.columns
+            = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+            %p
+              = link_to sponsor.name, sponsor.website
 
-.stripe
-  %br
-  %br
+.stripe.reverse
   = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: true }
-  %br
-  %br
 
-.stripe
+.stripe.reverse
   .row
     .medium-6.columns
       %h4 Students (#{@invitation.workshop.attending_students.count})

--- a/app/views/meeting_invitation_mailer/_agenda.html.haml
+++ b/app/views/meeting_invitation_mailer/_agenda.html.haml
@@ -1,0 +1,6 @@
+.content
+  %table
+    %tr
+      %td
+        %h4 Agenda
+        %p= @meeting.description.html_safe

--- a/app/views/meeting_invitation_mailer/_cancel_attendance.html.haml
+++ b/app/views/meeting_invitation_mailer/_cancel_attendance.html.haml
@@ -1,0 +1,8 @@
+.content
+  %table
+    %tr
+      %td
+        %h4
+          Can't make it anymore?
+        %p
+          = "Please #{link_to 'cancel your attendance', @cancellation_url} by following the instructions on the event page.".html_safe

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -1,12 +1,12 @@
-=render partial: 'shared_mailers/header', locals: { title: "codebar Monthly Attendance Confirmation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'codebar Monthly Attendance Confirmation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Attendance Confirmation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'codebar Monthly Attendance Confirmation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
@@ -18,15 +18,17 @@
 
         = render partial: 'agenda'
 
+        = render partial: 'cancel_attendance'
+
         .content
           %table
             %tr
               %td
                 %h4 Details
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+              %td.small{ width: '30%', style: 'vertical-align: top; padding-right: 10px;' }
                 = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: "vertical-align: top;" }
+              %td.small{ style: 'vertical-align: top;' }
                 %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -15,28 +15,26 @@
                 %h3 Hi, #{@member.name}
                 %p.lead
                   A spot opened up for the next codebar Monthly!
-                %h4
-                  Agenda
-                %p
-                  = @meeting.description.html_safe
-                %h4
-                  Can't make it anymore?
-                %p
-                  = "Please #{link_to 'cancel your attendance', @cancellation_url} by following the instructions on the event page.".html_safe
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
               %td
-                %h4
-                  Workshop
-                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
+                %h4 Details
+            %tr
+              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
+              %td.small{ style: "vertical-align: top;" }
+                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br
                   #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
 
         .content
           %table

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -12,7 +12,7 @@
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   A spot opened up for the next codebar Monthly!
 
@@ -22,35 +22,16 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Details
-            %tr
-              %td.small{ width: '30%', style: 'vertical-align: top; padding-right: 10px;' }
-                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: 'vertical-align: top;' }
-                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
-                %p
-                  #{@meeting.venue.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-
-        .content
-          %table
+            = render partial: 'shared_mailers/venue', locals: { host: @meeting.venue, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @meeting.organisers.each do |organiser|
-                    %p
+                    %li
                       = organiser.full_name
                       = organiser.mobile
-                      %br
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -16,6 +16,8 @@
                 %p.lead
                   A spot opened up for the next codebar Monthly!
 
+        = render partial: 'agenda'
+
         .content
           %table
             %tr

--- a/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
+++ b/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
@@ -1,12 +1,12 @@
-=render partial: 'shared_mailers/header', locals: { title: "codebar Monthly Attendance Reminder" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'codebar Monthly Attendance Reminder' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "codebar Monthly Attendance Reminder" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'codebar Monthly Attendance Reminder' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
@@ -22,15 +22,17 @@
 
         = render partial: 'agenda'
 
+        = render partial: 'cancel_attendance'
+
         .content
           %table
             %tr
               %td
                 %h4 Details
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+              %td.small{ width: '30%', style: 'vertical-align: top; padding-right: 10px;' }
                 = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: "vertical-align: top;" }
+              %td.small{ style: 'vertical-align: top;' }
                 %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}

--- a/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
+++ b/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
@@ -14,33 +14,31 @@
               %td
                 %h3 Hi, #{@member.name}
                 %p.lead
-                  This is a quick email to remind you that you have signed up for tomorrow's Monthly.
+                  This is a quick email to remind you that you have signed up for tomorrow's codebar Monthly.
                 %p
                   Please be advised that repeated no-shows to codebar events, including Monthlies, will result in suspension of your invitations. No +1s are allowed for Monthlies.
                 %p
-                  The talks will begin promptly at 7:00, food and drinks will be served from 6:30.
-                %h4
-                  Agenda
-                %p
-                  = @meeting.description.html_safe
-                %h4
-                  Can't make it anymore?
-                %p
-                  = "Please #{link_to 'cancel your attendance', @cancellation_url} by following the instructions on the event page.".html_safe
+                  The talks will begin promptly at 7:00PM, food and drinks will be served from 6:30PM.
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
               %td
-                %h4
-                  Workshop
-                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
+                %h4 Details
+            %tr
+              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
+              %td.small{ style: "vertical-align: top;" }
+                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br
                   #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
 
         .content
           %table

--- a/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
+++ b/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
@@ -20,6 +20,8 @@
                 %p
                   The talks will begin promptly at 7:00PM, food and drinks will be served from 6:30PM.
 
+        = render partial: 'agenda'
+
         .content
           %table
             %tr

--- a/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
+++ b/app/views/meeting_invitation_mailer/attendance_reminder.html.haml
@@ -12,7 +12,7 @@
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   This is a quick email to remind you that you have signed up for tomorrow's codebar Monthly.
                 %p
@@ -26,35 +26,16 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Details
-            %tr
-              %td.small{ width: '30%', style: 'vertical-align: top; padding-right: 10px;' }
-                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: 'vertical-align: top;' }
-                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
-                %p
-                  #{@meeting.venue.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-
-        .content
-          %table
+            = render partial: 'shared_mailers/venue', locals: { host: @meeting.venue, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @meeting.organisers.each do |organiser|
-                    %p
+                    %li
                       = organiser.full_name
                       = organiser.mobile
-                      %br
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -1,12 +1,12 @@
-=render partial: 'shared_mailers/header', locals: { title: "codebar Monthly Attendance Confirmation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'codebar Monthly Attendance Confirmation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Attendance Confirmation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Attendance Confirmation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
@@ -15,28 +15,26 @@
                 %h3 Hi, #{@member.name}
                 %p.lead
                   You're confirmed for the next codebar Monthly!
-                %h4
-                  Agenda
-                %p
-                  = @meeting.description.html_safe
-                %h4
-                  Can't make it anymore?
-                %p
-                  = "Please #{link_to 'cancel your attendance', @cancellation_url} by following the instructions on the event page.".html_safe
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
               %td
-                %h4
-                  Workshop
-                  %small #{humanize_date(@meeting.date_and_time, with_time: true)}
+                %h4 Details
+            %tr
+              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
+              %td.small{ style: "vertical-align: top;" }
+                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br
                   #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
 
         .content
           %table

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -12,7 +12,7 @@
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   You're confirmed for the next codebar Monthly!
 
@@ -22,36 +22,16 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Details
-            %tr
-              %td.small{ width: '30%', style: 'vertical-align: top; padding-right: 10px;' }
-                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: 'vertical-align: top;' }
-                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
-                %p
-                  #{@meeting.venue.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-
-        .content
-          %table
+            = render partial: 'shared_mailers/venue', locals: { host: @meeting.venue, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @meeting.organisers.each do |organiser|
-                    %p
+                    %li
                       = organiser.full_name
                       = organiser.mobile
-                      %br
-
         .content
           = render partial: 'shared_mailers/social'
       %td

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -1,7 +1,7 @@
 = render partial: 'shared_mailers/header', locals: { title: 'codebar Monthly Attendance Confirmation' }
 %body{ bgcolor: '#FFFFFF' }
 
-  = render partial: 'shared_mailers/body_header', locals: { title: 'Attendance Confirmation' }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'codebar Monthly Attendance Confirmation' }
 
   %table{ class: 'body-wrap'}
     %tr
@@ -18,15 +18,17 @@
 
         = render partial: 'agenda'
 
+        = render partial: 'cancel_attendance'
+
         .content
           %table
             %tr
               %td
                 %h4 Details
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+              %td.small{ width: '30%', style: 'vertical-align: top; padding-right: 10px;' }
                 = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: "vertical-align: top;" }
+              %td.small{ style: 'vertical-align: top;' }
                 %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -16,6 +16,8 @@
                 %p.lead
                   You're confirmed for the next codebar Monthly!
 
+        = render partial: 'agenda'
+
         .content
           %table
             %tr

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -1,7 +1,7 @@
-=render partial: 'shared_mailers/header', locals: { title: 'codebar Monthly Invitation' }
+= render partial: 'shared_mailers/header', locals: { title: 'codebar Monthly Invitation' }
 %body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: 'Monthly Talks Night Invitation' }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'codebar Monthly Invitation' }
 
   %table{ class: 'body-wrap'}
     %tr
@@ -17,31 +17,33 @@
                   We're back for another installment of codebar Monthlies on #{humanize_date(@meeting.date_and_time)} at #{@meeting.venue.name}!
                 %p
                   = "#{link_to 'You can RSVP here', @rsvp_url}, after logging into your codebar account.".html_safe
-                %h4
-                  Agenda
-                %p
-                  = @meeting.description.html_safe
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
               %td
-                %h4
-                  Details
-                %small #{humanize_date(@meeting.date_and_time, with_time: true)}
+                %h4 Details
+            %tr
+              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
+                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
+              %td.small{ style: "vertical-align: top;" }
+                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
                 %p
                   #{@meeting.venue.name}
                   %br
                   #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
 
         .content
           %table
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call
+                  If you have any trouble finding the venue, give us a call.
                   - @meeting.organisers.each do |organiser|
                     %p
                       = organiser.full_name

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -12,7 +12,7 @@
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   We're back for another installment of codebar Monthlies on #{humanize_date(@meeting.date_and_time)} at #{@meeting.venue.name}!
                 %p
@@ -22,35 +22,16 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Details
-            %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right: 10px;" }
-                = image_tag(@meeting.venue.avatar, alt: @meeting.venue.name)
-              %td.small{ style: "vertical-align: top;" }
-                %p #{humanize_date(@meeting.date_and_time, with_time: true)}
-                %p
-                  #{@meeting.venue.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-
-        .content
-          %table
+            = render partial: 'shared_mailers/venue', locals: { host: @meeting.venue, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call.
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @meeting.organisers.each do |organiser|
-                    %p
+                    %li
                       = organiser.full_name
                       = organiser.mobile
-                      %br
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -18,6 +18,8 @@
                 %p
                   = "#{link_to 'You can RSVP here', @rsvp_url}, after logging into your codebar account.".html_safe
 
+        = render partial: 'agenda'
+
         .content
           %table
             %tr

--- a/app/views/meetings/_meeting_actions.html.haml
+++ b/app/views/meetings/_meeting_actions.html.haml
@@ -1,9 +1,15 @@
 - if @meeting.venue.present?
   %h4 Venue
-  %strong= @meeting.venue.name
+  %p
+    %strong= @meeting.venue.name
+  .monthly-host-logo
+    = image_tag(@meeting.venue.avatar.thumb, alt: @meeting.venue.name)
+  %strong Address
   %p= @host_address
-  = image_tag(@meeting.venue.avatar.thumb, class: 'monthly_host_logo', alt: @meeting.venue.name)
-  - if @meeting.venue.accessibility_info.present?
+  - if @host_address.directions
+    %strong Directions
+    %p= @host_address.directions
+  - if @meeting.venue.accessibility_info
     %strong Accessibility information
     %p= @meeting.venue.accessibility_info
 

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -7,7 +7,7 @@
         %small=humanize_date(@meeting.date_and_time, with_time: true)
 
   .row
-    .medium-4.columns#host
+    .medium-4.columns
       = render partial: 'meeting_actions'
 
     .medium-8.columns

--- a/app/views/shared/_venue.html.haml
+++ b/app/views/shared/_venue.html.haml
@@ -1,0 +1,21 @@
+.small-12.column
+  %h3 Venue
+.medium-6.columns
+  %p
+    %strong= venue.name
+    %br
+      = address.to_html
+
+  - if address.directions
+    %p
+      %strong Directions:
+      = address.directions
+
+  - if venue.accessibility_info
+    %p
+      %strong Accessibility information:
+      = venue.accessibility_info
+
+.medium-6.columns
+  %iframe{ width: '100%', height: '350', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
+  = link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"

--- a/app/views/shared_mailers/_venue.html.haml
+++ b/app/views/shared_mailers/_venue.html.haml
@@ -4,13 +4,13 @@
 %tr
   %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
     %p
-      %strong #{@workshop.host.name}
+      %strong #{host.name}
       %br
-      #{@host_address.to_html}
-    - if @workshop.host.address.directions
+      #{address.to_html}
+    - if host.address.directions
       %p
         %strong Directions:
         %br
-        #{@workshop.host.address.directions}
+        #{host.address.directions}
   %td{ width: '30%', style: 'vertical-align: top;' }
-    = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
+    = image_tag(host.avatar, alt: host.name)

--- a/app/views/shared_mailers/_venue.html.haml
+++ b/app/views/shared_mailers/_venue.html.haml
@@ -1,0 +1,16 @@
+%tr
+  %td
+    %h4 Venue
+%tr
+  %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
+    %p
+      %strong #{@workshop.host.name}
+      %br
+      #{@host_address.to_html}
+    - if @workshop.host.address.directions
+      %p
+        %strong Directions:
+        %br
+        #{@workshop.host.address.directions}
+  %td{ width: '30%', style: 'vertical-align: top;' }
+    = image_tag(@workshop.host.avatar, alt: @workshop.host.name)

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -37,16 +37,16 @@
 
         .content
           %table
-            = render 'shared_mailers/venue'
+            = render partial: 'shared_mailers/venue', locals: { host: @workshop.host, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call:
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @workshop.organisers.each do |organiser|
-                    %p
+                    %li
                       = organiser.full_name
                       = organiser.mobile
-                      %br
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -37,22 +37,7 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Venue
-            %tr
-              %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
-                %p
-                  %strong #{@workshop.host.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-              %td{ width: '30%', style: 'vertical-align: top;' }
-                = image_tag(@workshop.venue.avatar, alt: @workshop.venue.name)
+            = render 'shared_mailers/venue'
             %tr
               %td
                 %p

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -1,64 +1,66 @@
-=render partial: 'shared_mailers/header', locals: { title: "Workshop Attendance Confirmation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Workshop Attendance Confirmation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Workshop Attendance Confirmation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Workshop Attendance Confirmation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   - if @waiting_list
                     A spot became available and your attendance has now been confirmed.
                   - else
                     Your spot has been confirmed.
-                    - if @invitation.role.eql?("Student")
-                      If you haven't already, please remember to let us know what you will be working on through the invitation.
-                      Projects that involve specific frameworks, libraries, or languages that are not part of the codebar tutorials
-                      (anything other than Ruby or Javascript) are welcome, but we cannot guarantee that a coach will be available to help you.
-                      We recommend having a backup option to work on, such as codebar tutorials or katas (codewars.com or exercism.io).
-                      See you at our workshop!
-
+                    - if @invitation.role.eql?('Student')
+                      %p If you haven't already, please remember to let us know what you will be working on through the invitation. Projects that involve specific frameworks, libraries, or languages that are not part of the codebar tutorials (anything other than Ruby or Javascript) are welcome, but we cannot guarantee that a coach will be available to help you. We recommend having a backup option to work on, such as codebar tutorials or katas (codewars.com or exercism.io). See you at our workshop!
                   %p
-                    If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.
-                    <a href="https://codebar.io/student-guide#attendance">We have a three-strikes attendance policy for no-shows.</a>
-
+                    If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the workshop.
+                    <a href='https://codebar.io/student-guide#attendance'>We have a three-strikes attendance policy for no-shows.</a>
                   %p
                     Please remember that removing the calendar entry will not cancel your invitation RSVP.
 
-
-
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@workshop.venue.avatar, alt: @workshop.venue.name)
               %td
                 %h4
                   Workshop
                   %small #{humanize_date(@workshop.date_and_time, with_time: true)}
-                %p
-                  #{@workshop.host.name}
-                  %br
-                  #{@host_address.to_html}
-                = link_to "Update your attendance", full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table
             %tr
               %td
+                %h4 Venue
+            %tr
+              %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
                 %p
-                  If you have any trouble finding the venue, give us a call
+                  %strong #{@workshop.host.name}
+                  %br
+                  #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
+              %td{ width: '30%', style: 'vertical-align: top;' }
+                = image_tag(@workshop.venue.avatar, alt: @workshop.venue.name)
+            %tr
+              %td
+                %p
+                  If you have any trouble finding the venue, give us a call:
                   - @workshop.organisers.each do |organiser|
                     %p
                       = organiser.full_name
-                      =organiser.mobile
+                      = organiser.mobile
                       %br
 
         .content

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -1,48 +1,57 @@
-=render partial: 'shared_mailers/header', locals: { title: "Workshop Attendance Reminder" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Workshop Attendance Reminder' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Workshop Attendance Reminder" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Workshop Attendance Reminder' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   This is a quick email to remind you that you have signed up for tomorrow's workshop.
                 %p
                   If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.
-                  <a href="https://codebar.io/student-guide#attendance">We have a three-strikes attendance policy for no-shows.</a>
+                  <a href='https://codebar.io/student-guide#attendance'>We have a three-strikes attendance policy for no-shows.</a>
                 %p
-                  <strong>Please do not turn up before #{(@workshop.date_and_time).strftime("%H:%M")}.</strong> If you are early, please wait in a nearby cafe.
-
+                  <strong>Please do not turn up before #{(@workshop.date_and_time).strftime('%H:%M')}.</strong> If you are early, please wait in a nearby cafe.
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@workshop.host.avatar, alt: @workshop.host.name)
               %td
                 %h4
                   Workshop
-                  %small= humanize_date(@workshop.date_and_time, with_time: true)
-                %p
-                  #{@workshop.host.name}
-                  %br
-                  #{@host_address.to_html}
-                = link_to "Update your attendance", full_url_for(invitation_url(@invitation)), class: 'btn'
+                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}
+                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table
             %tr
               %td
+                %h4 Venue
+            %tr
+              %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
                 %p
-                  If you have any trouble finding the venue call
+                  %strong #{@workshop.host.name}
+                  %br
+                  #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
+              %td{ width: '30%', style: 'vertical-align: top;' }
+                = image_tag(@workshop.venue.avatar, alt: @workshop.venue.name)
+            %tr
+              %td
+                %p
+                  If you have any trouble finding the venue, give us a call:
                   - @workshop.organisers.each do |organiser|
                     %p
                       = organiser.full_name

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -32,22 +32,7 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Venue
-            %tr
-              %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
-                %p
-                  %strong #{@workshop.host.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-              %td{ width: '30%', style: 'vertical-align: top;' }
-                = image_tag(@workshop.venue.avatar, alt: @workshop.venue.name)
+            = render 'shared_mailers/venue'
             %tr
               %td
                 %p

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -32,13 +32,14 @@
 
         .content
           %table
-            = render 'shared_mailers/venue'
+            = render partial: 'shared_mailers/venue', locals: { host: @workshop.host, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call:
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @workshop.organisers.each do |organiser|
-                    %p
+                    %li
                       = organiser.full_name
                       = organiser.mobile
 

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -1,44 +1,44 @@
-=render partial: 'shared_mailers/header', locals: { title: "Workshop Coach Invitation" }
-%body{ bgcolor: "#FFFFFF" }
+=render partial: 'shared_mailers/header', locals: { title: 'Workshop Coach Invitation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Workshop Coach Invitation" }
+  =render partial: 'shared_mailers/body_header', locals: { title: 'Workshop Coach Invitation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
-                  Invites for our next workshop are now open and we are looking for coaches. The workshop that will take place on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  Invites for our next workshop are now open and we are looking for coaches. The workshop will take place on #{humanize_date(@workshop.date_and_time, with_time: true)}.
 
                 %p At the workshop you will be helping students as they work their way through one of our tutorials or a personal project they need help. Don't worry we'll only match you with someone who you'll be able to help.
 
-                %p You can find all of our tutorials at #{link_to "http://tutorials.codebar.io/", "http://tutorials.codebar.io/"}. If you would like to improve any of the existing content, you can issue a pull request to our #{link_to "GitHub repository", "https://github.com/codebar/tutorials"}
+                %p You can find all of our tutorials at #{link_to 'http://tutorials.codebar.io/', 'http://tutorials.codebar.io/'}. If you would like to improve any of the existing content, you can issue a pull request to our #{link_to 'GitHub repository', 'https://github.com/codebar/tutorials'}
 
-                %p Before attending, make sure you have read and understood our #{link_to "Code of Conduct", "http://codebar.io/code-of-conduct"}. We have a zero tolerance policy towards conduct and expect everyone to behave appropriately. You should also go through our #{link_to "How to be an effective teacher", "http://codebar.io/effective-teacher-guide"}.
+                %p Before attending, make sure you have read and understood our #{link_to 'Code of Conduct', 'http://codebar.io/code-of-conduct'}. We have a zero tolerance policy towards conduct and expect everyone to behave appropriately. You should also go through our #{link_to 'How to be an effective teacher', 'http://codebar.io/effective-teacher-guide'}.
 
                 %p Please note: We do not accept any RSVPs over email.
 
-                %p.callout #{link_to "Join us on Slack", "https://codebar-slack.herokuapp.com"} to offer help and guidance outside the workshops.
+                %p.callout #{link_to 'Join us on Slack', 'https://codebar-slack.herokuapp.com'} to offer help and guidance outside the workshops.
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@workshop.host.avatar, alt: @workshop.host.name)
-              %td
+              %td{ width: '60%', style: 'vertical-align: top; padding-right: 20px;' }
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}
-                %p
-                  %b Venue
-                  #{@workshop.host.name}
-                =link_to "View invitation and RSVP", full_url_for(invitation_url(@invitation)), class: 'btn'
+                  %small= humanize_date(@workshop.date_and_time, with_time: true)
+                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+              %td{ width: '40%', style: 'vertical-align: top;'}
+                %h4
+                  Venue
+                  %small= @workshop.host.name
+                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -1,45 +1,42 @@
-=render partial: 'shared_mailers/header', locals: { title: "Workshop Student Invitation" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Workshop Student Invitation' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Workshop Student Invitation" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Workshop Student Invitation' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
-
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
         .content
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   If you would like to attend the workshop please RSVP as we need to know who is coming to make sure we have enough coaches and food.
                 %p
-                  In our workshops, you can work through any of our #{link_to "tutorials", "http://codebar.github.io/tutorials" } or get help and guidance on another technology for your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to "a lot of devoted developers", full_url_for(coaches_url)} who help out by coaching.
+                  In our workshops, you can work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or get help and guidance on another technology for your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', full_url_for(coaches_url)} who help out by coaching.
                 %p You will also get the opportunity to meet other people interested in coding and collaborate with them.
                 %p Please note: We do not accept any RSVPs over email.
 
-                %p.callout If you are working through the tutorials outside our workshop, or need any other help or advice #{ link_to "join the codebar Slack", "https://codebar-slack.herokuapp.com"}.
-
+                %p.callout If you are working through the tutorials outside our workshop, or need any other help or advice #{ link_to 'join the codebar Slack', 'https://codebar-slack.herokuapp.com'}.
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@workshop.host.avatar, alt: @workshop.host.name)
-              %td
+              %td{ width: '60%', style: 'vertical-align: top; padding-right: 20px;' }
                 %h4
                   Workshop
                   %small= humanize_date(@workshop.date_and_time, with_time: true)
-                %p
-                  %b Venue
-                  #{@workshop.host.name}
-                =link_to "RSVP", full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+              %td{ width: '40%', style: 'vertical-align: top;'}
+                %h4
+                  Venue
+                  %small= @workshop.host.name
+                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
 
         .content
           = render partial: 'shared_mailers/social'
-
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -1,12 +1,12 @@
-=render partial: 'shared_mailers/header', locals: { title: "Waiting List" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Waiting List' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Waiting List spot available" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Waiting List spot available' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
@@ -17,26 +17,36 @@
                   A spot just opened up for the workshop. If you would like to attend, please RSVP.
 
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@workshop.venue.avatar, @workshop.venue.name)
               %td
                 %h4
                   Workshop
                   %small #{humanize_date(@workshop.date_and_time, with_time: true)}
-                %p
-                  #{@workshop.venue.name}
-                  %br
-                  #{@host_address.to_html}
-                = link_to "RSVP", full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table
             %tr
               %td
+                %h4 Venue
+            %tr
+              %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
                 %p
-                  If you have any trouble finding the venue call
+                  %strong #{@workshop.host.name}
+                  %br
+                  #{@host_address.to_html}
+                - if @host_address.directions
+                  %p
+                    %strong Directions:
+                    %br
+                    #{@host_address.directions}
+              %td{ width: '30%', style: 'vertical-align: top;' }
+                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
+            %tr
+              %td
+                %p
+                  If you have any trouble finding the venue, give us a call:
                   - @workshop.organisers.each do |organiser|
                     - if organiser.mobile.present?
                       %p

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -12,7 +12,7 @@
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   A spot just opened up for the workshop. If you would like to attend, please RSVP.
 
@@ -27,16 +27,17 @@
 
         .content
           %table
-            = render 'shared_mailers/venue'
+            = render partial: 'shared_mailers/venue', locals: { host: @workshop.host, address: @host_address }
             %tr
               %td
                 %p
-                  If you have any trouble finding the venue, give us a call:
+                  If you have any trouble finding the venue, give one of the organisers a call:
+                %ul
                   - @workshop.organisers.each do |organiser|
                     - if organiser.mobile.present?
-                      %p
-                        = organiser.full_name
-                        = organiser.mobile
+                    %li
+                      = organiser.full_name
+                      = organiser.mobile
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -27,22 +27,7 @@
 
         .content
           %table
-            %tr
-              %td
-                %h4 Venue
-            %tr
-              %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
-                %p
-                  %strong #{@workshop.host.name}
-                  %br
-                  #{@host_address.to_html}
-                - if @host_address.directions
-                  %p
-                    %strong Directions:
-                    %br
-                    #{@host_address.directions}
-              %td{ width: '30%', style: 'vertical-align: top;' }
-                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
+            = render 'shared_mailers/venue'
             %tr
               %td
                 %p

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -1,45 +1,42 @@
-=render partial: 'shared_mailers/header', locals: { title: "Workshop Waiting List Reminder" }
-%body{ bgcolor: "#FFFFFF" }
+= render partial: 'shared_mailers/header', locals: { title: 'Workshop Waiting List Reminder' }
+%body{ bgcolor: '#FFFFFF' }
 
-  =render partial: 'shared_mailers/body_header', locals: { title: "Workshop Waiting List Reminder" }
+  = render partial: 'shared_mailers/body_header', locals: { title: 'Workshop Waiting List Reminder' }
 
-  %table{ class: "body-wrap"}
+  %table{ class: 'body-wrap'}
     %tr
       %td
-      %td{ class: "container", bgcolor: "#FFFFFF" }
+      %td{ class: 'container', bgcolor: '#FFFFFF' }
 
         .content
           %table
             %tr
               %td
-                %h3 Hi, #{@member.name}
+                %h3 Hi #{@member.name},
                 %p.lead
                   This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(@workshop.date_and_time, with_time: true)}.
                 %p
-                  If an attendee drops out, the next person on the waiting list will automatically get their place.
-                  We'll email you if this happens.
+                  If an attendee drops out, the next person on the waiting list will automatically get their place. We'll email you if this happens.
                   %strong Attendees often drop out at short notice,
                   so you should keep your laptop with you and check your email during the afternoon on the day of the workshop.
                 %p
                   Alternatively, if you know you can no longer make it, you should
-                  = link_to "remove yourself from the waiting list", full_url_for(invitation_url(@invitation))
+                  = link_to 'remove yourself from the waiting list', full_url_for(invitation_url(@invitation))
                   so someone else can come to the workshop.
 
-
         .content
-          %table{ bgcolor: "#FFFFFF" }
+          %table{ bgcolor: '#FFFFFF' }
             %tr
-              %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@workshop.host.avatar, alt: @workshop.host.name)
-              %td
+              %td{ width: '60%', style: 'vertical-align: top; padding-right: 20px;' }
                 %h4
                   Workshop
                   %small= humanize_date(@workshop.date_and_time, with_time: true)
-                %p
-                  #{@workshop.host.name}
-                  %br
-                  #{@host_address.to_html}
-                = link_to "Update your attendance", full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+              %td{ width: '40%', style: 'vertical-align: top;'}
+                %h4
+                  Venue
+                  %small= @workshop.host.name
+                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/workshops/_workshop_actions.html.haml
+++ b/app/views/workshops/_workshop_actions.html.haml
@@ -1,18 +1,17 @@
-%p
-  - if !@workshop.invitable_yet?
-    This workshop is not yet open for RSVP.
+- if !@workshop.invitable_yet?
+  %p This workshop is not yet open for RSVP.
+- else
+  - if @workshop.past?
+    - unless logged_in?
+      %p Sign up to be invited to future events.
   - else
-    - if @workshop.past?
-      - unless logged_in?
-        Sign up to be invited to future events.
-    - else
-      - if logged_in?
-        - if @workshop.attendee? current_user
-          You are attending this event.
-        - elsif @workshop.waitlisted? current_user
-          You are on the waiting List.
-        - elsif !@workshop.spaces?
-          Unfortunately this workshop is full, but do join the waiting list as spots open up in the lead up to the workshop.
+    - if logged_in?
+      - if @workshop.attendee? current_user
+        %p You are attending this event.
+      - elsif @workshop.waitlisted? current_user
+        %p You are on the waiting List.
+      - elsif !@workshop.spaces?
+        %p Unfortunately this workshop is full, but do join the waiting list as spots open up in the lead up to the workshop.
 
 - if logged_in? && @workshop.future? && (@workshop.invitable || @workshop.open_for_rsvp?)
   - if @workshop.attendee?(current_user)

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -1,50 +1,33 @@
-#container
-  .stripe.reverse
+.stripe.reverse
+  .row
+    .large-12.columns
+      %h2
+        Workshop at #{@workshop.host.name}
+        %br
+        %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
+      - if @workshop.date_and_time.past?
+        %label.label.warning This event has already taken place.
+  %section#banner
     .row
-      .large-12.columns
-        %h2
-          Workshop at #{@workshop.host.name}
-          %br
-          %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
-        - if @workshop.date_and_time.past?
-          %label.label.warning This event has already taken place.
-    %section#banner
-      .container
-        .row
-          .medium-12.columns
-            %p.lead
-              Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students.
+      .medium-12.columns
+        %p.lead
+          Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students.
 
-            - unless current_user and current_user.banned?
-              .medium-12.columns
-                = render 'workshop_actions'
+        - unless current_user and current_user.banned?
+          = render 'workshop_actions'
 
-  .stripe.reverse
-    .row
-      .medium-8.columns
-        %h3 Venue
-        %p
-          %strong= @workshop.host.name
-          %br
-            = @host_address.to_html
-          %br
-        - if @workshop.host.accessibility_info
-          %p
-            %strong Accessibility information:
-            = @workshop.host.accessibility_info
-        %iframe{ width: '100%', height: '350', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
-        = link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
-      .large-4.columns
-        %h3 Sponsors
-        %ul.no-bullet
-          - @workshop.sponsors.each do |sponsor|
-            %li
-              .row
-                .large-5.columns
-                  .sponsor-image
-                    =link_to sponsor.website do
-                      =image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
-            %br
+.stripe.reverse
+  .row
+    = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @host_address}
 
-  .stripe.reverse
-    = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: false }
+    .small-12.column
+      %h3 Sponsors
+      %ul.row.no-bullet
+        - @workshop.sponsors.each do |sponsor|
+          %li.small-4.columns
+            = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+            %p
+              = link_to sponsor.name, sponsor.website
+
+.stripe.reverse
+  = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: false }

--- a/db/migrate/20180608010545_add_directions_to_addresses.rb
+++ b/db/migrate/20180608010545_add_directions_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddDirectionsToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :directions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180519231943) do
+ActiveRecord::Schema.define(version: 20180608010545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20180519231943) do
     t.string   "city"
     t.string   "latitude"
     t.string   "longitude"
+    t.text     "directions"
   end
 
   create_table "announcements", force: :cascade do |t|

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -49,6 +49,7 @@ feature 'Managing sponsors' do
         visit edit_admin_sponsor_path(sponsor)
 
         fill_in 'Accessibility information', with: 'This venue is fully accessible to wheelchair users.'
+        fill_in 'Directions', with: 'Office is located on the third floor.'
 
         click_on 'Save changes'
 

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe EventInvitationMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
-  let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Event of the day') }
+  let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }
   let(:member) { Fabricate(:member) }
   let(:invitation) { Fabricate(:invitation, event: event, member: member) }
 
@@ -16,6 +16,13 @@ describe EventInvitationMailer do
   it '#invite_coach' do
     email_subject = "Coach Invitation: #{event.name}"
     EventInvitationMailer.invite_coach(event, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+  end
+
+  it '#attending' do
+    email_subject = "Your spot to #{event.name} has been confirmed."
+    EventInvitationMailer.attending(event, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
   end

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match('This is a quick email to remind you that you have signed up for tomorrow\'s Monthly.')
+      expect(mail.body.encoded).to match('This is a quick email to remind you that you have signed up for tomorrow\'s codebar Monthly.')
     end
   end
 end

--- a/spec/mailers/previews/event_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/event_invitation_mailer_preview.rb
@@ -1,0 +1,13 @@
+class EventInvitationMailerPreview < ActionMailer::Preview
+  def invite_student
+    EventInvitationMailer.invite_student(Event.last, Member.last, Invitation.last)
+  end
+
+  def invite_coach
+    EventInvitationMailer.invite_coach(Event.last, Member.last, Invitation.last)
+  end
+
+  def attending
+    EventInvitationMailer.attending(Event.last, Member.last, Invitation.last)
+  end
+end

--- a/spec/mailers/previews/meeting_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/meeting_invitation_mailer_preview.rb
@@ -1,5 +1,17 @@
 class MeetingInvitationMailerPreview < ActionMailer::Preview
   def invite
-    MeetingInvitationMailer.invite(Meeting.first, Member.last)
+    MeetingInvitationMailer.invite(Meeting.last, Member.last)
+  end
+
+  def attending
+    MeetingInvitationMailer.attending(Meeting.last, Member.last)
+  end
+
+  def approve_from_waitlist
+    MeetingInvitationMailer.approve_from_waitlist(Meeting.last, Member.last)
+  end
+
+  def attendance_reminder
+    MeetingInvitationMailer.attendance_reminder(Meeting.last, Member.last)
   end
 end

--- a/spec/mailers/previews/workshop_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/workshop_invitation_mailer_preview.rb
@@ -1,9 +1,25 @@
 class WorkshopInvitationMailerPreview < ActionMailer::Preview
   def invite_coach
-    WorkshopInvitationMailer.invite_coach(Workshop.first, Member.last, WorkshopInvitation.first)
+    WorkshopInvitationMailer.invite_coach(Workshop.last, Member.last, WorkshopInvitation.first)
   end
 
   def invite_student
-    WorkshopInvitationMailer.invite_coach(Workshop.first, Member.first, SessionInvitation.first)
+    WorkshopInvitationMailer.invite_student(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def attending
+    WorkshopInvitationMailer.attending(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def attending_reminder
+    WorkshopInvitationMailer.attending_reminder(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def waiting_list_reminder
+    WorkshopInvitationMailer.waiting_list_reminder(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def notify_waiting_list
+    WorkshopInvitationMailer.notify_waiting_list(WorkshopInvitation.first)
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,5 +6,9 @@ describe Address do
   it { should respond_to(:sponsor) }
   it { should respond_to(:flat) }
   it { should respond_to(:street) }
+  it { should respond_to(:city) }
+  it { should respond_to(:latitude) }
+  it { should respond_to(:longitude) }
   it { should respond_to(:postal_code) }
+  it { should respond_to(:directions) }
 end


### PR DESCRIPTION
## Description
This PR tackles #489 and adds an extra info field to address (called directions) that can be used to add directions as free text to addresses that are hard to find. Directions are then showed on workshop, meeting and events pages as needed and also in every email we send out that includes a host address. This PR also tackles some refactoring of the email templates: markup clean up, moving often repeated code into partials and adding previews for all emails for all event types.

## Status
Ready for Review

## Related Github issue / Trello cards
#489 

## Screenshots

## Self-review checklist
* [x] Tests are written and passing
* [x] Rubocop passing on new code