### PR TITLE
Etag events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ TAGS
 
 # Local ruby version
 .ruby-version
+
+# Ignore local uploads
+public/uploads/

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,6 +6,8 @@ class EventsController < ApplicationController
   RECENT_EVENTS_DISPLAY_LIMIT = 40
 
   def index
+    fresh_when(latest_model_updated, etag: latest_model_updated)
+    
     events = [Workshop.past.includes(:chapter).limit(RECENT_EVENTS_DISPLAY_LIMIT)]
     events << Course.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events << Meeting.past.includes(:venue).limit(RECENT_EVENTS_DISPLAY_LIMIT)
@@ -54,6 +56,16 @@ class EventsController < ApplicationController
   end
 
   private
+  
+  def latest_model_updated
+    [
+      Workshop.maximum(:updated_at),
+      Course.maximum(:updated_at),
+      Meeting.maximum(:updated_at),
+      Event.maximum(:updated_at),
+      Member.maximum(:updated_at)
+    ].compact.max
+  end
 
   def find_invitation_and_redirect_to_event(role)
     set_event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,7 @@ class EventsController < ApplicationController
 
   def index
     fresh_when(latest_model_updated, etag: latest_model_updated)
-    
+
     events = [Workshop.past.includes(:chapter).limit(RECENT_EVENTS_DISPLAY_LIMIT)]
     events << Course.past.limit(RECENT_EVENTS_DISPLAY_LIMIT)
     events << Meeting.past.includes(:venue).limit(RECENT_EVENTS_DISPLAY_LIMIT)
@@ -56,7 +56,7 @@ class EventsController < ApplicationController
   end
 
   private
-  
+
   def latest_model_updated
     [
       Workshop.maximum(:updated_at),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,8 @@ RSpec.configure do |config|
       example.run
     end
   end
+  
+  config.example_status_persistence_file_path = 'tmp/spec_failures'
 
   if Bullet.enable?
     config.around(:each) do |example|


### PR DESCRIPTION
Etags allows the server to communicate to the browser if the page is unchanged.
If this is the case, it will tell the browser just that; Rails will not continue processing the action.

In this case, the events endpoint is quite slow. This mitigates that problem on subsequent page views.

([I wrote blog post](https://eola.co.uk/blog/how-to-make-your-site-faster) quite recently on some speed tricks aimed at more junior devs, if anyone's interested)

----------

This PR also adds public/uploads to the .gitignore, preventing accidental commits of local images

----------

Also, another tiny change - getting rspec to save the results of the last run allows a faster test cycle with `rspec --only-failures`