### PR TITLE
(fix) remove default_scope from Chapter

### DIFF
--- a/app/controllers/admin/portal_controller.rb
+++ b/app/controllers/admin/portal_controller.rb
@@ -3,11 +3,11 @@ class Admin::PortalController < Admin::ApplicationController
     authorize :admin_portal
 
     @jobs_pending_approval = Job.where(approved: false, submitted: true).count
-    @sponsors = Sponsor.last(5)
-    @chapters = Chapter.all
+    @chapters = Chapter.active.all
     @workshops = Workshop.upcoming
-    @groups = Group.includes(:chapter)
-    @subscribers = Subscription.order('created_at DESC').limit(20).includes(:member, :group)
+    @groups = Group.joins(:chapter).merge(@chapters)
+    @subscribers = Subscription.joins(:chapter).merge(@chapters)
+                               .ordered.limit(20).includes(:member, :group)
   end
 
   def guide

--- a/app/controllers/chapter_controller.rb
+++ b/app/controllers/chapter_controller.rb
@@ -1,6 +1,6 @@
 class ChapterController < ApplicationController
   def show
-    chapter = Chapter.find_by!(slug: slug)
+    chapter = Chapter.active.find_by!(slug: slug)
     @chapter = ChapterPresenter.new(chapter)
 
     events = @chapter.upcoming_workshops.includes(:sponsors).sort_by(&:date_and_time).group_by(&:date)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,7 +5,7 @@ class DashboardController < ApplicationController
   helper_method :year_param
 
   def show
-    @chapters = Chapter.all.order(:created_at)
+    @chapters = Chapter.active.all.order(:created_at)
     @user = current_user ? MemberPresenter.new(current_user) : nil
     @upcoming_workshops = upcoming_events.map.inject({}) do |hash, (key, value)|
       hash[key] = EventPresenter.decorate_collection(value)

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -18,8 +18,6 @@ class Chapter < ActiveRecord::Base
 
   scope :active, -> { where(active: true) }
 
-  default_scope -> { active }
-
   delegate :upcoming, to: :workshops, prefix: true
 
   def self.available_to_user(user)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,7 +6,7 @@ class Subscription < ActiveRecord::Base
   has_one :chapter, through: :group
 
   validates_uniqueness_of :group, scope: :member_id
-  scope :ordered, -> { order(:created_at) }
+  scope :ordered, -> { order(created_at: :desc) }
 
   after_create :subscribe_to_mailing_list
   after_destroy :unsubscribe_from_mailing_list

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -3,7 +3,7 @@
     .large-12.columns
       %h4= @chapter.name
       %p.lead
-        = raw t('chapters.intro', email: @chapter.email)
+        = t('chapters.intro', email: @chapter.email).html_safe
       - if logged_in?
         = render partial: 'subscriptions'
       - else

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -1,38 +1,51 @@
 require 'spec_helper'
 
 feature 'viewing a Chapter' do
-  it 'a visitor to the website cannot access non active chapters' do
-    inactive_chapter = Fabricate(:chapter, active: false)
-    visit chapter_path(inactive_chapter.slug)
+  context 'non active chapters' do
+    let(:inactive_chapter) { Fabricate(:chapter, active: false) }
 
-    expect(page).to have_content('Page not found')
-  end
+    it 'a visitor to the website cannot access non active chapters' do
+      visit chapter_path(inactive_chapter.slug)
 
-  it 'a visitor to the website cannot access non existing chapter pages' do
-    visit chapter_path('test')
-
-    expect(page).to have_content('Page not found')
-  end
-
-  it 'renders any upcoming workshops for the chapter' do
-    chapter = Fabricate(:chapter)
-    workshops = 2.times.map do |n|
-      Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.now + 9.days - n.weeks)
+      expect(page).to have_content('Page not found')
     end
 
-    visit chapter_path(chapter.slug)
-    workshops.each do |workshop|
-      expect(page).to have_content "Workshop at #{workshop.host.name}"
+    it 'a visitor to the website can access inactive chapter events' do
+      past_workshop = Fabricate(:workshop, chapter: inactive_chapter, date_and_time: Time.zone.today-2.week)
+
+      visit workshop_path(past_workshop)
+
+      expect(page).to have_content "Workshop at #{past_workshop.host.name}"
     end
   end
 
-  it 'renders the most recent past workshop for the chapter' do
-    chapter = Fabricate(:chapter)
-    past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today-2.week)
-    recent_past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today-1.week)
+  context 'actigve chapters' do
+    it 'a visitor to the website cannot access non existing chapter pages' do
+      visit chapter_path('test')
 
-    visit chapter_path(chapter.slug)
-    expect(page).to have_content "Workshop at #{recent_past_workshop.host.name}"
-    expect(page).to_not have_content "Workshop at #{past_workshop.host.name}"
+      expect(page).to have_content('Page not found')
+    end
+
+    it 'renders any upcoming workshops for the chapter' do
+      chapter = Fabricate(:chapter)
+      workshops = 2.times.map do |n|
+        Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.now + 9.days - n.weeks)
+      end
+
+      visit chapter_path(chapter.slug)
+      workshops.each do |workshop|
+        expect(page).to have_content "Workshop at #{workshop.host.name}"
+      end
+    end
+
+    it 'renders the most recent past workshop for the chapter' do
+      chapter = Fabricate(:chapter)
+      past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today-2.week)
+      recent_past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today-1.week)
+
+      visit chapter_path(chapter.slug)
+      expect(page).to have_content "Workshop at #{recent_past_workshop.host.name}"
+      expect(page).to_not have_content "Workshop at #{past_workshop.host.name}"
+    end
   end
 end

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -29,6 +29,21 @@ feature 'when visiting the homepage' do
     expect(page).to have_content 'The Long Version'
   end
 
+  scenario 'I can only view active chapters' do
+    inactive_chapters = Fabricate.times(3, :chapter, active: false)
+    active_chapters = Fabricate.times(4, :chapter)
+
+    visit root_path
+
+    active_chapters.each do |chapter|
+      expect(page).to have_content(chapter.name)
+    end
+
+    inactive_chapters.each do |chapter|
+      expect(page).to_not have_content(chapter.name)
+    end
+  end
+
   scenario 'i can sign in' do
     visit root_path
 

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -31,12 +31,12 @@ describe Chapter do
   end
 
   context 'scopes' do
-    context '#default_scope' do
+    context '#active' do
       it 'only returns active Chapters' do
         2.times { Fabricate(:chapter) }
         3.times { Fabricate(:chapter, active: false) }
 
-        expect(Chapter.all.count).to eq(2)
+        expect(Chapter.active.all.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
This should resolve most rollbar issues we’ve been encountering, most relating to past workshops allocated to inactive chapters causing application errors