### PR TITLE
#682 Change date and time pickers on meetings(monthlies) to match workshops

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,12 +27,12 @@
 
 $(function(){
   $(document).foundation();
-  $('#workshop_local_date, #event_date_and_time, #workshop_rsvp_open_local_date').pickadate({
+  $('#meeting_local_date, #workshop_local_date, #event_date_and_time, #workshop_rsvp_open_local_date').pickadate({
     format: 'dd/mm/yyyy'
   });
 
   $('#announcement_expires_at, #ban_expires_at').pickadate();
-  $('#workshop_local_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_local_time').pickatime({
+  $('#meeting_local_time, #workshop_local_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_local_time').pickatime({
     format: 'HH:i'
   });
 
@@ -50,7 +50,7 @@ $(function(){
   $('#member_lookup_id').chosen().change(function(e) {
     $('#view_profile').attr('href', '/admin/members/' + $(this).val())
   });
-  
+
   // Prevent tabbing through side menu links when menu is hidden.
   // This somewhat hacky approach is required because Foundation doesn't
   // allow us to modify the functionality directly :(

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -70,8 +70,10 @@ class Admin::MeetingsController < Admin::ApplicationController
   end
 
   def meeting_params
-    params.require(:meeting).permit(:name, :description, :slug, :date_and_time,
-                                    :invitable, :spaces, :venue_id, :sponsor_id, :chapters)
+    params.require(:meeting).permit(
+      :name, :description, :slug, :date_and_time, :local_date, :local_time,
+      :invitable, :spaces, :venue_id, :sponsor_id, :chapters
+    )
   end
 
   def organiser_ids

--- a/app/models/concerns/date_time_concerns.rb
+++ b/app/models/concerns/date_time_concerns.rb
@@ -1,0 +1,40 @@
+module DateTimeConcerns
+  extend ActiveSupport::Concern
+
+  included do
+    include InstanceMethods
+  end
+
+  module InstanceMethods
+    delegate :future?, to: :date_and_time
+
+    def set_date_and_time
+      new_date_and_time = datetime_from_fields(local_date, local_time)
+      self.date_and_time = new_date_and_time if new_date_and_time
+    end
+
+    def date
+      I18n.l(date_and_time, format: :dashboard)
+    end
+
+    def time
+      date_and_time.try(:time)
+    end
+
+    def date_and_time
+      return nil unless super
+      super.in_time_zone(time_zone)
+    end
+
+    def datetime_from_fields(date_string, time_string)
+      return nil if date_string.blank? || time_string.blank? || !time_zone
+      date = Date.parse(date_string)
+      time = Time.zone.parse(time_string)
+      ActiveSupport::TimeZone[time_zone].local(date.year, date.month, date.day, time.hour, time.min)
+    end
+
+    def past?
+      date_and_time < Time.zone.today
+    end
+  end
+end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -1,4 +1,5 @@
 class Workshop < ActiveRecord::Base
+  include DateTimeConcerns
   include Invitable
   include Listable
 
@@ -52,17 +53,9 @@ class Workshop < ActiveRecord::Base
     has_host? && host.address.present?
   end
 
-  def past?
-    date_and_time.past?
-  end
-
   def rsvp_available?
     return rsvp_closes_at.future? if rsvp_closes_at
     future?
-  end
-
-  def future?
-    date_and_time.future?
   end
 
   def open_for_rsvp?
@@ -103,40 +96,15 @@ class Workshop < ActiveRecord::Base
     WorkshopPolicy
   end
 
-  def date_and_time
-    return nil unless super
-    super.in_time_zone(time_zone)
-  end
-
   def rsvp_opens_at
     return nil unless super
     super.in_time_zone(time_zone)
   end
 
-  def date
-    I18n.l(date_and_time, format: :dashboard)
-  end
-
-  def time
-    date_and_time.try(:time)
-  end
-
   private
-
-  def set_date_and_time
-    new_date_and_time = datetime_from_fields(local_date, local_time)
-    self.date_and_time = new_date_and_time if new_date_and_time
-  end
 
   def set_opens_at
     new_opens_at = datetime_from_fields(rsvp_open_local_date, rsvp_open_local_time)
     self.rsvp_opens_at = new_opens_at if new_opens_at
-  end
-
-  def datetime_from_fields(date_string, time_string)
-    return nil if date_string.blank? || time_string.blank? || !time_zone
-    date = Date.parse(date_string)
-    time = Time.parse(time_string)
-    ActiveSupport::TimeZone[time_zone].local(date.year, date.month, date.day, time.hour, time.min)
   end
 end

--- a/app/views/admin/meetings/_form.html.haml
+++ b/app/views/admin/meetings/_form.html.haml
@@ -7,8 +7,11 @@
         .medium-6.columns
           = f.input :slug
   .row
-    .large-12.columns
-      = f.input :date_and_time, as: :datetime, required: true, label: 'Date', input_html: { style: 'width: 120px;' }
+    .medium-6.columns.admin_margin
+      = f.input :local_date, as: :string, required: true, input_html: { data: { value: @meeting.date_and_time.try(:strftime, '%d/%m/%Y') } }
+  .row
+    .medium-6.columns
+      = f.input :local_time, as: :string, required: true, input_html: { data: { value: @meeting.time.try(:strftime, '%H:%M') } }
   .row
     .large-12.columns.admin_margin
       = f.input :description, placeholder: 'Supports HTML', as: :text, input_html: { style: 'height: 300px;' }

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -16,6 +16,8 @@ feature 'Managing meetings' do
       visit new_admin_meeting_path
 
       fill_in 'Name', with: 'August meeting'
+      fill_in 'Local date', with: Date.current
+      fill_in 'Local time', with: '11:30'
       select venue.name
       click_on 'Update'
 


### PR DESCRIPTION
- tests are passing
  - I had to change one test to match the format of the workshop test to add date/time details

- queries: is this desired behaviour?
  1. neither the existing new workshop date/time picker actually displays the date data provided until you click on the field
  2. when creating a new meeting, the 'Team' details do not appear to be saved and are not displayed
    - they are saved when editing an existing meeting
  3. when running the tests, Faker created surname "O'Reilly" which resulted in a failed css check due to the apostrophe
    - I have not had any trouble displaying names with apostrophes on the website, so perhaps we need to add a step to the Faker name creation to remove any non alphabetic characters?