### PR TITLE
Add instance variable @skill to SkillsController

### DIFF
--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,5 +1,6 @@
 class SkillsController < ApplicationController
   def show
+    @skill = skill
     @coaches = Member.includes(:skills)
                       .with_skill(skill)
                       .paginate(page: page)

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -2,8 +2,8 @@ class SkillsController < ApplicationController
   def show
     @skill = skill
     @coaches = Member.includes(:skills)
-                      .with_skill(skill)
-                      .paginate(page: page)
+                     .with_skill(skill)
+                     .paginate(page: page)
   end
 
   private

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -45,6 +45,8 @@ feature 'when visiting the coaches page' do
 
     visit skill_path('ruby')
 
+    expect(page).to have_content("Coaches skilled in 'ruby'")
+
     coaches.each do |coach|
       expect(page).to have_content(coach.full_name)
     end


### PR DESCRIPTION
Instance variable `@skill` is used when rendering a /skills page e.g. https://codebar.io/skills/ruby

As of writing this PR, the header for that page says 

> Coaches skilled in ''

![image](https://user-images.githubusercontent.com/5173183/46764883-91bd4200-ccd5-11e8-9048-f4ea73a9b4d7.png)

This PR adds the `@skill` instance variable to `app/controllers/skills_controller.rb` which is referenced in `app/views/skills/show.html.haml`. The title now says

> Coaches skilled in 'ruby'

I added an expectation to one of the tests. Should I check for a full sentence like that? Checking for content 'ruby' matches the list of coaches below...