### PR TITLE
Fix intermittently failing test

### DIFF
--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -51,6 +51,6 @@ describe WorkshopPresenter do
                        Fabricate(:attending_workshop_invitation, member: member,  workshop: workshop, role: 'Coach')
     end
 
-    expect(presenter.attendees_emails).to eq(members.map(&:email).join(', '))
+    expect(presenter.attendees_emails.split(', ')).to match_array(members.map(&:email))
   end
 end


### PR DESCRIPTION
The order or the `attendees` isn't guaranteed in `WorkshopPresenter#attendees_emails`, which means this test sometimes fails, since `expect(a).to eq(b)` expects the array to be exactly the
same. Unlike `match_array`, which only verifies that the arrays have identical items.

For example, this test failed in the unrelated dependabot upgrade for `pundit`:

https://travis-ci.org/codebar/planner/builds/440397050 (https://github.com/codebar/planner/pull/827)
