### PR TITLE
Update simplecov version to remove warnings from rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'coveralls', require: false
+  gem 'coveralls', '~> 0.8.22', require: false
   gem 'dotenv-rails'
   gem 'fabrication'
   gem 'faker'
@@ -67,7 +67,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'codeclimate-test-reporter', require: nil
   gem 'database_cleaner'
   gem 'poltergeist'
   gem 'shoulda-matchers', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,8 +103,6 @@ GEM
       sass-rails (>= 3.2)
     chunky_png (1.3.10)
     cliver (0.3.2)
-    codeclimate-test-reporter (1.0.8)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -129,11 +127,11 @@ GEM
     concurrent-ruby (1.0.5)
     coolline (0.5.0)
       unicode_utils (~> 1.4)
-    coveralls (0.8.19)
+    coveralls (0.8.22)
       json (>= 1.8, < 3)
-      simplecov (~> 0.12.0)
+      simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
+      thor (~> 0.19.4)
       tins (~> 1.6)
     crass (1.0.4)
     css_parser (1.6.0)
@@ -148,7 +146,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     diffy (3.1.0)
-    docile (1.1.5)
+    docile (1.3.1)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -370,8 +368,8 @@ GEM
     simple_form (4.0.0)
       actionpack (> 4)
       activemodel (> 4)
-    simplecov (0.12.0)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
@@ -424,10 +422,9 @@ DEPENDENCIES
   carrierwave
   carrierwave-ftp
   chosen-rails
-  codeclimate-test-reporter
   coffee-rails (~> 4.2)
   compass-rails!
-  coveralls
+  coveralls (~> 0.8.22)
   database_cleaner
   delayed_job
   delayed_job_active_record


### PR DESCRIPTION
## Description
The current version of `simplecov`, a `coveralls` and `codeclimate-test-reporter` gem dependency, was polluting the rails console with the following warnings:
```
/Users/Kriszta/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/configuration.rb:207: warning: constant ::Fixnum is deprecated
/Users/Kriszta/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/source_file.rb:29: warning: constant ::Fixnum is deprecated
/Users/Kriszta/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/source_file.rb:30: warning: constant ::Fixnum is deprecated
```
Updated coveralls gem version to `~> 0.8.22` in Gemfile to update the simplecov gem version in Gemfile.lock. Also removed `codeclimate-test-reporter` as this gem is deprecated (https://github.com/codeclimate/ruby-test-reporter).

## Status
Ready for Review