### PR TITLE
Resolve Capybara is unable to load `puma` for its server error when running the test suite

### DIFF
--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
-feature 'A new student signs up', js: false do
+feature 'A new student signs up' do
   before do
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
-                                                                  provider: 'github',
-                                                                  uid: '42',
-                                                                  credentials: { token: 'Fake token' },
-                                                                  info: {
-                                                                    email: Faker::Internet.email,
-                                                                    name: Faker::Name.name
-                                                                  }
-                                                                )
+      provider: 'github',
+      uid: '42',
+      credentials: { token: 'Fake token' },
+      info: {
+        email: Faker::Internet.email,
+        name: Faker::Name.name
+      }
+    )
   end
 
   scenario 'A visitor can access signups through the landing page' do
@@ -20,7 +20,7 @@ feature 'A new student signs up', js: false do
     expect(page).to have_current_path(step1_member_path(member_type: 'student'))
   end
 
-  scenario 'A visitor must fill in all mandatory fields in order to sign up', js: true do
+  scenario 'A visitor must fill in all mandatory fields in order to sign up' do
     member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil)
     member.update(can_log_in: true)
     login member

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 require 'simplecov'
 require 'coveralls'
 require 'shoulda/matchers'
+
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                 SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-                                                               ])
+])
+
 SimpleCov.start 'rails' do
   add_group 'Presenters', 'app/presenters'
   add_group 'Policies', 'app/policies'


### PR DESCRIPTION
## Description
A test marked with the `:js` flag started raising the following error when running the test suite locally:
```
LoadError:
       Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`.
```
This PR removes the `:js` flag from the test found in `./spec/features/member_joining_spec.rb:23`.

It also fixes some indentation inconsistencies in  `./spec/features/member_joining_spec.rb` and `spec_helper.rb`.

## Status 
Ready for Review