### PR TITLE
Minor bugfix: Remove link borders in footer links and admin event checkboxes

### DIFF
--- a/app/assets/stylesheets/partials/_attendances.scss
+++ b/app/assets/stylesheets/partials/_attendances.scss
@@ -3,8 +3,14 @@
         margin-bottom: 0;
     }
 
+    .verify_attendance,
+    .cancel_attendance {
+        border: none;
+    }
+
     a .fa {
         color: black;
+
         &:hover {
             text-shadow: 1px 1px 1px #999;
         }

--- a/app/assets/stylesheets/partials/_layout.scss
+++ b/app/assets/stylesheets/partials/_layout.scss
@@ -4,6 +4,7 @@ footer {
 
   a {
     color: $white;
+    border: none;
 
     &:hover {
       color: $secondary-color;


### PR DESCRIPTION
Resolves minor visual bug introduced in #837:
![image](https://user-images.githubusercontent.com/1155816/47034657-e64a3c80-d16f-11e8-99c2-59c15b1ca233.png)
![image](https://user-images.githubusercontent.com/1155816/47034713-05e16500-d170-11e8-9e3d-156ab141c767.png)


I haven't been able to test this locally as I've not succeeded in getting the planner to run on my machine. But I've tested it in the browser and I'm pretty confident that it will works. If you're able to test it for me, I'd really appreciate it!