### PR TITLE
Improve footer text contrast, and add a class

### DIFF
--- a/app/assets/stylesheets/partials/_layout.scss
+++ b/app/assets/stylesheets/partials/_layout.scss
@@ -1,4 +1,4 @@
-footer {
+.main-footer {
   background-color: $primary-color;
   padding: 50px 0;
 

--- a/app/assets/stylesheets/partials/_layout.scss
+++ b/app/assets/stylesheets/partials/_layout.scss
@@ -1,6 +1,7 @@
 .main-footer {
   background-color: $primary-color;
   padding: 50px 0;
+  color: rgba(255, 255, 255, 0.8);
 
   a {
     color: $white;

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer
+%footer.main-footer
   .row
     .large-3.columns
       %p.copyright


### PR DESCRIPTION
A couple of extra improvements that I noticed after submitting #844:

1. Apply footer CSS to a class, not a generic element type.
It's valid HTML for the footer element to be used in multiple locations on a page, so it's unsafe to write CSS for the main footer and apply it globally to this element, and assume that it won't cause side-effects in the future.

2. Change footer text color to 80% white to improve a11y/readability.
The contrast ratio on this existing black-on-dark-grey text was exceptionally poor.
![image](https://user-images.githubusercontent.com/1155816/47035582-4e9a1d80-d172-11e8-8420-2f1194c32222.png)
