### PR TITLE
Add Sponsors section to chapter pages

### DIFF
--- a/app/controllers/chapter_controller.rb
+++ b/app/controllers/chapter_controller.rb
@@ -8,6 +8,7 @@ class ChapterController < ApplicationController
     past_event = @chapter.workshops.most_recent
     past_events = past_event.present? ? [past_event].group_by(&:date) : []
     @latest_workshops = past_events.map.inject({}) { |hash, (key, value)| hash[key] = EventPresenter.decorate_collection(value); hash }
+    @recent_sponsors = Sponsor.recent_for_chapter(@chapter)
   end
 
   private

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -10,6 +10,7 @@ class Sponsor < ActiveRecord::Base
   }
 
   has_one :address
+  has_many :chapters, through: :workshops
   has_many :workshop_sponsors
   has_many :workshops, through: :workshop_sponsors
   has_many :member_contacts
@@ -20,6 +21,16 @@ class Sponsor < ActiveRecord::Base
 
   default_scope -> { order('updated_at desc') }
   scope :active, -> { where.not(level: 'hidden') }
+
+  scope :recent_for_chapter, -> (chapter) {
+    distinct
+      .unscope(:order)
+      .includes(:workshops)
+      .joins(:workshops, :chapters)
+      .where(chapters: {id: chapter.id})
+      .order('workshops.date_and_time DESC')
+      .limit(6)
+  }
 
   mount_uploader(:avatar, AvatarUploader)
 

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -22,12 +22,12 @@ class Sponsor < ActiveRecord::Base
   default_scope -> { order('updated_at desc') }
   scope :active, -> { where.not(level: 'hidden') }
 
-  scope :recent_for_chapter, -> (chapter) {
+  scope :recent_for_chapter, lambda { |chapter|
     distinct
       .unscope(:order)
       .includes(:workshops)
       .joins(:workshops, :chapters)
-      .where(chapters: {id: chapter.id})
+      .where(chapters: { id: chapter.id })
       .order('workshops.date_and_time DESC')
       .limit(6)
   }

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -1,14 +1,14 @@
 %section.stripe.reverse
   .row
     .large-12.columns
-      %h4= @chapter.name
+      %h1= @chapter.name
       %p.lead
         = t('chapters.intro', email: @chapter.email).html_safe
       - if logged_in?
         = render partial: 'subscriptions'
       - else
         %p
-          =link_to "Sign up", new_member_path, class: 'button tiny'
+          =link_to 'Sign up', new_member_path, class: 'button tiny'
 
 
 %section.stripe.reverse#chapter
@@ -39,13 +39,21 @@
 
       %script(async src="https://platform.twitter.com/widgets.js" charset="utf-8")
 
+- if @recent_sponsors.any?
+  .stripe.reverse
+    .row
+      .small-12.columns
+        %h3 Sponsors
+    .row.sponsor-row
+      - @recent_sponsors.each do |sponsor|
+        .small-4.medium-2.columns.sponsor-image
+          = link_to image_tag(sponsor.avatar, class: "small-image", alt: sponsor.name), sponsor.website, title: sponsor.name
 
 .stripe.reverse
   .row
     .large-12.columns
-      %a{ name: "organisers" }
+      %a{ name: 'organisers' }
       %h3 Team
-
       .row
         - @chapter.organisers.shuffle.each do |organiser|
           .small-12.medium-6.large-3.columns.end

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -19,7 +19,7 @@ feature 'viewing a Chapter' do
     end
   end
 
-  context 'actigve chapters' do
+  context 'active chapters' do
     it 'a visitor to the website cannot access non existing chapter pages' do
       visit chapter_path('test')
 
@@ -46,6 +46,18 @@ feature 'viewing a Chapter' do
       visit chapter_path(chapter.slug)
       expect(page).to have_content "Workshop at #{recent_past_workshop.host.name}"
       expect(page).to_not have_content "Workshop at #{past_workshop.host.name}"
+    end
+    
+    it 'renders the 6 most recent sponsors for the chapter' do
+      chapter = Fabricate(:chapter)
+      workshops = 6.times.map do |n|
+        Fabricate(:workshop, chapter:chapter, date_and_time: Time.zone.now - n.weeks)
+      end
+
+      visit chapter_path(chapter.slug)
+      workshops.each do |workshop|
+        expect(page).to have_link(workshop.sponsors.name)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
This PR adds a Sponsors section to the individual chapter pages. This section displays the 6 most recent sponsors for the chapters workshops.

## Status 
Ready to Review

## Related Github issue / Trello ticket
#629

## Screenshots
Example from my local installation, ignore the duplicated logos, many of the sponsrs have the same logo in the seed data
<img width="1280" alt="screen shot 2018-10-16 at 21 17 51" src="https://user-images.githubusercontent.com/5873816/47062038-f9b5d180-d188-11e8-8bf3-2f4c2e794e36.png">

## Self-review checklist
* [x] Branch up to date with master
* [x] Snyk check is passing
* [x] codeclimate check is passing
* [x] Test are written and passing locally / on CI