### PR TITLE
(fix) add spec to verify #824 and resolve

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -85,6 +85,6 @@ class DashboardController < ApplicationController
     meeting = Meeting.includes(:venue).next
     events = Event.includes(:venue, :sponsors).future(DEFAULT_UPCOMING_EVENTS)
 
-    [*workshops, course, *events, meeting].compact
+    [*workshops, course, *events, meeting].uniq.compact
   end
 end

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -3,19 +3,47 @@ require 'spec_helper'
 feature 'Member portal' do
   subject { page }
   let(:member) { Fabricate(:member) }
-  let!(:invitations) { 5.times.map { Fabricate(:attending_workshop_invitation, member: member) } }
-  let!(:group) { Fabricate(:group) }
 
   context 'A signed in member' do
     before do
       login(member)
     end
 
-    it 'can access the member dashboard' do
-      visit dashboard_path
+    context '#dashboard' do
+      it 'can access the member dashboard' do
+        visit dashboard_path
 
-      expect(page).to have_content('Dashboard')
-      expect(page).to have_content(member.full_name)
+        expect(page).to have_content('Dashboard')
+        expect(page).to have_content(member.full_name)
+      end
+
+      it 'can view attending workshops' do
+        workshop = Fabricate(:workshop, chapter: Fabricate(:chapter_with_groups))
+        subscription = Fabricate(:subscription, member: member, group: workshop.chapter.groups.first)
+        invitation = Fabricate(:attending_workshop_invitation, member: member,
+                                                               workshop: workshop)
+        presenter = WorkshopPresenter.new(workshop)
+        visit dashboard_path
+
+        expect(page).to have_content("#{presenter.to_s} at #{presenter.venue.name}", count: 1)
+      end
+
+      it 'can view upcoming workshops for their chapters' do
+        c1_workshop = Fabricate(:workshop, chapter: Fabricate(:chapter_with_groups))
+        Fabricate(:subscription, member: member, group: c1_workshop.chapter.groups.first)
+
+        c2_workshop = Fabricate(:workshop, chapter: Fabricate(:chapter_with_groups))
+        Fabricate(:subscription, member: member, group: c2_workshop.chapter.groups.first)
+        c1_workshop_presenter = WorkshopPresenter.new(c1_workshop)
+        c2_workshop_presenter = WorkshopPresenter.new(c2_workshop)
+
+        visit dashboard_path
+
+        expect(page).to have_content("#{c1_workshop_presenter.to_s} at #{c1_workshop_presenter.venue.name}",
+                                     count: 1)
+        expect(page).to have_content("#{c2_workshop_presenter.to_s} at #{c2_workshop_presenter.venue.name}",
+                                     count: 1)
+      end
     end
 
     it 'can access and update their profile' do
@@ -33,6 +61,7 @@ feature 'Member portal' do
     end
 
     it 'can subscribe to groups' do
+      group  = Fabricate(:group) 
       visit profile_path
       within '#member_profile' do
         click_on 'Manage subscriptions'
@@ -43,6 +72,7 @@ feature 'Member portal' do
     end
 
     it 'can view the invitations they RSVPed to' do
+      invitations = 5.times.map { Fabricate(:attending_workshop_invitation, member: member) } 
       visit invitations_path
 
       expect(page).to have_content('Invitations')

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -36,11 +36,11 @@ describe Job do
     it '#active returns all active jobs' do
       2.times.map { Fabricate(:job, expiry_date: 1.week.ago) }
 
-      expect(Job.active.to_a).to eq(approved + drafts + pending_approval)
+      expect(Job.active.to_a).to match_array(approved + drafts + pending_approval)
     end
 
     it '#pending_or_published returns all pending or published jobs' do
-      expect(Job.pending_or_published.to_a).to eq(approved + pending_approval)
+      expect(Job.pending_or_published.to_a).to match_array(approved + pending_approval)
     end
   end
 

--- a/spec/presenters/chapter_presenter_spec.rb
+++ b/spec/presenters/chapter_presenter_spec.rb
@@ -20,7 +20,7 @@ describe ChapterPresenter do
     Fabricate.times(2, :past_workshop, chapter: chapter)
     workshops = Fabricate.times(3, :workshop, chapter: chapter, date_and_time: Time.zone.now + 1.week)
 
-    expect(presenter.upcoming_workshops).to eq(workshops)
+    expect(presenter.upcoming_workshops).to match_array(workshops)
   end
 
   it '#organisers' do


### PR DESCRIPTION
don’t render workshops twice on dashboard page when a user is both subscribed to the chapter and attending the workshop