### PR TITLE
Add description field to chapter

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -78,7 +78,6 @@ nav a.menu {
 .sign-up-wizard .collapsed { display: none; }
 .no-js .sign-up-wizard .collapsed { display: block; }
 
-
 .workshop.title {
   color: grey;
   font-style: italic;
@@ -174,8 +173,15 @@ u {
 
 form .hint {
   color: gray;
+  display: inline-block;
+  font-size: 0.875em;
+  margin-bottom: 0.5rem;
 }
 
 .breadcrumbs {
   background-color: none;
+}
+
+.chosen-dropwdown {
+  margin-bottom: 1.14286rem;
 }

--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -62,7 +62,7 @@ class Admin::ChaptersController < Admin::ApplicationController
   private
 
   def chapter_params
-    params.require(:chapter).permit(:name, :email, :city, :time_zone, :twitter)
+    params.require(:chapter).permit(:name, :email, :city, :time_zone, :twitter, :description)
   end
 
   def set_chapter

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -4,7 +4,8 @@ class Chapter < ActiveRecord::Base
   validates :name, :email, uniqueness: true, presence: true
   validates :city, presence: true
   validates :time_zone, presence: true
-  validate :time_zone_exists
+  validate  :time_zone_exists
+  validates :description, length: { maximum: 280 }
 
   has_many :workshops
   has_and_belongs_to_many :events

--- a/app/views/admin/chapters/edit.html.haml
+++ b/app/views/admin/chapters/edit.html.haml
@@ -1,7 +1,7 @@
 %section#banner
   .row
     .medium-12.columns
-      %h2 Edit Chapter #{@chapter.name}
+      %h2 Edit #{@chapter.name} chapter
       = simple_form_for [:admin, @chapter] do |f|
         .row
           .large-6.columns
@@ -14,10 +14,13 @@
             = f.input :city, required: true
         .row
           .large-6.columns
-            = f.input :time_zone, required: true
+            = f.input :description, required: false, hint: 'Optionally, specify a custom welcome message for the chapter, to be displayed on the chapter page. Max. 280 characters.'
         .row
           .large-6.columns
-            = f.input :twitter, required: false
+            = f.input :twitter, placeholder: '@codebarCam', required: false
+        .row
+          .large-6.columns.chosen-dropwdown
+            = f.input :time_zone, required: true
         .row
           .large-12.columns.text-right
             = f.submit 'Update chapter', class: 'button'

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -7,12 +7,11 @@
       - if @chapter.description
         %p.lead= @chapter.description
       - else
-        %p.lead= t('chapters.intro').html_safe
-
+        %p.lead= t('chapters.intro_html')
 .panel
   .row
     .small-12.medium-6.columns
-      = t('chapters.info', email: @chapter.email).html_safe
+      = t('chapters.info', email: h(@chapter.email)).html_safe
     .small-12.medium-6.columns.text-center
       - if logged_in?
         = render partial: 'subscriptions'

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -2,14 +2,22 @@
   .row
     .large-12.columns
       %h1= @chapter.name
-      %p.lead
-        = t('chapters.intro', email: @chapter.email).html_safe
+  .row
+    .large-7.columns
+      - if @chapter.description
+        %p.lead= @chapter.description
+      - else
+        %p.lead= t('chapters.intro').html_safe
+
+.panel
+  .row
+    .small-12.medium-6.columns
+      = t('chapters.info', email: @chapter.email).html_safe
+    .small-12.medium-6.columns.text-center
       - if logged_in?
         = render partial: 'subscriptions'
       - else
-        %p
-          =link_to 'Sign up', new_member_path, class: 'button tiny'
-
+        =link_to 'Sign up', new_member_path, class: 'button small radius'
 
 %section.stripe.reverse#chapter
   .row
@@ -29,7 +37,6 @@
             .medium-12.columns
               %h4= date
             = render workshops
-
 
     .large-4.columns
       - if @chapter.twitter_handle

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -267,7 +267,8 @@ de:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hallo und willkommen bei codebar! Wenn du Fragen hast kannst du unsere <a href='http://codebar.io/faq'>FAQ</a> lesen, du kannst uns aber auch gerne an %{email} schreiben, wenn du die Antwort die du suchst nicht findest. Ansonsten kannst du den folgenden Button verwenden um den Anmeldeprozess zu starten."
+    intro: "Hallo und willkommen bei codebar!"
+    info: "Wenn du Fragen hast kannst du unsere <a href='http://codebar.io/faq'>FAQ</a> lesen, du kannst uns aber auch gerne an <a href='mailto:%{email}'>%{email}</a> schreiben, wenn du die Antwort die du suchst nicht findest. Ansonsten kannst du den folgenden Button verwenden um den Anmeldeprozess zu starten."
     sign_up: "um zu unseren Workshops eingeladen zu werden."
     no_incoming: "Aktuell sind keine Workshops geplant."
     contact: "Um das %{city}er Team zu kontaktieren kannst du einfach eine E-Mail an %{email} schicken"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,7 +267,8 @@ en:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -267,7 +267,8 @@ en-AU:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -267,7 +267,8 @@ en-GB:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -267,7 +267,8 @@ en-US:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -267,7 +267,8 @@ es:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -267,7 +267,8 @@ fi:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -267,7 +267,8 @@ fr:
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -267,7 +267,8 @@
       title: "Students with Disability"
       description: "We want to ensure that our workshops are as accessible as possible. If you are disabled and are unsure about whether our venues can cater to your needs, we encourage you to please get in touch with us at <a href='mailto:hello@codebar.io'>hello@codebar.io</a> and we will do what we can to accommodate you."
   chapters:
-    intro: "Hi and welcome to codebar! Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, and feel free to email us at %{email} if you can't find the answer you're looking for. Otherwise, use the button below to start the sign-up process."
+    intro: "Hi and welcome to codebar!"
+    info: "Check out our <a href='http://codebar.io/faq'>FAQ</a> page for any questions you might have, or email us at <a href='mailto:%{email}'>%{email}</a> if you can't find the answer you're looking for. Otherwise, click the Sign up button to get started."
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"

--- a/db/migrate/20181019002645_add_description_to_chapters.rb
+++ b/db/migrate/20181019002645_add_description_to_chapters.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToChapters < ActiveRecord::Migration
+  def change
+    add_column :chapters, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181013230006) do
+ActiveRecord::Schema.define(version: 20181019002645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,8 +83,9 @@ ActiveRecord::Schema.define(version: 20181013230006) do
     t.string   "twitter"
     t.string   "twitter_id"
     t.string   "slug"
-    t.boolean  "active",     default: true
-    t.string   "time_zone",  default: "London", null: false
+    t.boolean  "active",      default: true
+    t.string   "time_zone",   default: "London", null: false
+    t.text     "description"
   end
 
   create_table "chapters_events", force: :cascade do |t|
@@ -301,8 +302,8 @@ ActiveRecord::Schema.define(version: 20181013230006) do
     t.string   "email"
     t.string   "link_to_job"
     t.integer  "created_by_id"
-    t.boolean  "approved",       default: false
-    t.boolean  "submitted",      default: false
+    t.boolean  "approved",         default: false
+    t.boolean  "submitted",        default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "company"

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
-describe Chapter do
+RSpec.describe Chapter, type: :model do
+  it { should validate_presence_of(:city) }
+  it { should validate_length_of(:description).is_at_most(280) }
+
   context 'validations' do
     context '#slug' do
       it 'a chapter must have a slug set' do


### PR DESCRIPTION
## Description
This PR adds a description field to the Chapter model so chapter organizers can provide custom intro text for their chapters to be displayed on the individual chapter pages. Character count for the field is capped at 280. If there is no description field specified, a default welcome message is shown. This PR also extracts the current intro text into two strings: intro (can be customized on a chapter basis) and info (same for every chapter) and moves the info text (FAQ and chapter email) into it's own visually highlighted section with the CTA buttons (Sign in etc.).

## Status
Ready for Review

## Related Github ticket
#849 

## Screenshots
Chapter page with custom intro (logged out)
<img width="1440" alt="screen shot 2018-10-18 at 8 32 22 pm" src="https://user-images.githubusercontent.com/5873816/47197229-ae7ef880-d319-11e8-97f9-6dd8a3ddf938.png">

Chapter page with custom intro (logged in)
<img width="1440" alt="screen shot 2018-10-18 at 8 33 58 pm" src="https://user-images.githubusercontent.com/5873816/47197238-b63e9d00-d319-11e8-8bca-05545f55f586.png">

Chapter page with default intro (logged out)
<img width="1440" alt="screen shot 2018-10-18 at 8 34 47 pm" src="https://user-images.githubusercontent.com/5873816/47197258-dbcba680-d319-11e8-9cfd-9b4883f600fa.png">