### PR TITLE
Fix and improve appearance of chapter page organisers grid

### DIFF
--- a/app/assets/stylesheets/partials/_chapter.scss
+++ b/app/assets/stylesheets/partials/_chapter.scss
@@ -1,5 +1,4 @@
 #chapter {
-
   .date {
     text-align: center;
   }
@@ -30,15 +29,5 @@
 
   .organisers {
     margin-top: 12px;
-  }
-}
-
-.organiser  {
-  border: 1px solid #f7f4fa;
-  margin: 4px;
-  .row {
-    text-align: center;
-    padding: 15px;
-    margin: 0 5px;
   }
 }

--- a/app/assets/stylesheets/partials/_organisers.scss
+++ b/app/assets/stylesheets/partials/_organisers.scss
@@ -1,3 +1,32 @@
 .user-link {
   border-bottom: none;
 }
+
+.organisers-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.organiser-item {
+  display: flex;
+  margin-bottom: 2rem;
+}
+
+.organiser-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 1rem;
+  text-align: center;
+  border: 1px solid $main-stroke;
+  &:hover {
+    box-shadow: 0 0 5px 0 $main-stroke;
+  }
+}
+
+.organiser-image {
+  border-radius: 3.57143rem;
+  margin-bottom: 0.5rem;
+}

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -49,7 +49,7 @@
   .stripe.reverse
     .row
       .small-12.columns
-        %h3 Sponsors
+        %h2 Sponsors
     .row.sponsor-row
       - @recent_sponsors.each do |sponsor|
         .small-4.medium-2.columns.sponsor-image
@@ -59,20 +59,14 @@
   .row
     .large-12.columns
       %a{ name: 'organisers' }
-      %h3 Team
-      .row
-        - @chapter.organisers.shuffle.each do |organiser|
-          .small-12.medium-6.large-3.columns.end
-            .organiser
-              .row
-                .small-12.columns
-                  =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
-                    =image_tag(organiser.avatar(65), class: 'th radius', title: organiser.full_name, alt: organiser.full_name)
-              .row
-                .small-12.columns
-                  =link_to twitter_url_for(organiser.twitter) do
-                    = organiser.full_name
-
-      %br
+      %h2 Team
+  .row.organisers-grid
+    - @chapter.organisers.shuffle.each do |organiser|
+      .small-12.medium-6.large-3.columns.organiser-item
+        = link_to twitter_url_for(organiser.twitter), title: "#{organiser.full_name} Twitter profile", class: 'organiser-content' do
+          = image_tag(organiser.avatar(65), alt: organiser.full_name, class: 'organiser-image')
+          = organiser.full_name
+  .row  
+    .large-12.columns
       .panel
         = t('chapters.contact', city: @chapter.name, email: @chapter.email)


### PR DESCRIPTION
## Description
This PR refactors the chapter page organisers grid to fix items breaking out of the grid because of differing heights.

## Status
Ready for Review

## Related Github ticket
#848 

## Screenshots
<img width="1271" alt="screen shot 2018-10-23 at 9 11 14 pm" src="https://user-images.githubusercontent.com/5873816/47405870-8e2faf00-d708-11e8-9627-26229a5950b9.png">