### PR TITLE
Spelt GitHub in the correct format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,7 +187,7 @@ en:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -185,7 +185,7 @@ en-AU:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -185,7 +185,7 @@ en-GB:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -185,7 +185,7 @@ en-US:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -185,7 +185,7 @@ es:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -185,7 +185,7 @@ fi:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -185,7 +185,7 @@ fr:
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -185,7 +185,7 @@
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"
-    sign_in_with_github: "Sign in with Github"
+    sign_in_with_github: "Sign in with GitHub"
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"


### PR DESCRIPTION
Changed the small h in GitHub to a capital. As it is meant to be. 
CC @joenash :octocat: 