### PR TITLE
Add start time to monthlies invitation email + other email improvements

### DIFF
--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  A spot opened up for the next codebar Monthly!
+                  A spot opened up for the next codebar Monthly on #{humanize_date(@meeting.date_and_time, with_time: true)} at #{@meeting.venue.name}!
 
         = render partial: 'agenda'
 

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  You're confirmed for the next codebar Monthly!
+                  You're confirmed for the next codebar Monthly on #{humanize_date(@meeting.date_and_time, with_time: true)} at #{@meeting.venue.name}!
 
         = render partial: 'agenda'
 

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  We're back for another installment of codebar Monthlies on #{humanize_date(@meeting.date_and_time)} at #{@meeting.venue.name}!
+                  We're back for another installment of codebar Monthlies on #{humanize_date(@meeting.date_and_time, with_time: true)} at #{@meeting.venue.name}!
                 %p
                   = "#{link_to 'You can RSVP here', @rsvp_url}, after logging into your codebar account.".html_safe
 
@@ -35,5 +35,4 @@
 
         .content
           = render partial: 'shared_mailers/social'
-
           = render partial: 'shared_mailers/footer'

--- a/app/views/shared_mailers/_body_header.html.haml
+++ b/app/views/shared_mailers/_body_header.html.haml
@@ -2,12 +2,11 @@
   %tr
     %td
     %td.header.container
-
       .content
         %table{ bgcolor: "#fdfdfd" }
           %tr
-            %td
-              = image_tag( 'https://raw.githubusercontent.com/codebar/assets/master/logo/png/website-logo.png', alt: "codebar logo")
-            %td{ align: "right"}
+            %td{ width: "40%" }
+              = image_tag("https://raw.githubusercontent.com/codebar/assets/master/logo/png/website-logo.png", alt: "codebar logo")
+            %td{ align: "right" }
               %h6.collapse= title
     %td

--- a/app/views/shared_mailers/_venue.html.haml
+++ b/app/views/shared_mailers/_venue.html.haml
@@ -2,15 +2,21 @@
   %td
     %h4 Venue
 %tr
-  %td{ width: '70%', style: 'vertical-align: top; padding-right:20px;' }
+  %td{ width: '70%', style: 'vertical-align: top; padding-right: 20px;' }
     %p
       %strong #{host.name}
       %br
       #{address.to_html}
-    - if host.address.directions
+    - if host.address.directions.present?
       %p
         %strong Directions:
         %br
         #{host.address.directions}
+    - if host.accessibility_info.present?
+      %p
+        %strong Accessibility information:
+        %br
+        #{host.accessibility_info}
+
   %td{ width: '30%', style: 'vertical-align: top;' }
     = image_tag(host.avatar, alt: host.name)

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match('You\'re confirmed for the next codebar Monthly!')
+      expect(mail.body.encoded).to match('You\'re confirmed for the next codebar Monthly')
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match('A spot opened up for the next codebar Monthly!')
+      expect(mail.body.encoded).to match('A spot opened up for the next codebar Monthly')
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match('This is a quick email to remind you that you have signed up for tomorrow\'s codebar Monthly.')
+      expect(mail.body.encoded).to match('This is a quick email to remind you that you have signed up for tomorrow\'s codebar Monthly')
     end
   end
 end


### PR DESCRIPTION
## Description
This PR adds the start time to the monthlies invitation, attending and approved_from_waitlist emails. Other emails improvements include displaying the accessibility info in the venue section of the email and reducing the size of the codebar logo in the email header.

## Status
Ready for Review

## Related Github issue
Fixes #913 