### PR TITLE
Order groups alphabetically on Subscriptions page

### DIFF
--- a/app/views/subscriptions/index.html.haml
+++ b/app/views/subscriptions/index.html.haml
@@ -2,12 +2,12 @@
 %section#banner
 .row
   .large-12.columns
-    %p.lead Subscriptions control the emails you receive. For example if you would like to receive student invitations for the Brighton and West London workshops then select Brighton (Students) and West London (Students).
+    %p.lead Subscriptions control the invitation emails you receive. For example if you would like to receive student invitations for the Brighton and West London workshops then subscribe to the Brighton (Students) and West London (Students) options.
     %br
     - @groups.group_by(&:chapter).each do |chapter, groups|
       %h4= chapter.name
       %hr
-      - groups.each do |group|
+      - groups.sort_by(&:name).each do |group|
         .row
           .medium-9.columns
             %p= group.name


### PR DESCRIPTION
## Description
This PR orders groups alphabetically (Coaches and then Students) on the Subscriptions page. Relatedly, I was wondering if we could make this page a bit more visually clear? I feel like we need more separation between the Chapters and groups.

## Status
Ready for Review

## Relates Github issue
Fixes #908 

## Screenshot
![screenshot_2019-02-19 codebar](https://user-images.githubusercontent.com/5873816/53037122-355df200-342e-11e9-9a11-afb55da7bdd6.png)