### PR TITLE
Create button disappears when new sponsor form has error #907

### DIFF
--- a/app/views/admin/sponsors/_form.html.haml
+++ b/app/views/admin/sponsors/_form.html.haml
@@ -45,7 +45,7 @@
 
   .row
     .large-6.columns
-      - if params[:action] == 'new'
+      - if params[:action] == 'new' || params[:action] == 'create'
         = f.submit 'Create sponsor', class: 'button round'
       - elsif params[:action] == 'edit'
         = f.submit 'Save changes', class: 'button round'

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -39,6 +39,21 @@ feature 'Managing sponsors' do
         expect(page).to have_content 'Namecan\'t be blank'
       end
     end
+
+    context 'with invalid input' do
+      it 'renders new and shows create button' do
+        visit new_admin_sponsor_path
+
+        fill_in 'sponsor_name', with: ''
+        fill_in 'Website', with: 'https://www.sponsorname.com/'
+        attach_file('Avatar', Rails.root + 'spec/support/codebar-logo.png')
+        fill_in 'Student Spots', with: 20
+
+        click_on 'Create sponsor'
+
+        expect(page).to have_button('Create sponsor')
+      end
+    end
   end
 
   describe 'updating a sponsor' do


### PR DESCRIPTION
When saving a new sponsor fails, the 'new' form is rendered.
The submit button text is dependent on the params action either being new or edit. When rendered, the params action is now create, so no submit button is shown.

Added a test to manage_sponsor_spec that confirms that there is a 'Create sponsor' button upon initial submission with invalid input.
Updated sponsors/_form to show the 'Create sponsor' button if the action is new OR create.