### PR TITLE
Fix skipped mailing list test

### DIFF
--- a/spec/lib/services/mailing_list_spec.rb
+++ b/spec/lib/services/mailing_list_spec.rb
@@ -8,12 +8,13 @@ describe MailingList, wip: true do
 
   before do
     allow(mailing_list).to receive(:client).and_return(client)
+    allow(Rails).to receive(:env).and_return("production".inquiry)
 
     expect(client).to receive(:lists).and_return(lists)
   end
 
   context '#subscribe' do
-    xit 'add user to mailing list' do
+    it 'adds a user to the mailing list' do
       expect(lists).to receive(:subscribe)
 
       mailing_list.subscribe(:email, :first_name, :last_name)
@@ -21,7 +22,7 @@ describe MailingList, wip: true do
   end
 
   context '#unsubscribe' do
-    xit 'removes a user from the mailing list' do
+    it 'removes a user from the mailing list' do
       expect(lists).to receive(:unsubscribe)
 
       mailing_list.unsubscribe(:email)


### PR DESCRIPTION
These tests were skipped because there of a guard clause preventing
mailing list subscribing/unsubscribing unless in production. Since
neither tests nor code have been touched in about a year I think this
is an acceptable workaround (I really dislike pending tests!).

A further explanation of why this works can be found here:
https://stackoverflow.com/a/25134591