### PR TITLE
Remove PhantomJS/Poltergeist as currently unused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,6 @@ FROM ruby:2.4.2
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y build-essential libpq-dev nodejs
 
-# Install PhantomJS for tests - see https://blog.codeship.com/testing-rails-application-docker/
-ENV PHANTOMJS_VERSION 2.1.1
-RUN set -ex; \
-    mkdir -p /usr/local/share/phantomjs; \
-    curl -fsSL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
-      | tar xj -C /usr/local/share/phantomjs --strip-components=1; \
-    ln -s /usr/local/share/phantomjs/bin/phantomjs /usr/local/bin/phantomjs
-
 WORKDIR /planner
 
 COPY Gemfile Gemfile.lock ./

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ end
 group :test do
   gem 'capybara'
   gem 'database_cleaner'
-  gem 'poltergeist'
   gem 'shoulda-matchers', '~> 3.1'
 end
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ The current Dockerfile and docker-compose were closely copied from [the Docker g
 Run `bin/drake` to run all the tests and make sure everything works.
 You can also use `bin/drails` and `bin/dspec` to run specific rails and rspec commands via docker.
 
-*Note:* JavaScript acceptance tests are relying on the [Poltergeist](https://github.com/teampoltergeist/poltergeist) driver, which requires
-[PhantomJS](http://phantomjs.org). For more information about installing PhantomJS, please take a look
-[here](https://github.com/teampoltergeist/poltergeist#installing-phantomjs).
+*Note:* Running feature tests with JavaScript enabled is currently not setup correctly (and currently there are no tests that require this anyway). This is due to the removal of the previous PhantomJS/Poltergeist setup. This will be replaced in due course with headless Chrome.
 
 ### 5. Start the app
 

--- a/native-installation-instructions.md
+++ b/native-installation-instructions.md
@@ -48,7 +48,6 @@ brew services start postgresql
 Install other dependencies:
 ```
 brew install imagemagick
-brew install phantomjs
 ```
 
 Install the Gems:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,2 +1,0 @@
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
There are no feature tests which currently use `js: true`. The only one
that needs it (in `spec/features/admin/manage_workshop_attendances_spec.rb`)
is currently skipped, and also doesn't work with the current
Poltergeist/PhantomJS setup anyway.

PhantomJS is currently unmaintained:
https://github.com/ariya/phantomjs/issues/15105#issuecomment-322850178.
It looks like the next thing to do is to look into using headless
Chrome, which will be addressed in a future PR.