### PR TITLE
Updates Gemfile.lock after poltergeist gem has been removed from the Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,6 @@ GEM
       railties (>= 3.0)
       sass-rails (>= 3.2)
     chunky_png (1.3.10)
-    cliver (0.3.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -222,10 +221,6 @@ GEM
     pg (0.20.0)
     pickadate-rails (3.5.6.0)
       railties (>= 3.1.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
     premailer (1.11.1)
       addressable
@@ -371,9 +366,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.1)
     uniform_notifier (1.12.1)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
     will_paginate (3.1.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -419,7 +411,6 @@ DEPENDENCIES
   omniauth-github
   pg (~> 0.20.0)
   pickadate-rails
-  poltergeist
   premailer-rails
   pry-byebug
   pry-remote


### PR DESCRIPTION
## Description
After merging in #942 auto deployment to codebar-staging failed because the updated Gemfile.lock wasn't committed after removing the poltergeist app from the Gemfile. Per the error message from the build log:

```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

You have deleted from the Gemfile:
* poltergeist
```

This PR updates and commits the new Gemfile.lock.