### PR TITLE
Expand length of chapter.description

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -5,7 +5,7 @@ class Chapter < ActiveRecord::Base
   validates :city, presence: true
   validates :time_zone, presence: true
   validate  :time_zone_exists
-  validates :description, length: { maximum: 280 }
+  validates :description, length: { maximum: 5000 }
 
   has_many :workshops
   has_and_belongs_to_many :events

--- a/app/views/admin/chapters/edit.html.haml
+++ b/app/views/admin/chapters/edit.html.haml
@@ -14,7 +14,7 @@
             = f.input :city, required: true
         .row
           .large-6.columns
-            = f.input :description, required: false, hint: 'Optionally, specify a custom welcome message for the chapter, to be displayed on the chapter page. Max. 280 characters.'
+            = f.input :description, required: false, hint: 'Optionally, specify a custom welcome message for the chapter, to be displayed on the chapter page. Max. 5000 characters.'
         .row
           .large-6.columns
             = f.input :twitter, placeholder: '@codebarCam', required: false

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -3,7 +3,7 @@
     .medium-6.columns.chapter-header-text
       %h1= @chapter.name
       - if @chapter.description
-        %p.lead= @chapter.description
+        %p.lead= raw @chapter.description
       - else
         %p.lead= t('chapters.intro_html')
     - if @chapter.image.present?
@@ -66,7 +66,7 @@
         = link_to twitter_url_for(organiser.twitter), title: "#{organiser.full_name} Twitter profile", class: 'organiser-content' do
           = image_tag(organiser.avatar(65), alt: organiser.full_name, class: 'organiser-image')
           = organiser.full_name
-  .row  
+  .row
     .large-12.columns
       .panel
         = t('chapters.contact', city: @chapter.name, email: @chapter.email)

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Chapter, type: :model do
   it { should validate_presence_of(:city) }
-  it { should validate_length_of(:description).is_at_most(280) }
+  it { should validate_length_of(:description).is_at_most(5000) }
   it { should respond_to(:image) }
 
   context 'validations' do


### PR DESCRIPTION
Following an initiative in Barcelona Chapter, I've extended the length of the chapter description.
I added two tests in `spec/models/chapter_spec.rb` to show allowed and not allowed lengths but then realised that it was already covered by `it { should validate_length_of(:description).is_at_most(xxx) }` part, so I removed them to follow the exiting approach along the app.

@iliasbartolini do you want to have a look to the PR?