### PR TITLE
Added text to new job form

### DIFF
--- a/app/views/member/jobs/_form.html.haml
+++ b/app/views/member/jobs/_form.html.haml
@@ -34,6 +34,10 @@
   .row
     .large-6.columns
       = f.input :location, required: true
+
+  %small
+    = t('member.jobs.new.optional_details_message')
+
   .row
     .large-6.columns
       = f.input :company_address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,7 @@ en:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
+        optional_details_message: "The information below is only required if you want this job post to be shared with Google Search UK."
         pay: You have made the requirement payment of £35 through %{link}
         donation: a donation
         button:

--- a/spec/features/member/jobs_spec.rb
+++ b/spec/features/member/jobs_spec.rb
@@ -72,6 +72,12 @@ feature 'Member managing jobs' do
 
       expect(page).to have_content('This is a preview of your job.Edit to amend or Submit for approval')
     end
+
+    scenario 'can view text that address and postcode fields are optional' do
+      visit new_member_job_path
+
+      expect(page).to have_content('The information below is only required if you want this job post to be shared with Google Search UK.')
+    end
   end
 
   context 'viewing a job' do


### PR DESCRIPTION
Added provided text to new job form explaining it is only required if user wants job to be shared with Google Search UK.

I was unsure of the required text size, so I went with small font.

Fixes Issue #964 

<img width="1265" alt="Screen Shot 2019-06-08 at 1 20 56 PM" src="https://user-images.githubusercontent.com/18410214/59150368-5b64cd80-89f0-11e9-8e9a-0223db07106a.png">

