### PR TITLE
Replace chromedriver-helper with webdrivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 bundler_args: --without development
 rvm:
   - 2.4.2
+services:
+  - postgresql
 before_script:
   - bundle exec rake db:create db:schema:load
 

--- a/Gemfile
+++ b/Gemfile
@@ -71,10 +71,10 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'chromedriver-helper'
   gem 'database_cleaner'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'webdrivers'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       activerecord (>= 4.2.8)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     better_errors (2.5.1)
@@ -83,9 +81,6 @@ GEM
       coffee-rails (>= 3.2)
       railties (>= 3.0)
       sass-rails (>= 3.2)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chunky_png (1.3.10)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -169,7 +164,6 @@ GEM
     icalendar (2.5.3)
       ice_cube (~> 0.16)
     ice_cube (0.16.3)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -373,6 +367,10 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
     uniform_notifier (1.12.1)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     will_paginate (3.1.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -388,7 +386,6 @@ DEPENDENCIES
   carrierwave
   carrierwave-ftp
   chosen-rails
-  chromedriver-helper
   coffee-rails (~> 4.2)
   compass-rails!
   coveralls (~> 0.8.23)
@@ -444,6 +441,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
+  webdrivers
   will_paginate
 
 RUBY VERSION


### PR DESCRIPTION
 - Closes issue: https://github.com/codebar/planner/issues/1012
 - chromedriver-helper is no longer maintained as of 2019-03-31
  - webdrivers has a near superset of the functionality. Webdrivers
    is the default for rails 6 going forward
  - https://github.com/flavorjones/chromedriver-helper/issues/83