### PR TITLE
fix: travis-ci error - back to trusty with explicit db service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+dist: trusty
 language: ruby
 bundler_args: --without development
 rvm:
   - 2.4.2
+services:
+  - postgresql
 before_script:
   - bundle exec rake db:create db:schema:load
 


### PR DESCRIPTION

      - travis have been moving builds from trusty to xenial
      - when planner is tested on Xenial it fails. Because:
        - 1. no postgresql service
          - could not connect to server: Connection refused
            Is the server running on host "localhost" (127.0.0.1) and
            accepting TCP/IP connections on port 5432?
        - 2. tests become 'flaky'
      - setting back to trusty and adding explicit postgres service