### PR TITLE
Replace chromedriver-helper with webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,10 +72,9 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'chromedriver-helper'
   gem 'database_cleaner'
-  gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.1'
+  gem 'webdrivers'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       activerecord (>= 4.2.8)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     better_errors (2.5.1)
@@ -82,9 +80,6 @@ GEM
       coffee-rails (>= 3.2)
       railties (>= 3.0)
       sass-rails (>= 3.2)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chunky_png (1.3.10)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -167,7 +162,6 @@ GEM
     icalendar (2.5.3)
       ice_cube (~> 0.16)
     ice_cube (0.16.3)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -373,6 +367,10 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
     uniform_notifier (1.12.1)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     will_paginate (3.2.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -388,7 +386,6 @@ DEPENDENCIES
   carrierwave
   carrierwave-ftp
   chosen-rails
-  chromedriver-helper
   coffee-rails (~> 4.2)
   compass-rails!
   coveralls (~> 0.8.23)
@@ -436,7 +433,6 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.75.1)
   sass-rails (~> 5.0.1)
-  selenium-webdriver
   shoulda-matchers (~> 4.1)
   simple_form
   stripe
@@ -444,6 +440,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
+  webdrivers
   will_paginate
 
 RUBY VERSION

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,4 @@
-require 'selenium-webdriver'
+require 'webdrivers'
 
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new


### PR DESCRIPTION
- Why are we changing?
   Chromedriver is used to automate our browser tests.
      - Chromedriver implements the webdriver standards for
          automated testing of webapps for Chrome.
          https://chromedriver.chromium.org/
   Chromedriver-helper had the task of installing Chromedriver
    for us and making sure the exe  was in the Gem path. We could
    have installed it ourselves but this was easier.
    chromedriver-helper is no longer maintained as of 2019-03-31
        - https://github.com/flavorjones/chromedriver-helper/issues/83

- What are we changing to?
    Webdrivers is now responsible for downloading drivers - in our
    case chromedriver.
 - webdrivers has selenium-webdrivers as dependency removing from
     Gemfile and changing Capabyara to require 'webdrivers'

- What are the differences?
  Webdrivers can do the same as Chromedrivers (superset of
   functionality) - but can also do other drivers and it does it
    automatically - with chromedriver-helper you had to automated
    it by hand - this should help avoid problems with running tests 
    with old drivers.

Closes issue https://github.com/codebar/planner/issues/1012