### PR TITLE
Fix: flaky test breaks when fabricator produces apostrophe name

### DIFF
--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -58,8 +58,8 @@ feature 'Managing meetings' do
       click_on 'Update'
 
       expect(page).to have_content('You have succesfully updated the details of this meeting')
-      expect(page).to have_css("span[title='#{permissions.members.last.full_name}']")
-      expect(page).to_not have_css("span[title='#{permissions.members.first.full_name}']")
+      expect(page).to have_css(%(span[title="#{permissions.members.last.full_name}"]))
+      expect(page).to_not have_css(%(span[title="#{permissions.members.first.full_name}"]))
     end
   end
 


### PR DESCRIPTION
  - Nokogriri::CSS::SyntaxError: expect(page).to
    have_css("span[title='#{permissions.members.last.full_name}']")
  - the programmer needed to use two sets of quotes. Double quotes
    for the have_css string and single quotes for the nested CSS
    attribute for title's value.
  - When the fabricator produced a standard name like smith
    or Jones it worked - about 9 times in 10.
  - When the fabricator produced a name with an apostrophe in it
    it broke the test, about 1 in 10 times, because the CSS
    attribute was: title='O'Conner' and the string became
    unbalanced