### PR TITLE
Xenial + Flaky test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: ruby
 bundler_args: --without development
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :test do
   gem 'chromedriver-helper'
   gem 'database_cleaner'
   gem 'selenium-webdriver'
-  gem 'shoulda-matchers', '~> 3.1'
+  gem 'shoulda-matchers', '~> 4.1'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,8 +333,8 @@ GEM
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.1.2)
+      activesupport (>= 4.2.0)
     simple_form (4.0.0)
       actionpack (> 4)
       activemodel (> 4)
@@ -437,7 +437,7 @@ DEPENDENCIES
   rubocop (~> 0.74.0)
   sass-rails (~> 5.0.1)
   selenium-webdriver
-  shoulda-matchers (~> 3.1)
+  shoulda-matchers (~> 4.1)
   simple_form
   stripe
   timecop

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -14,6 +14,10 @@ describe Group, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_inclusion_of(:name).in_array(Group::NAMES) }
+    it do
+      should validate_inclusion_of(:name).
+        in_array(%w(Coaches Students)).
+        with_message('Invalid name for Group')
+    end
   end
 end

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Job do
+describe Job, type: :model do
   context '#fields' do
     subject(:job) { Fabricate.build(:job) }
 
@@ -14,24 +14,13 @@ describe Job do
     it { should respond_to(:created_by) }
     it { should respond_to(:approved) }
     it { should respond_to(:submitted) }
+    it { should define_enum_for(:status).with_values(draft: 0, pending: 1, published: 2) }
   end
 
   context 'scopes' do
     let!(:approved) { 2.times.map { Fabricate(:published_job) } }
     let!(:drafts) { 1.times.map { Fabricate(:job) } }
     let!(:pending_approval) { 4.times.map { Fabricate(:pending_job) } }
-
-    it '#published returns all published job' do
-      expect(Job.published.all).to eq(approved)
-    end
-
-    it '#draft returns all draft jobs' do
-      expect(Job.draft.all).to eq(drafts)
-    end
-
-    it '#pending returns all jobs pending approval' do
-      expect(Job.pending.all).to match_array(pending_approval)
-    end
 
     it '#active returns all active jobs' do
       2.times.map { Fabricate(:job, expiry_date: 1.week.ago) }


### PR DESCRIPTION
- trusty => Xenial - if you look at the [chrome install on the last build](https://travis-ci.org/codebar/planner/builds/583913069) it isn't working. This has lasted all day.

```
Errors were encountered while processing:
 /tmp/google-chrome-stable_current_amd64.deb
```

I'm guessing that the trusty infrastructure, which stopped being supported 1st May, is going to be less reliable - putting in a request to move to Xenial.

When I last tried Xenial the build had flaky tests and I naively backed off thinking they were due to Xenial. I now know, it was happening on Trusty as well. I've tested the Xenial branch 15 times without failing. However, I have a long list of spec errors that could be flaky, err I mean, non deterministic. These all broke doing a gem bumps of the codebar/planner master branch - the suspicious list:

```
spec/features/jobs_spec.rb:14
spec/features/jobs_spec.rb:22
spec/mailers/meeting_invitation_mailer_spec.rb:63
spec/features/admin/managing_meeting_invitations_spec.rb:24
spec/mailers/workshop_invitation_mailer_spec.rb:24 # WorkshopInvitationMailer #waitlist_reminder
spec/models/workshop_invitation_spec.rb:48 # WorkshopInvitation scopes #not_reminded
```
### Additionally: 
Removed Flaky test from [a bad assumptions about DB ordering](https://samsaffron.com/archive/2019/05/15/tests-that-sometimes-fail)
Updated shoulda-matcher which failed to bump - the test required a `with_message`.