### PR TITLE
Fix Synchronise rubocop and codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+version: "2"
+plugins:
+  rubocop:
+    enabled: true
+    channel: rubocop-0-79
+  brakeman:
+    enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,11 +7,18 @@ AllCops:
     - config/**/*
     - bin/**/*
 
+require:
+  - rubocop-rails
+
 Layout/LineLength:
   Max: 120
 
 Layout/EndOfLine:
   EnforcedStyle: lf
+
+Naming/MethodParameterName:
+  Exclude:
+    - app/helpers/email_header_helper.rb
 
 Style/Documentation:
   Enabled: false
@@ -22,9 +29,5 @@ Style/FrozenStringLiteralComment:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Rails:
-  Enabled: true
-
 Rails/Date:
   Enabled: true
-

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.80.1', require: false
+  gem 'rubocop-rails', require: false
   gem 'timecop'
   gem 'bullet'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,9 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.4.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
     sass (3.4.25)
@@ -439,6 +442,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rubocop (~> 0.80.1)
+  rubocop-rails
   sass-rails (~> 5.0.1)
   shoulda-matchers (~> 4.1)
   simple_form


### PR DESCRIPTION
### Current situation:

- Rubocop 0.79.0 doesn't work with `.rubocop.yml` as it doesn't recognise "Rails" cops which were [removed in Rubocop 0.72.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0720-2019-06-25)
- I don't know what version of Rubocop Codeclimate uses by default. The [documentation says Rubocop 0.52.1](https://docs.codeclimate.com/docs/rubocop) but I am not sure as it seems very old.

### Changes
- added rubocop-rails
  - this breaks codeclimate so I had to change codeclimate
- codeclimate set "channel" to rubocop-0-79 (required)
  - I've also set it to version 2 (not required)

With these changes it now works but has a list of "new" rubocop errors - while some really are new (from a cop introduced recently) most are not. Regardless, I have fixed all I can.

All were auto-corrected **except**:
- (refactor) Disable do not use instance helper 
- (refactor) ChapterController#show has too many lines

### Skipped one cop error
The only rubyocop/codeclimate error I dodged was Rails/Date timezone cop for job_presenter which I think would be better looked at by despo.
