### PR TITLE
gitignore byebug_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ TAGS
 .env
 .DS_Store
 
+.byebug_history
+
 # Emacs
 *~
 \#*\#


### PR DESCRIPTION
Now in by default in Rails - and very useful when debugging