### PR TITLE
fix warning: 'checking for expected text of nil is confusing'

### DIFF
--- a/spec/fabricators/course_fabricator.rb
+++ b/spec/fabricators/course_fabricator.rb
@@ -1,11 +1,11 @@
 Fabricator(:course) do
-  description { Faker::Lorem.paragraph }
-  short_description { Faker::Lorem.sentence }
   title { Faker::Lorem.sentence }
+  short_description { Faker::Lorem.sentence }
+  description { Faker::Lorem.paragraph }
   tutor { Fabricate(:member) }
-  chapter
   date_and_time { Time.zone.now + 1.week }
-  sponsor
-
   seats 1
+  url { Faker::Internet.url }
+  sponsor
+  chapter
 end

--- a/spec/features/viewing_a_course_spec.rb
+++ b/spec/features/viewing_a_course_spec.rb
@@ -10,7 +10,7 @@ feature 'viewing a course' do
     expect(page).to have_content course.title
     expect(page).to have_content course.description
     expect(page).to have_content course.short_description
-    expect(page).to have_content course.url
+    expect(page).to have_link "Read more", href: course.url
 
     expect(page).to have_content 'Sign up'
     expect(page).to have_content 'Sign in'


### PR DESCRIPTION
When you run the tests you get this warning `checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.`

![Screenshot 2019-09-22 at 10 18 57](https://user-images.githubusercontent.com/1710795/65385118-80bce380-dd22-11e9-83ce-22a1b9db8621.png)

### This is the fix

  - Two steps required to fix issue
    1) The course fabricator was not producing a URL
    2) The test was testing for text and not a URL

  - 1) Course Fabricator should have generated a URL
    - to help the reader understand what attributes the Fabricator
      had and what it should have had I moved the Fabricators
      attributes to the database table's schema order. This is to
      avoid mistakes in the future.
    - Finally, I added the missing url faker

  - 2) expectation testing for have_content of URL when it
    should have been testing for have_link