### PR TITLE
Fix: schema synchronised with ExtendedJobModel migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -309,7 +309,6 @@ ActiveRecord::Schema.define(version: 20181021014646) do
     t.datetime "updated_at"
     t.string   "company"
     t.integer  "approved_by_id"
-    t.string   "company_region"
     t.string   "company_website"
     t.string   "company_address"
     t.string   "company_postcode"


### PR DESCRIPTION
 - schema includes in Job table the attribute/column company_region
 - extend_job_model that introduced these set of changes did *not*
   include company_region
 - no reference to company_region in the code (and would have
   to be added to a new migration anyway)
 - removing company_region
 - referenced commit 85b9db678365b01623df567190f84a5b1cbd8042

--------------
Odd one. The attribute is only in the schema and not in migrations .. when you run the full migrations again after trashing the database it removes it from the schema. 
You are left with a change in your repository.

@despo - might want to check it out?
