### PR TITLE
s/before_filter/before_action

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,6 +1,6 @@
 class Admin::EventsController < Admin::ApplicationController
-  before_filter :set_event, only: [:show]
-  before_filter :find_event, only: %i[edit update]
+  before_action :set_event, only: [:show]
+  before_action :find_event, only: %i[edit update]
 
   def new
     @event = Event.new

--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -1,5 +1,5 @@
 class Admin::SponsorsController < Admin::ApplicationController
-  before_filter :set_sponsor, only: %i[show edit update]
+  before_action :set_sponsor, only: %i[show edit update]
 
   def index
     authorize Sponsor

--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -6,6 +6,8 @@ class Admin::SponsorsController < Admin::ApplicationController
     @sponsors = Sponsor.all.order(:name)
   end
 
+  def show; end
+
   def new
     @sponsor = Sponsor.new
     @sponsor.build_address

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -2,8 +2,8 @@ class Admin::WorkshopsController < Admin::ApplicationController
   include  Admin::SponsorConcerns
   include  Admin::WorkshopConcerns
 
-  before_filter :set_workshop_by_id, only: %i[show edit destroy]
-  before_filter :set_and_decorate_workshop, only: %i[attendees_checklist attendees_emails send_invites]
+  before_action :set_workshop_by_id, only: %i[show edit destroy]
+  before_action :set_and_decorate_workshop, only: %i[attendees_checklist attendees_emails send_invites]
 
   WORKSHOP_DELETION_TIME_FRAME_SINCE_CREATION = 4.hours
 


### PR DESCRIPTION
Rail's is deprecating `before_filter` for `before_action` in Rails 5. In the code base the before_filter is an alias of before_action. The change will not effect the code the application runs.


Below Rails code for alias of before_action in Rails 4.2 [Link to the Rails codebase](https://github.com/rails/rails/blob/4-2-stable/actionpack/lib/abstract_controller/callbacks.rb#L164-L172)
```ruby
    # set up before_action, prepend_before_action, skip_before_action, etc.
    # for each of before, after, and around.
    [:before, :after, :around].each do |callback|
      define_method "#{callback}_action" do |*names, &blk|
        _insert_callbacks(names, blk) do |name, options|
          set_callback(:process_action, callback, name, options)
        end
      end
      alias_method :"#{callback}_filter", :"#{callback}_action"
```

- [Rails 5 - Deprecated all *_filter callbacks in favor of *_action callbacks](https://edgeguides.rubyonrails.org/5_0_release_notes.html#action-pack-deprecations)
- [Taken from @koddson Rails 5 version](https://github.com/codebar/planner/pull/958)
