### PR TITLE
fix: listable_spec flaky scope test - introduce match_array

### DIFF
--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -9,7 +9,7 @@ describe Listable do
         Fabricate.times(5, :past_workshop)
         future_workshops = Fabricate.times(3, :workshop)
 
-        expect(Workshop.upcoming).to eq(future_workshops)
+        expect(Workshop.upcoming).to match_array(future_workshops)
       end
     end
 
@@ -18,7 +18,7 @@ describe Listable do
         past_workshops = Fabricate.times(5, :past_workshop)
         Fabricate.times(3, :workshop)
 
-        expect(Workshop.past).to eq(past_workshops)
+        expect(Workshop.past).to match_array(past_workshops)
       end
     end
 


### PR DESCRIPTION
  - Problem:
    - the tests fabricate three future workshops without specifying an order
    - the test asserts that three future workshops appear in date order
  - Fix: test asserts workshops are present but not the order of appearance

[This broke PR #1056 earlier today on "#upcoming returns a list of all upcoming workshops" but its sibling test could have just as easily broken](https://github.com/codebar/planner/pull/1056)

![Screenshot 2019-09-23 at 11 51 04](https://user-images.githubusercontent.com/1710795/65420219-81c04480-ddf8-11e9-962e-7529cab8e214.png)

 note: the bot forced pushed a couple of hours later and passed the second time