### PR TITLE
s/uniq/distinct

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -20,7 +20,7 @@ class Meeting < ActiveRecord::Base
   before_save :set_slug
 
   def invitees
-    Member.uniq.joins(:chapters).merge(chapters)
+    Member.distinct.joins(:chapters).merge(chapters)
   end
 
   def title

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -13,8 +13,8 @@ class Member < ActiveRecord::Base
   has_many :subscriptions
   has_many :groups, through: :subscriptions
   has_many :member_notes
-  has_many :chapters, -> { uniq }, through: :groups
-  has_many :announcements, -> { uniq }, through: :groups
+  has_many :chapters, -> { distinct }, through: :groups
+  has_many :announcements, -> { distinct }, through: :groups
   has_many :meeting_invitations
 
   validates :auth_services, presence: true


### PR DESCRIPTION
Rails 4 aliases uniq to distinct and deprecates uniq in Rails 5 - this commit gets us ahead of that.


[active_record/relation/query_methods.rb](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/relation/query_methods.rb#L766-L779)

```ruby
    def distinct(value = true)
      spawn.distinct!(value)
    end
    alias uniq distinct
```
[active_record/associations/collection_association.rb](
https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/associations/collection_association.rb#L365-L371)

```ruby
      def distinct
        seen = {}
        load_target.find_all do |record|
          seen[record.id] = true unless seen.key?(record.id)
        end
      end
      alias uniq distinct
```
[active_record/associations/collection_proxy.rb](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/associations/collection_proxy.rb#L678-L681)

```ruby
       def distinct
        @association.distinct
      end
      alias uniq distinct
```
