### PR TITLE
Lint: add space inside block braces

### DIFF
--- a/app/models/meeting_invitation.rb
+++ b/app/models/meeting_invitation.rb
@@ -8,5 +8,5 @@ class MeetingInvitation < ActiveRecord::Base
   belongs_to :member
 
   scope :accepted, -> { where(attending: true) }
-  scope :attended, -> { where(attended: true)}
+  scope :attended, -> { where(attended: true) }
 end

--- a/spec/fabricators/auth_service_fabricator.rb
+++ b/spec/fabricators/auth_service_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:auth_service) do
   provider { Faker::Company.name }
-  uid { Fabricate.sequence(:uid)  { |n| "sq#{n}" }}
+  uid { Fabricate.sequence(:uid)  { |n| "sq#{n}" } }
 end


### PR DESCRIPTION
 - rubocop default
 - rubocop --only Layout/SpaceInsideBlockBraces --auto-correct

---

There's so many rubocop errors - and I know lots of people debate them. But I prepared a few around layouts missing spaces.