### PR TITLE
lint: add space after colon

### DIFF
--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -17,7 +17,7 @@ Fabricator(:coach, from: :member) do
 end
 
 Fabricator(:banned_member, from: :member) do
-  bans(count:1) { Fabricate(:ban) }
+  bans(count: 1) { Fabricate(:ban) }
 end
 
 Fabricator(:chapter_organiser, from: :member) do

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -51,7 +51,7 @@ feature 'viewing a Chapter' do
     it 'renders the 6 most recent sponsors for the chapter' do
       chapter = Fabricate(:chapter)
       workshops = 6.times.map do |n|
-        Fabricate(:workshop, chapter:chapter, date_and_time: Time.zone.now - n.weeks)
+        Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.now - n.weeks)
       end
 
       visit chapter_path(chapter.slug)


### PR DESCRIPTION
 - rubocop default style
 - rubocop --auto-correct --only Layout/SpaceAfterColon