### PR TITLE
Lint: add space around operators

### DIFF
--- a/app/models/concerns/listable.rb
+++ b/app/models/concerns/listable.rb
@@ -7,7 +7,7 @@ module Listable
     scope :upcoming, -> { where('date_and_time >= ?', Time.zone.now).order(date_and_time: :asc) }
     scope :past, -> { where('date_and_time < ?', Time.zone.now).order(:date_and_time) }
     scope :recent, -> { where('date_and_time < ?', Time.zone.now).order(date_and_time: :desc).limit(NUMBER_OF_RECENT_WORKSHOPS_TO_RETRIEVE) }
-    scope :completed_since_yesterday, -> { where('date_and_time < ? and date_and_time > ?', Time.zone.now, Time.zone.now-24.hours).order(:date_and_time) }
+    scope :completed_since_yesterday, -> { where('date_and_time < ? and date_and_time > ?', Time.zone.now, Time.zone.now - 24.hours).order(:date_and_time) }
   end
 
   module ClassMethods

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -56,7 +56,7 @@ class Meeting < ActiveRecord::Base
   def set_slug
     return if slug.present?
     self.slug = loop.with_index do |_, index|
-      url = "#{I18n.l(date_and_time, format: :year_month).downcase}-#{title.parameterize}-#{index+1}"
+      url = "#{I18n.l(date_and_time, format: :year_month).downcase}-#{title.parameterize}-#{index + 1}"
       break url unless Meeting.where(slug: url).exists?
     end
   end

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -11,7 +11,7 @@ feature 'viewing a Chapter' do
     end
 
     it 'a visitor to the website can access inactive chapter events' do
-      past_workshop = Fabricate(:workshop, chapter: inactive_chapter, date_and_time: Time.zone.today-2.week)
+      past_workshop = Fabricate(:workshop, chapter: inactive_chapter, date_and_time: Time.zone.today - 2.week)
 
       visit workshop_path(past_workshop)
 
@@ -40,8 +40,8 @@ feature 'viewing a Chapter' do
 
     it 'renders the most recent past workshop for the chapter' do
       chapter = Fabricate(:chapter)
-      past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today-2.week)
-      recent_past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today-1.week)
+      past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today - 2.week)
+      recent_past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.today - 1.week)
 
       visit chapter_path(chapter.slug)
       expect(page).to have_content "Workshop at #{recent_past_workshop.host.name}"

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -9,8 +9,8 @@ feature 'when visiting the coaches page' do
   end
 
   scenario 'I can see the top coaches by year' do
-    latest_workshop = Fabricate(:workshop, date_and_time: Time.zone.now-1.year)
-    old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now-3.year)
+    latest_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 1.year)
+    old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 3.year)
     invitations = 5.times { Fabricate(:attended_coach, workshop: latest_workshop) }
     older_invitations = 15.times { Fabricate(:attended_coach, workshop: old_workshop) }
 
@@ -23,8 +23,8 @@ feature 'when visiting the coaches page' do
 
   scenario 'I can navigate the top coaches by year' do
     current_workshop = Fabricate(:workshop, date_and_time: Time.zone.now)
-    latest_workshop = Fabricate(:workshop, date_and_time: Time.zone.now-1.year)
-    old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now-3.year)
+    latest_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 1.year)
+    old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 3.year)
     current_invitations = 10.times { Fabricate(:attended_coach, workshop: current_workshop) }
     invitations = 7.times { Fabricate(:attended_coach, workshop: latest_workshop) }
     older_invitations = 12.times { Fabricate(:attended_coach, workshop: old_workshop) }

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -61,7 +61,7 @@ feature 'Member portal' do
     end
 
     it 'can subscribe to groups' do
-      group  = Fabricate(:group) 
+      group = Fabricate(:group) 
       visit profile_path
       within '#member_profile' do
         click_on 'Manage subscriptions'

--- a/spec/lib/tasks/reminders_meeting_rake_spec.rb
+++ b/spec/lib/tasks/reminders_meeting_rake_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'rake reminders:meeting', type: :task do
   end
 
   it 'sends out reminders for meetings taking place between 6 and 30 hours from now' do
-    meeting =  Fabricate(:meeting, date_and_time: Time.zone.now + 29.hours)
-    just_now_meeting =  Fabricate(:meeting, date_and_time: Time.zone.now + 2.hours)
-    past_meeting =  Fabricate(:meeting, date_and_time: 1.day.ago)
+    meeting = Fabricate(:meeting, date_and_time: Time.zone.now + 29.hours)
+    just_now_meeting = Fabricate(:meeting, date_and_time: Time.zone.now + 2.hours)
+    past_meeting = Fabricate(:meeting, date_and_time: 1.day.ago)
 
     invitation_manager = InvitationManager.new
     expect(InvitationManager).to receive(:new).and_return(invitation_manager)


### PR DESCRIPTION
  - rubocop default style
  - rubocop --only Layout/SpaceAroundOperators

Yup, most people weren't ready to do pull requests... here's one I prepared earlier *ahem*