### PR TITLE
lint: remove extra spacing in code

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -60,7 +60,7 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :span, class: :error }
     ## Inputs
     b.use :label_input
-    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :hint, wrap_with: { tag: :span, class: :hint }
   end
 
   # Define the way to render check boxes / radio buttons with labels.

--- a/spec/fabricators/auth_service_fabricator.rb
+++ b/spec/fabricators/auth_service_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:auth_service) do
   provider { Faker::Company.name }
-  uid { Fabricate.sequence(:uid)  { |n| "sq#{n}" } }
+  uid { Fabricate.sequence(:uid) { |n| "sq#{n}" } }
 end

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -15,10 +15,10 @@ feature 'when visiting the coaches page' do
     older_invitations = 15.times { Fabricate(:attended_coach, workshop: old_workshop) }
 
     visit coaches_path(year: latest_workshop.date_and_time.year)
-    expect(page).to have_css(".coach", count:  5)
+    expect(page).to have_css(".coach", count: 5)
 
     visit coaches_path(year: old_workshop.date_and_time.year)
-    expect(page).to have_css(".coach", count:  15)
+    expect(page).to have_css(".coach", count: 15)
   end
 
   scenario 'I can navigate the top coaches by year' do
@@ -30,13 +30,13 @@ feature 'when visiting the coaches page' do
     older_invitations = 12.times { Fabricate(:attended_coach, workshop: old_workshop) }
 
     visit coaches_path
-    expect(page).to have_css(".coach", count:  10)
+    expect(page).to have_css(".coach", count: 10)
 
     click_on latest_workshop.date_and_time.year.to_s
-    expect(page).to have_css(".coach", count:  7)
+    expect(page).to have_css(".coach", count: 7)
 
     click_on old_workshop.date_and_time.year.to_s
-    expect(page).to have_css(".coach", count:  12)
+    expect(page).to have_css(".coach", count: 12)
   end
 
   scenario 'I can view coaches listed by skills' do

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe InvitationManager do
   subject(:manager) { InvitationManager.new }
 
-  let(:chapter)   { Fabricate(:chapter) }
+  let(:chapter) { Fabricate(:chapter) }
   let(:workshop) { Fabricate(:workshop, chapter: chapter) }
   let(:students) { Fabricate.times(3, :member) }
   let(:coaches) { Fabricate.times(6, :member) }


### PR DESCRIPTION
 - default rubocop setting
 - rubocop --auto-correct --only Layout/ExtraSpacing

--------------

Didn't put this one up yesterday as it had a merge conflict with the braces spacing (I had forgotten they were also called squigglies) - turns out Rubocop really doesn't like this line: 

 `uid { Fabricate.sequence(:uid)  { |n| "sq#{n}" } }` 

