### PR TITLE
travis matrix for ruby 2.4.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 dist: xenial
 language: ruby
 bundler_args: --without development
-rvm:
-  - 2.4.2
+matrix:
+  include:
+  - rvm: 2.4.2
+  - rvm: 2.4.3
+  - rvm: 2.4.4
+  - rvm: 2.4.9
 services:
   - postgresql
+before_install:
+  - gem install bundler --version '= 1.17.3' --no-document
+  - bundle _1.17.3_ install
 before_script:
   - bundle exec rake db:create db:schema:load
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.2'
+ruby '~> 2.4.0'
 
 gem 'rails', '4.2.11.1'
 


### PR DESCRIPTION
 - multiple ruby builds 2.4.X
 - Gemfile ruby version floating on the patch number
 - .ruby-version remains on 2.4.2
---------
Demonstrating the build across different Ruby Versions.
Have you thought about stepping up Ruby versions?
