### PR TITLE
[WIP] chapter with basic layer of testing

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -25,7 +25,8 @@ class Chapter < ActiveRecord::Base
 
   def self.available_to_user(user)
     return Chapter.all if user.has_role?(:organiser) || user.has_role?(:admin) || user.has_role?(:organiser, Chapter)
-    return Chapter.find_roles(:organiser, user).map(&:resource)
+
+    Chapter.find_roles(:organiser, user).map(&:resource)
   end
 
   def organisers


### PR DESCRIPTION
I'll wait on @yihyang pull request #1069  - by eye I haven't seen any merge conflict but I want to keep things easy.

---------------------------------------------------------------
 - using subject(:chapter) where possible
 - trying is_expected.to it can automatically be changed by
   Rubocop
 - validating all attributes as required on model
 - slug is an on save test - explicit save! and reload before
   testing again
 - scope tests only need one object of each type and see if it
   is allowed or denied

 - mystery
   - available_to_user
   - not sure if we need a URL safe slug or not but it isn't
     being enforced

-----------------

And, coverall, like one word in production code removed. I'm hoping for at least +0.001% increase in coverage *fingers crossed*
