### PR TITLE
Empty line after guard clause

### DIFF
--- a/app/models/concerns/date_time_concerns.rb
+++ b/app/models/concerns/date_time_concerns.rb
@@ -23,11 +23,13 @@ module DateTimeConcerns
 
     def date_and_time
       return nil unless super
+
       super.in_time_zone(time_zone)
     end
 
     def datetime_from_fields(date_string, time_string)
       return nil if date_string.blank? || time_string.blank? || !time_zone
+
       date = Date.parse(date_string)
       time = Time.zone.parse(time_string)
       ActiveSupport::TimeZone[time_zone].local(date.year, date.month, date.day, time.hour, time.min)

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -19,6 +19,7 @@ class Feedback < ActiveRecord::Base
 
   def self.submit_feedback(params, token)
     return false unless feedback_request = FeedbackRequest.find_by(token: token)
+
     feedback = Feedback.new(params)
     feedback.workshop = feedback_request.workshop
 

--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -1,6 +1,7 @@
 class InvitationManager
   def send_workshop_emails(workshop, audience)
     return 'The workshop is not invitable' unless workshop.invitable?
+
     invite_students_to_workshop(workshop) unless audience.eql?('coaches')
     invite_coaches_to_workshop(workshop) unless audience.eql?('students')
   end
@@ -8,6 +9,7 @@ class InvitationManager
 
   def send_event_emails(event, chapter)
     return 'The event is not invitable' unless event.invitable?
+
     invite_coaches_to_event(event, chapter) unless event.audience.eql?('Students')
     invite_students_to_event(event, chapter) unless event.audience.eql?('Coaches')
   end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -55,6 +55,7 @@ class Meeting < ActiveRecord::Base
 
   def set_slug
     return if slug.present?
+
     self.slug = loop.with_index do |_, index|
       url = "#{I18n.l(date_and_time, format: :year_month).downcase}-#{title.parameterize}-#{index + 1}"
       break url unless Meeting.where(slug: url).exists?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -74,6 +74,7 @@ class Member < ActiveRecord::Base
   def received_welcome_for?(subscription)
     return received_student_welcome_email if subscription.student?
     return received_coach_welcome_email if subscription.coach?
+
     true
   end
 

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -55,6 +55,7 @@ class Workshop < ActiveRecord::Base
 
   def rsvp_available?
     return rsvp_closes_at.future? if rsvp_closes_at
+
     future?
   end
 
@@ -70,6 +71,7 @@ class Workshop < ActiveRecord::Base
   def attendee?(person)
     return false if person.nil?
     raise ArgumentError, "Person should be a Member, not a #{person.class}" unless person.is_a? Member
+
     attending_students.map(&:member).include?(person) || attending_coaches.map(&:member).include?(person)
   end
 
@@ -77,6 +79,7 @@ class Workshop < ActiveRecord::Base
   def waitlisted?(person)
     return false if person.nil?
     raise ArgumentError, 'Person should be a Member' unless person.is_a?(Member)
+
     WaitingList.students(self).include?(person) || WaitingList.coaches(self).include?(person)
   end
 
@@ -98,6 +101,7 @@ class Workshop < ActiveRecord::Base
 
   def rsvp_opens_at
     return nil unless super
+
     super.in_time_zone(time_zone)
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -42,6 +42,7 @@ class ApplicationPolicy
 
   def is_admin_or_chapter_organiser?
     return false unless user
+
     user.is_admin? || user.has_role?(:organiser) || is_chapter_organiser?
   end
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -11,6 +11,7 @@ class EventPolicy < ApplicationPolicy
 
   def is_admin_or_organiser?
     return false unless user
+
     user.is_admin? || user.has_role?(:organiser, record)
   end
 end

--- a/lib/services/mailing_list.rb
+++ b/lib/services/mailing_list.rb
@@ -7,6 +7,7 @@ class MailingList
 
   def subscribe(email, first_name, last_name)
     return true unless Rails.env.production?
+
     client.lists.subscribe(id: list_id,
                            email: { email: email },
                            merge_vars: { FNAME: first_name, LNAME: last_name },
@@ -16,6 +17,7 @@ class MailingList
 
   def unsubscribe(email)
     return true unless Rails.env.production?
+
     client.lists.unsubscribe(id: list_id,
                              email: { email: email },
                              send_notify:  false)


### PR DESCRIPTION
  - default style
  - rubocop -a --only Layout/EmptyLineAfterGuardClause

-------
Rubocop fix! 

It's a checkin where '\n' has been added but ... I love spaces after guardclauses - it divides the method up into stuff that shouldn't be happening and the code that should - the body of the method.

Commit adds consistency, readability and most importantly understanding of what the method is about.