### PR TITLE
Remove respond_to from specs

### DIFF
--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -2,13 +2,4 @@ require 'spec_helper'
 
 describe Address do
   subject(:address) { Fabricate.build(:address) }
-
-  it { should respond_to(:sponsor) }
-  it { should respond_to(:flat) }
-  it { should respond_to(:street) }
-  it { should respond_to(:city) }
-  it { should respond_to(:latitude) }
-  it { should respond_to(:longitude) }
-  it { should respond_to(:postal_code) }
-  it { should respond_to(:directions) }
 end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 RSpec.describe Chapter, type: :model do
   it { should validate_presence_of(:city) }
   it { should validate_length_of(:description).is_at_most(280) }
-  it { should respond_to(:image) }
 
   context 'validations' do
     context '#slug' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,16 +4,6 @@ describe Event do
   subject(:event) { Fabricate(:event) }
 
   it { should be_valid }
-  it { should respond_to(:name) }
-  it { should respond_to(:slug) }
-  it { should respond_to(:info) }
-  it { should respond_to(:schedule) }
-  it { should respond_to(:description) }
-  it { should respond_to(:venue) }
-  it { should respond_to(:sponsorships) }
-  it { should respond_to(:sponsors) }
-  it { should respond_to(:organisers) }
-  it { should respond_to(:chapters) }
 
   context '#verified_students' do
     it 'returns all students who have verified their attendance' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 describe Group, type: :model do
   subject(:group) { Fabricate.build(:group) }
 
-  it { should respond_to(:name) }
-  it { should respond_to(:description) }
-
   context 'validations' do
     it { should validate_presence_of(:name) }
 

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -4,16 +4,6 @@ describe Job, type: :model do
   context '#fields' do
     subject(:job) { Fabricate.build(:job) }
 
-    it { should respond_to(:title) }
-    it { should respond_to(:description) }
-    it { should respond_to(:location) }
-    it { should respond_to(:expiry_date) }
-    it { should respond_to(:email) }
-    it { should respond_to(:link_to_job) }
-    it { should respond_to(:expiry_date) }
-    it { should respond_to(:created_by) }
-    it { should respond_to(:approved) }
-    it { should respond_to(:submitted) }
     it { should define_enum_for(:status).with_values(draft: 0, pending: 1, published: 2) }
   end
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -3,14 +3,6 @@ require 'spec_helper'
 describe Workshop do
   subject(:workshop) { Fabricate(:workshop) }
 
-  it { should respond_to(:title) }
-  it { should respond_to(:description) }
-  it { should respond_to(:date_and_time) }
-  it { should respond_to(:sponsors) }
-  it { should respond_to(:workshop_sponsors) }
-  it { should respond_to(:rsvp_opens_at) }
-  it { should respond_to(:time_zone) }
-
   context 'time zone fields' do
     let(:workshop) { Fabricate.build(:workshop, chapter: Fabricate(:chapter, time_zone: 'Pacific Time (US & Canada)')) }
     let(:pacific_time) { ActiveSupport::TimeZone['Pacific Time (US & Canada)'].local(2015, 6, 12, 18, 30) }


### PR DESCRIPTION
  - removes 40 respond_to tests
    - inconsistent: respond_to covers 40 of 240 possible attributes
    - adds nothing over the rails tests. If it's in the migration
      it will 'respond_to'
    - adds nothing as a reference over the source of truth:
      schema.rb
----------------------------
40 tests removed, coverage remains the same.