### PR TITLE
[WIP] Fix: take students from waiting list separate of coach spots

### DIFF
--- a/app/models/concerns/workshop_invitation_manager_concerns.rb
+++ b/app/models/concerns/workshop_invitation_manager_concerns.rb
@@ -34,8 +34,8 @@ module WorkshopInvitationManagerConcerns
     def send_waiting_list_emails(workshop)
       workshop = WorkshopPresenter.decorate(workshop)
 
-      retrieve_and_notify_waitlisted(role: 'Coach') if workshop.coach_spaces?
-      retrieve_and_notify_waitlisted(role: 'Student') if workshop.student_spaces?
+      retrieve_and_notify_waitlisted(workshop, role: 'Coach') if workshop.coach_spaces?
+      retrieve_and_notify_waitlisted(workshop, role: 'Student') if workshop.student_spaces?
     end
     handle_asynchronously :send_waiting_list_emails
 
@@ -83,7 +83,7 @@ module WorkshopInvitationManagerConcerns
       end
     end
 
-    def retrieve_and_notify_waitlisted(role:)
+    def retrieve_and_notify_waitlisted(workshop, role:)
       WaitingList.by_workshop(workshop).where_role(role).each do |waiting_list|
         WorkshopInvitationMailer.notify_waiting_list(waiting_list.invitation).deliver_now
         waiting_list.destroy

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -70,6 +70,16 @@ Fabricator(:workshop_no_spots, class_name: :workshop) do
   end
 end
 
+Fabricator(:workshop_no_coaches, class_name: :workshop) do
+  date_and_time Time.zone.now + 2.days
+  title Faker::Lorem.sentence
+  description Faker::Lorem.sentence
+  chapter
+  after_build do |workshop|
+    Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor, number_of_coaches: 0), host: true)
+  end
+end
+
 Fabricator(:past_workshop, from: :workshop) do
   date_and_time 3.months.ago
   ends_at 3.months.ago + 2.hours

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -130,4 +130,48 @@ RSpec.describe InvitationManager, type: :model  do
       invitations.each { |invitation| expect(invitation.reload.reminded_at).to_not be_nil }
     end
   end
+
+  describe '#send_waiting_list_emails' do
+    it 'emails coaches when there are free coach spots' do
+      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Coach')
+
+      expect(WorkshopInvitationMailer).to receive(:notify_waiting_list).once
+        .with(waitinglist_invitation)
+        .and_call_original
+
+      manager.send_waiting_list_emails(workshop)
+    end
+
+    it 'does not email coaches when no coach spots are available' do
+      workshop = Fabricate(:workshop_no_coaches)
+      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Coach')
+
+      expect(WorkshopInvitationMailer).not_to receive(:notify_waiting_list)
+        .with(waitinglist_invitation)
+        .and_call_original
+
+      manager.send_waiting_list_emails(workshop)
+    end
+
+    it 'emails students when there are free student spots' do
+      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Student')
+
+      expect(WorkshopInvitationMailer).to receive(:notify_waiting_list).once
+        .with(waitinglist_invitation)
+        .and_call_original
+
+      manager.send_waiting_list_emails(workshop)
+    end
+
+    it 'does not email students when no student spots are available' do
+      workshop = Fabricate(:workshop_no_spots)
+      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Student')
+
+      expect(WorkshopInvitationMailer).not_to receive(:notify_waiting_list)
+        .with(waitinglist_invitation)
+        .and_call_original
+
+      manager.send_waiting_list_emails(workshop)
+    end
+  end
 end


### PR DESCRIPTION
### Fix: take students from waiting list separate of coach spots

Another issue I saw when testing: the limiting of emails to students on the wait list: 

> - students are only emailed on the wait list if there were free seats for students *and* coaches

It looked like an indentation issue but maybe this is a business choice?? But why would you want a workshop full of coaches and the students not being offered spots that have become free? Commit 1e0084e will give maxed out coach workshops waitlisted students.
