### PR TITLE
Added helper function for page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,14 @@ module ApplicationHelper
     human_date
   end
 
+  def title(*page_title)
+    if Array(page_title).size.zero?
+      return content_for?(:title) ? content_for(:title) : t(:brand)
+    else
+      return content_for :title, (Array(page_title) << t(:brand)).join(' | ')
+    end
+  end
+
   def dot_markdown(text)
     GitHub::Markdown.render_gfm(text).html_safe
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,12 +7,14 @@ module ApplicationHelper
     human_date
   end
 
-  def title(*page_title)
-    if Array(page_title).size.zero?
-      return content_for?(:title) ? content_for(:title) : t(:brand)
-    else
-      return content_for :title, (Array(page_title) << t(:brand)).join(' | ')
-    end
+  def title(title = nil)
+    return unless title
+    title = title + ' | ' + t(:brand)
+    content_for :title, title
+  end
+
+  def retrieve_title
+    content_for?(:title) ? content_for(:title) : t(:brand)
   end
 
   def dot_markdown(text)

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,3 +1,4 @@
+- title "Homepage"
 %section.hero.opaque
   .row
     .medium-offset-1.medium-6.columns

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,4 +1,4 @@
-- title "Homepage"
+- title t('homepage.title')
 %section.hero.opaque
   .row
     .medium-offset-1.medium-6.columns

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,3 +1,4 @@
+- title t('events.title')
 %section#banner
   .row
     .large-12.columns

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     %link{ rel: 'image_src', href: 'http://codebar.io/images/logo-square.png', :alt => "codebar logo" }
 
     %title
-      = title
+      = retrieve_title
     = favicon_link_tag 'favicon.ico'
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': true
     = javascript_include_tag 'vendor/modernizr'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,8 @@
 
     %link{ rel: 'image_src', href: 'http://codebar.io/images/logo-square.png', :alt => "codebar logo" }
 
-    %title codebar.io
+    %title
+      = title
     = favicon_link_tag 'favicon.ico'
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': true
     = javascript_include_tag 'vendor/modernizr'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
         precision: 0
         format: '%u%n'
   homepage:
+    title: Homepage
     intro: "<strong>codebar</strong> is a non-profit initiative that facilitates the growth of a diverse tech community by running regular programming workshops."
     explanation: "Our goal is to enable underrepresented people to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature 'when visiting the homepage', type: :feature do
     visit root_path
   end
 
+  scenario 'the correct page title is rendered' do
+    expect(page).to have_title('Homepage | codebar.io')
+  end
+
   scenario 'i can view the next workshop' do
     expect(page).to have_content "Workshop at #{next_workshop.host.name}"
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,4 +21,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.number_to_currency(20100)).to eq('£20,100')
     end
   end
+
+  describe '#title and #get_title' do
+    it 'sets page title with the given title name' do
+      helper.title("Homapage")
+
+      expect(helper.retrieve_title).to eq('Homapage | codebar.io')
+    end
+
+    it 'sets page title to codebar.io if no title is set' do
+      helper.title
+
+      expect(helper.retrieve_title).to eq('codebar.io')
+    end
+  end
 end


### PR DESCRIPTION
## Resolves #1077 
@notapatch Please review the PR. I added a helper function that evaluate the page title and call it in the application layout to display the page title.
Now, a page title can be added to the different view. I added `Homepage` title only to `Dashboard#show` as this is the root route.
## Screenshots
![Screenshot from 2019-10-15 21-30-27](https://user-images.githubusercontent.com/18237025/66863700-df792400-ef93-11e9-9a8f-6baf6c10d89f.png)


