### PR TITLE
[no deploy] RSpec modernizing - remove monkey patch and tag with metadata

### DIFF
--- a/spec/controllers/admin/member_notes_controller_spec.rb
+++ b/spec/controllers/admin/member_notes_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Admin::MemberNotesController, type: :controller do
+RSpec.describe Admin::MemberNotesController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:chapter_organiser) }
   let!(:member_note) { Fabricate(:member_note) }

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Admin::SponsorsController, type: :controller do
+RSpec.describe Admin::SponsorsController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:member1) { Fabricate(:member) }
   let(:address) { Fabricate(:address) }

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Admin::WorkshopsController, type: :controller do
+RSpec.describe Admin::WorkshopsController, type: :controller do
   let!(:workshop) { Fabricate(:workshop) }
   let(:admin) { Fabricate(:member) }
 

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MembersController, type: :controller do
+RSpec.describe MembersController, type: :controller do
   describe "GET unsubscribe/#token" do
     it "redirects to the subscription path when token is valid" do
       member = Fabricate(:member)

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'a member can' do
+RSpec.feature 'a member can', type: :feature do
   context '#workshop' do
     let(:member) { Fabricate(:member) }
     let(:invitation) { Fabricate(:workshop_invitation, member: member) }

--- a/spec/features/admin/accessing_portal_spec.rb
+++ b/spec/features/admin/accessing_portal_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'admin portal' do
+RSpec.feature 'admin portal', type: :feature do
   scenario 'non admin cannot access the admin portal' do
     member = Fabricate(:member)
     login(member)

--- a/spec/features/admin/announcements_spec.rb
+++ b/spec/features/admin/announcements_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Announcements' do
+RSpec.feature 'Announcements', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_groups) }
 

--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Chapter workshop feedback' do
+RSpec.feature 'Chapter workshop feedback', type: :feature do
   it 'is only available to chapter organisers' do
     member = Fabricate(:member)
     chapter = Fabricate(:chapter)

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Chapters' do
+RSpec.feature 'Chapters', type: :feature do
   let(:member) { Fabricate(:member) }
 
   context 'Authorization smoke test' do

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Event creation' do
+RSpec.feature 'Event creation', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_groups) }
 

--- a/spec/features/admin/groups_spec.rb
+++ b/spec/features/admin/groups_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'admin groups' do
+RSpec.feature 'admin groups', type: :feature do
   context '#creating a new group' do
     let(:member) { Fabricate(:member) }
     let!(:chapter) { Fabricate(:chapter, name: 'Brighton') }

--- a/spec/features/admin/jobs_spec.rb
+++ b/spec/features/admin/jobs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Admin Jobs' do
+RSpec.feature 'Admin Jobs', type: :feature do
   let(:member) { Fabricate(:member) }
 
   before do

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing events' do
+RSpec.feature 'Managing events', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter_with_groups) }
   let!(:event) { Fabricate(:event, confirmation_required: true) }

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing sponsors' do
+RSpec.feature 'Managing sponsors', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }
 

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'managing workshop attendances' do
+RSpec.feature 'managing workshop attendances', type: :feature do
   context 'an admin' do
     let(:member) { Fabricate(:member) }
     let(:chapter) { Fabricate(:chapter) }

--- a/spec/features/admin/managing_meeting_invitations_spec.rb
+++ b/spec/features/admin/managing_meeting_invitations_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing meeting invitations' do
+RSpec.feature 'Managing meeting invitations', type: :feature do
   let(:admin) { Fabricate(:member) }
   let(:meeting) { Fabricate(:meeting) }
 

--- a/spec/features/admin/managing_organisers_spec.rb
+++ b/spec/features/admin/managing_organisers_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing organisers' do
+RSpec.feature 'Managing organisers', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter) }
 

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing meetings' do
+RSpec.feature 'Managing meetings', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }
   let!(:venue) { Fabricate(:sponsor) }

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing users' do
+RSpec.feature 'Managing users', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:chapter_organiser) }
   let!(:invitation) { Fabricate(:attended_workshop_invitation, attending: true, member: member) }

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing workshops' do
+RSpec.feature 'Managing workshops', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }
   let!(:sponsor) { Fabricate(:sponsor) }

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'viewing a Chapter' do
+RSpec.feature 'viewing a Chapter', type: :feature do
   context 'non active chapters' do
     let(:inactive_chapter) { Fabricate(:chapter, active: false) }
 

--- a/spec/features/coach_accepting_invitation_spec.rb
+++ b/spec/features/coach_accepting_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'a Coach can' do
+RSpec.feature 'a Coach can', type: :feature do
   context '#workshop' do
     let(:member) { Fabricate(:member) }
     let(:invitation) { Fabricate(:coach_workshop_invitation, member: member) }

--- a/spec/features/coach_viewing_feedback_spec.rb
+++ b/spec/features/coach_viewing_feedback_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Coach viewing feedback' do
+RSpec.feature 'Coach viewing feedback', type: :feature do
   it 'can access all feedback' do
     coach = Fabricate(:workshop_coach_attendee, name: 'Le name one')
     Fabricate(:coaches, members: [coach])

--- a/spec/features/internationalization_spec.rb
+++ b/spec/features/internationalization_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Internationalization' do
+RSpec.feature 'Internationalization', type: :feature do
   context 'a visitor to the website' do
     context 'views the website in English' do
       scenario 'by default' do

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Jobs' do
+RSpec.feature 'Jobs', type: :feature do
   context 'Listing' do
     context 'a visitor to the website' do
       scenario 'can see a message when there are no available jobs' do

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'when visiting the coaches page' do
+RSpec.feature 'when visiting the coaches page', type: :feature do
   scenario 'I can see the most active coaches' do
     coach = Fabricate(:attended_coach).member
     visit coaches_path

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'events_controller'
 
-feature 'event listing' do
+RSpec.feature 'event listing', type: :feature do
   describe 'I can see the names and titles of events' do
     let!(:upcoming_course) { Fabricate(:course) }
     let!(:upcoming_workshop) { Fabricate(:workshop) }

--- a/spec/features/member/jobs_spec.rb
+++ b/spec/features/member/jobs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Member managing jobs' do
+RSpec.feature 'Member managing jobs', type: :feature do
   let(:member) { Fabricate(:member) }
 
   before do

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'member feedback' do
+RSpec.feature 'member feedback', type: :feature do
   let(:feedback_request) { Fabricate(:feedback_request) }
   let(:valid_token) { feedback_request.token }
   let(:submited_token) { Fabricate(:feedback_request, submited: true).token }

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'A new student signs up' do
+RSpec.feature 'A new student signs up', type: :feature do
   before do
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
       provider: 'github',

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Member portal' do
+RSpec.feature 'Member portal', type: :feature do
   subject { page }
 
   let(:member) { Fabricate(:member) }

--- a/spec/features/sponsors_spec.rb
+++ b/spec/features/sponsors_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Sponsors' do
+RSpec.feature 'Sponsors', type: :feature do
   context 'Listing' do
     scenario 'can see a listing of all non expired job posts' do
       gold_sponsor = Fabricate.create(:sponsor, level: :gold)

--- a/spec/features/subscribing_to_emails_spec.rb
+++ b/spec/features/subscribing_to_emails_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Managing subscriptions' do
+RSpec.feature 'Managing subscriptions', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:group) { Fabricate(:group) }
 

--- a/spec/features/view_event_spec.rb
+++ b/spec/features/view_event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'viewing an event' do
+RSpec.feature 'viewing an event', type: :feature do
   let(:closed_event) { Fabricate(:event, confirmation_required: true, surveys_required: true) }
   let(:open_event) { Fabricate(:event, confirmation_required: false, surveys_required: false) }
 

--- a/spec/features/viewing_a_course_spec.rb
+++ b/spec/features/viewing_a_course_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'viewing a course' do
+RSpec.feature 'viewing a course', type: :feature do
   let(:date_and_time) { Time.zone.now + 1.week }
   let!(:course) { Fabricate(:course) }
 

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'viewing a meeting' do
+RSpec.feature 'viewing a meeting', type: :feature do
   let!(:meeting) { Fabricate(:meeting) }
 
   scenario "i can view a meeting's information" do

--- a/spec/features/viewing_pages_spec.rb
+++ b/spec/features/viewing_pages_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'A visitor to the website' do
+RSpec.feature 'A visitor to the website', type: :feature do
   scenario 'can access and view the cookie policy' do
     visit root_path
 

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'when visiting the homepage' do
+RSpec.feature 'when visiting the homepage', type: :feature do
   let!(:next_workshop) { Fabricate(:workshop) }
   let!(:next_course) { Fabricate(:course) }
   let!(:event) { Fabricate(:event) }

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Viewing a workshop page' do
+RSpec.feature 'Viewing a workshop page', type: :feature do
   let(:workshop) { Fabricate(:workshop) }
   let(:workshop_auto_rsvp_in_past) { Fabricate(:workshop_auto_rsvp_in_past) }
   let(:workshop_auto_rsvp_in_future) { Fabricate(:workshop_auto_rsvp_in_future) }

--- a/spec/lib/services/mailing_list_spec.rb
+++ b/spec/lib/services/mailing_list_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'services/mailing_list'
 
-describe MailingList, wip: true do
+RSpec.describe MailingList, wip: true do
   let(:client) { double(:gibbon) }
   let(:mailing_list) { MailingList.new(:list_id) }
   let(:lists) { double(:lists) }

--- a/spec/lib/verifier_spec.rb
+++ b/spec/lib/verifier_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'verifier'
 
-describe Verifier do
+RSpec.describe Verifier do
   before do
     Planner::Application.config.secret_token = '123'
   end

--- a/spec/mailers/course_invitation_mailer_spec.rb
+++ b/spec/mailers/course_invitation_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CourseInvitationMailer do
+RSpec.describe CourseInvitationMailer, type: :mailer  do
   let(:email) { ActionMailer::Base.deliveries.last }
 
   it '#invite_student' do

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe EventInvitationMailer do
+RSpec.describe EventInvitationMailer, type: :mailer  do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FeedbackRequestMailer do
+RSpec.describe FeedbackRequestMailer, type: :mailer  do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe WorkshopInvitationMailer do
+RSpec.describe WorkshopInvitationMailer, type: :mailer  do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
   let(:member) { Fabricate(:member) }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Address do
+RSpec.describe Address, type: :model  do
   subject(:address) { Fabricate.build(:address) }
 end

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Listable do
+RSpec.describe Listable, type: :model do
   subject(:workshop) { Fabricate(:workshop) }
 
   context 'scopes' do

--- a/spec/models/course_invitation_spec.rb
+++ b/spec/models/course_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CourseInvitation do
+RSpec.describe CourseInvitation, type: :model  do
   let(:invitation) { Fabricate(:course_invitation) }
   let!(:accepted_invitation) { 2.times { Fabricate(:course_invitation, attending: true) } }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Course do
+RSpec.describe Course, type: :model  do
   let(:course) { Fabricate(:course) }
 
   context 'validations' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Event do
+RSpec.describe Event, type: :model  do
   subject(:event) { Fabricate(:event) }
 
   it { should be_valid }

--- a/spec/models/feedback_request_spec.rb
+++ b/spec/models/feedback_request_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FeedbackRequest do
+RSpec.describe FeedbackRequest, type: :model  do
   subject { Fabricate(:feedback_request) }
 
   it { should respond_to(:member) }

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Feedback do
+RSpec.describe Feedback, type: :model  do
   subject(:feedback) { Fabricate.build(:feedback) }
 
   let(:valid_feedback_token) { 'valid_feedback_token' }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Group, type: :model do
+RSpec.describe Group, type: :model do
   subject(:group) { Fabricate.build(:group) }
 
   context 'validations' do

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe InvitationManager do
+RSpec.describe InvitationManager, type: :model  do
   subject(:manager) { InvitationManager.new }
 
   let(:chapter) { Fabricate(:chapter) }

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Invitation do
+RSpec.describe Invitation, type: :model  do
   context 'validations' do
     subject { Invitation.new }
 

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Job, type: :model do
+RSpec.describe Job, type: :model do
   context '#fields' do
     subject(:job) { Fabricate.build(:job) }
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Meeting do
+RSpec.describe Meeting, type: :model  do
   context 'validations' do
     subject { Meeting.new }
 

--- a/spec/models/meeting_talk_spec.rb
+++ b/spec/models/meeting_talk_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MeetingTalk do
+RSpec.describe MeetingTalk, type: :model  do
   context 'validations' do
     subject { MeetingTalk.new }
 

--- a/spec/models/member_note_spec.rb
+++ b/spec/models/member_note_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MemberNote do
+RSpec.describe MemberNote, type: :model do
   context 'Mandatory attributes' do
     it 'Requires a note' do
       note = Fabricate.build(:member_note, note: nil)

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Member do
+RSpec.describe Member, type: :model  do
   context 'mandatory attributes' do
     context 'validations for a logginable member' do
       context 'presence' do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Role do
+RSpec.describe Role, type: :model  do
   context 'scopes' do
     let(:student_role) { Fabricate(:student_role) }
     let(:coach_role) { Fabricate(:coach_role) }

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Sponsor do
+RSpec.describe Sponsor, type: :model  do
   subject(:sponsor) { Fabricate.build(:sponsor) }
 
   it { should respond_to(:name) }

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Tutorial do
+RSpec.describe Tutorial, type: :model  do
   subject(:tutorial) { Fabricate.build(:tutorial) }
 
   it { should respond_to(:title) }

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe WorkshopInvitation do
+RSpec.describe WorkshopInvitation, type: :model  do
   context 'methods' do
     let(:invitation) { Fabricate(:student_workshop_invitation) }
     let!(:accepted_invitation) { 2.times { Fabricate(:workshop_invitation, attending: true) } }

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Workshop do
+RSpec.describe Workshop, type: :model  do
   subject(:workshop) { Fabricate(:workshop) }
 
   context 'time zone fields' do

--- a/spec/models/workshop_sponsor_spec.rb
+++ b/spec/models/workshop_sponsor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe WorkshopSponsor do
+RSpec.describe WorkshopSponsor, type: :model  do
   let!(:workshop) { Fabricate(:workshop) }
 
   context '#scopes' do

--- a/spec/presenters/address_presenter_spec.rb
+++ b/spec/presenters/address_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AddressPresenter do
+RSpec.describe AddressPresenter do
   let(:address) { Fabricate.build(:address) }
   let(:presenter) { AddressPresenter.new(address) }
 

--- a/spec/presenters/chapter_presenter_spec.rb
+++ b/spec/presenters/chapter_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ChapterPresenter do
+RSpec.describe ChapterPresenter do
   let(:chapter) { Fabricate(:chapter_without_organisers) }
   let(:presenter) { ChapterPresenter.new(chapter) }
 

--- a/spec/presenters/course_presenter_spec.rb
+++ b/spec/presenters/course_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CoursePresenter do
+RSpec.describe CoursePresenter do
   let(:course) { double(:course) }
   let(:event) { CoursePresenter.new(course) }
 

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe EventPresenter do
+RSpec.describe EventPresenter do
   let(:workshop) { Fabricate(:workshop) }
   let(:event) { EventPresenter.new(workshop) }
 

--- a/spec/presenters/invitation_presenter_spec.rb
+++ b/spec/presenters/invitation_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe InvitationPresenter do
+RSpec.describe InvitationPresenter do
   let(:invitation) { Fabricate(:student_workshop_invitation) }
   let(:invitation_presenter) { InvitationPresenter.new(invitation) }
 

--- a/spec/presenters/job_presenter_spec.rb
+++ b/spec/presenters/job_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe JobPresenter do
+RSpec.describe JobPresenter do
   let(:presenter) { JobPresenter.new(job) }
 
   context '#published_on' do

--- a/spec/presenters/jobs_presenter_spec.rb
+++ b/spec/presenters/jobs_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe JobsPresenter do
+RSpec.describe JobsPresenter do
   let(:presenter) { JobsPresenter.new(jobs) }
   let(:jobs) { Fabricate.times(4, :job) }
 

--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MeetingPresenter do
+RSpec.describe MeetingPresenter do
   let(:meeting) { Fabricate(:meeting) }
   let(:event) { MeetingPresenter.new(meeting) }
 

--- a/spec/presenters/member_presenter_spec.rb
+++ b/spec/presenters/member_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MemberPresenter do
+RSpec.describe MemberPresenter do
   let(:member) { Fabricate(:member) }
   let(:member_presenter) { MemberPresenter.new(member) }
 

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe WorkshopPresenter do
+RSpec.describe WorkshopPresenter do
   let(:invitations) do
     [Fabricate(:student_workshop_invitation),
      Fabricate(:student_workshop_invitation),

--- a/spec/support/shared_examples/behaves_like_an_invitation.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation.rb
@@ -1,4 +1,4 @@
-shared_examples InvitationConcerns do
+RSpec.shared_examples InvitationConcerns do
   it 'has a token set on creation' do
     expect(invitation.token).to_not be(nil)
   end

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -1,4 +1,4 @@
-shared_examples 'invitation route' do
+RSpec.shared_examples 'invitation route' do
   context 'accept an invitation' do
     scenario 'when there are available spots' do
       Tutorial.create(title: 'title')


### PR DESCRIPTION
The current suite is a mix of new and old style boiler plate and this moves the suite to all modern.
1. Remove the 'describe' and 'feature' monkey patch
2. add metadata types where appropriate: models, features and mailer specs

- only test suite changes / no production code changed

---
### Monkey Patch

Modern RSpec suites remove the monkey patching on the keywords 'describe' and 'feature' by adding 'RSpec' name space.

describe => RSpec.describe
feature => RSpec.feature

[RSpec.describe vs describe](https://stackoverflow.com/questions/24747448/rspec-describe-vs-describe)

---
### Metadata types

RSpec 2 guessed the type of test (model or mailer or feature) from directory structure. RSpec 3 now uses metadata types instead.

RSpec.describe "some test" do => RSpec.describe "some test" type: :model do
RSpec.feature "some test" do => RSpec.feature "some test" type: :feature do

[RSpec directory Structure
](https://relishapp.com/rspec/rspec-rails/docs/directory-structure)

[What does including the type in the describe block of a rspec do?
](https://stackoverflow.com/questions/45023022/what-does-including-the-type-in-the-describe-block-of-a-rspec-do)
