### PR TITLE
Ability to mark a workshop as cancelled #856

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -99,7 +99,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   def workshop_params
     params.require(:workshop).permit(:local_date, :local_time, :chapter_id,
-                                     :invitable, :seats, :rsvp_open_local_date,
+                                     :invitable, :cancelled, :seats, :rsvp_open_local_date,
                                      :rsvp_open_local_time, :ends_at, sponsor_ids: [])
   end
 

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -28,6 +28,7 @@
       %label Organisers
       = f.collection_select :organisers, Member.all, :id, :full_name, { selected: @workshop.organisers.map(&:id) }, { multiple: true }
       = f.input :invitable
+      = f.input :cancelled
   .row
     .large-12.columns.text-right
       = f.submit 'Save', class: 'button'

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -26,6 +26,7 @@
   .row
     .large-6.columns
       = f.input :invitable
+      = f.input :cancelled
   .row
     .large-12.columns.text-right
       = f.submit 'Save', class: 'button'

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -38,6 +38,10 @@
             %small=@workshop.chapter.name
         %h3
           %small #{l(@workshop.date_and_time)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : "" }
+        - if @workshop.cancelled?
+          %label.label.warning This event has been cancelled
+          %br
+          %br
         - if @workshop.rsvp_opens_at
           RSVPs will open at
           = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -7,6 +7,10 @@
           at
           = link_to event.venue.name, event.venue.website
     .event__details
+      - if defined?(event.cancelled) && event.cancelled?
+        %label.label.warning Cancelled
+        %br
+        %br
       .time
         %i.material-icons
           access_time

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -12,7 +12,9 @@
             access_time
           = @workshop.time
           = @workshop.ends_at.present? ? "- " +  l(@workshop.ends_at, format: :time) : ""
-      - if @workshop.date_and_time.past?
+      - if @workshop.cancelled?
+        %label.label.warning This event has been cancelled
+      - if @workshop.date_and_time.past? && !@workshop.cancelled?
         %label.label.warning This event has already taken place.
   %section#banner
     .row

--- a/db/migrate/20191019185043_add_cancelled_to_workshops.rb
+++ b/db/migrate/20191019185043_add_cancelled_to_workshops.rb
@@ -1,0 +1,5 @@
+class AddCancelledToWorkshops < ActiveRecord::Migration
+  def change
+    add_column :workshops, :cancelled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 20191018175052) do
+=======
+ActiveRecord::Schema.define(version: 20191019185043) do
+>>>>>>> Ability to mark a workshop as cancelled
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -560,6 +564,7 @@ ActiveRecord::Schema.define(version: 20191018175052) do
     t.datetime "rsvp_closes_at"
     t.datetime "rsvp_opens_at"
     t.datetime "ends_at"
+    t.boolean  "cancelled",      default: false
   end
 
   add_index "workshops", ["chapter_id"], name: "index_workshops_on_chapter_id", using: :btree

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -119,4 +119,13 @@ feature 'Managing workshops' do
 
     expect(page.current_path).to eq(admin_workshop_path(workshop))
   end
+
+  scenario 'cancelling a workshop' do
+    workshop = Fabricate(:workshop)
+    visit edit_admin_workshop_path(workshop)
+    page.check('workshop_cancelled')
+    click_on 'Save'
+
+    expect(page).to have_content('This event has been cancelled')
+   end   
 end


### PR DESCRIPTION
Added a new migration to add a new column `cancelled`.
When editing a workshop there's a new checkbox `Cancelled` in the bottom of the page.

After setting workshop as cancelled there appears a warning label in events listing, workshop view and workshop admin view.
<img width="533" alt="events-listing" src="https://user-images.githubusercontent.com/1539910/67149537-0a75b780-f2b5-11e9-9f6c-7553c1cedb65.png">
<img width="570" alt="workshop-view" src="https://user-images.githubusercontent.com/1539910/67149542-13ff1f80-f2b5-11e9-959d-a110eec969c9.png">
<img width="471" alt="workshop-admin-view" src="https://user-images.githubusercontent.com/1539910/67149547-1792a680-f2b5-11e9-8cf5-626594a4e432.png">
