### PR TITLE
Enable description field in workshop creation #783

### DIFF
--- a/app/assets/stylesheets/partials/_admin_workshop.scss
+++ b/app/assets/stylesheets/partials/_admin_workshop.scss
@@ -2,3 +2,6 @@
   padding-top: 10px;
 }
 
+#workshop_description {
+  height: 150px;
+}

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -100,7 +100,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
   def workshop_params
     params.require(:workshop).permit(:local_date, :local_time, :chapter_id,
                                      :invitable, :seats, :rsvp_open_local_date,
-                                     :rsvp_open_local_time, :ends_at, sponsor_ids: [])
+                                     :rsvp_open_local_time, :ends_at, :description, sponsor_ids: [])
   end
 
   def chapter_id

--- a/app/views/admin/workshops/_edit_form.html.haml
+++ b/app/views/admin/workshops/_edit_form.html.haml
@@ -13,9 +13,19 @@
   .row
     .large-6.columns
       = f.input :host, as: :select, collection: Sponsor.all, include_blank: true, selected: (@workshop.host.id rescue '')
+  %br
   .row
     .large-6.columns
       = f.association :sponsors
+  %br
+  .row
+    .large-6.columns
+      %h6 Default description text:
+      %small= t("workshops.lead")
+  .row
+    .large-6.columns
+      = f.input :description, as: :text, label: 'Additional description (supports HTML)',
+      placeholder: 'Use this space to write a description of the workshop.'
   %br
   .row
     .large-6.columns

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -19,6 +19,16 @@
   %br
   .row
     .large-6.columns
+      %h6 Default description text:
+      %p
+        %small= t("workshops.lead")
+  .row
+    .large-6.columns
+      = f.input :description, as: :text, label: 'Additional description (supports HTML)',
+      placeholder: 'Use this space to write a description of the workshop.'
+  %br
+  .row
+    .large-6.columns
       .panel.callout
         %p Fill out these fields if you want RSVPs to open automatically at a future time. Leave blank if you'll handle it manually later.
         = f.input :rsvp_open_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -47,6 +47,9 @@
           %strong.label.round.primary #{@workshop.venue.seats} student spots, #{@workshop.venue.coach_spots} coach spots
           - unless @workshop.spaces?
             %label.label.round.warning Full
+          %p.description
+            %br
+            = sanitize(@workshop.description)
     %br
     .row
       .large-3.small-6.columns#host

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -18,7 +18,9 @@
     .row
       .medium-12.columns
         %p.lead
-          Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students.
+          = t("workshops.lead")
+        %p.description
+          = sanitize(@workshop.description)
 
         - unless current_user and current_user.banned?
           = render 'workshop_actions'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -123,6 +123,8 @@ de:
       paper: "Benutze Stift und Papier oder ein Whiteboard! Viele der Lernenden haben keine Vorgeschichte mit der Informatik. Zeichnungen und visuelle Hilfen können sehr nützlich sein."
       stubling: "Lasse zu, dass die Lernenden auch mal stolpern. Wir lernen aus Fehlern, indem wir unseren eigenen Weg von der Frustration zur Lösung des Problems finden. Stehe den Lernenden unterstützend zur Seite, aber lass sie selbständig erkunden."
       suggestions: "Hast du noch Vorschläge? Eröffne einen <a href='https://github.com/codebar/planner'>pull request</a> oder <a href='https://github.com/codebar/planner/issues/new'>erstelle eine issue</a>\""
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Veranstaltungen"
     past: "Vergangene"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,8 @@ en:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -123,6 +123,8 @@ en-AU:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -123,6 +123,8 @@ en-GB:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problems in our own ways. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -123,6 +123,8 @@ en-US:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -123,6 +123,8 @@ es:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -123,6 +123,8 @@ fi:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -123,6 +123,8 @@ fr:
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -123,6 +123,8 @@
       paper: "Use pen and paper or go to a whiteboard! Often students are coming from a non-technical background. Drawing and explaining with visual material is really helpful."
       stubling: "Let them stumble. We learn by making mistakes, getting frustrated, and working through problem in our own way. Be supportive, but let them explore."
       suggestions: "Do you have something to suggest? Make a <a href='https://github.com/codebar/planner'>pull request</a> or <a href='https://github.com/codebar/planner/issues/new'>create an issue</a>"
+  workshops:
+    lead: "Attend our workshops to learn programming in a safe and supportive environment at your own pace, or to share your knowledge and coach our students."
   events:
     title: "Events"
     past: "Past"


### PR DESCRIPTION
Added description field to workshops.

<img width="993" alt="admin-workshop-edit" src="https://user-images.githubusercontent.com/1539910/67163611-a0731600-f379-11e9-9692-27b7e767077c.png">
<img width="970" alt="admin-workshop-view" src="https://user-images.githubusercontent.com/1539910/67163614-a2d57000-f379-11e9-8775-e89cd84246b4.png">
<img width="982" alt="workshop-view-description" src="https://user-images.githubusercontent.com/1539910/67163616-a537ca00-f379-11e9-8543-1956ed6051f0.png">
