### PR TITLE
Replace string array with word array (Rubocop autocomplete)

### DIFF
--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -50,7 +50,7 @@ class Admin::ChaptersController < Admin::ApplicationController
     authorize chapter
     type = params[:type]
 
-    if ['students', 'coaches'].include?(type)
+    if %w[students coaches].include?(type)
       @emails = chapter.send(type).map(&:email).join("\n")
     else
       @emails = chapter.members.pluck(:email).uniq.join("\n")

--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -50,11 +50,11 @@ class Admin::ChaptersController < Admin::ApplicationController
     authorize chapter
     type = params[:type]
 
-    if %w[students coaches].include?(type)
-      @emails = chapter.send(type).map(&:email).join("\n")
-    else
-      @emails = chapter.members.pluck(:email).uniq.join("\n")
-    end
+    @emails = if %w[students coaches].include?(type)
+                chapter.send(type).map(&:email).join("\n")
+              else
+                chapter.members.pluck(:email).uniq.join("\n")
+              end
 
     render plain: @emails
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -84,6 +84,6 @@ class Event < ActiveRecord::Base
   end
 
   def permitted_audience_values
-    ['Students', 'Coaches']
+    %w[Students Coaches]
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,7 +3,7 @@ class Invitation < ActiveRecord::Base
 
   validates :event, :member, presence: true
   validates :member_id, uniqueness: { scope: %i[event_id role] }
-  validates_inclusion_of :role, in: ['Student', 'Coach']
+  validates_inclusion_of :role, in: %w[Student Coach]
 
   belongs_to :event
   belongs_to :member

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -6,7 +6,7 @@ class WorkshopInvitation < ActiveRecord::Base
 
   validates :workshop, :member, presence: true
   validates :member_id, uniqueness: { scope: %i[workshop_id role] }
-  validates_inclusion_of :role, in: ['Student', 'Coach'], allow_nil: true
+  validates_inclusion_of :role, in: %w[Student Coach], allow_nil: true
 
   scope :year, -> (year) { joins(:workshop).where('EXTRACT(year FROM workshops.date_and_time) = ?', year) }
   scope :accepted, -> { where(attending: true) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,13 +65,13 @@ if Rails.env.development?
       'Full-stack Developer'
     ]
 
-    job_companies = [
-      'ACME',
-      'Globex',
-      'Soylent',
-      'Initech',
-      'Umbrella',
-      'Wonka'
+    job_companies = %w[
+      ACME
+      Globex
+      Soylent
+      Initech
+      Umbrella
+      Wonka
     ]
 
     Rails.logger.info "Creatings jobs..."

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -21,6 +21,6 @@ describe Tutorial do
     tutorial_1 = Tutorial.create(title: 'title1')
     tutorial_2 = Tutorial.create(title: 'title2')
 
-    expect(Tutorial.all_titles).to match_array(['title1', 'title2'])
+    expect(Tutorial.all_titles).to match_array(%w[title1 title2])
   end
 end


### PR DESCRIPTION
 - rubocop default
 - rubocop --only Style/WordArray -a

---

[Rubocop WordArray
](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/WordArray)
 - fixed via autocomplete
 - consistency as already used in 12 of the 18 possible places. 


```ruby
EnforcedStyle: brackets

# good
['foo', 'bar', 'baz']

# bad
%w[foo bar baz]
```



