### PR TITLE
Rubocop out of production environment and out of bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development, :test do
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails'
+  gem 'rubocop', '~> 0.75.1', require: false
   gem 'timecop'
   gem 'bullet'
 end
@@ -83,5 +84,4 @@ group :production do
 end
 
 gem 'newrelic_rpm'
-gem 'rubocop', '~> 0.75.1'
 gem 'rollbar'


### PR DESCRIPTION
  - rubocop is a gem for development and testing it should
    not have been in production.
  - rubocop is a tool that runs separately from the application's
    bundle. When rails starts planner app up it doesn't need
    rubocop (require: false)

---

I have been looking at Rubocop and I would like to feed this in to simplify the final PR. 


### References

[Why does rubocop recommend require: false in Gemfile?](https://stackoverflow.com/questions/35004020/why-does-rubocop-recommend-require-false-in-gemfile)