### PR TITLE
Fix: lock travis to bundler = 1.17.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 dist: xenial
 language: ruby
-bundler_args: --without development
 rvm:
   - 2.4.2
 services:
   - postgresql
+before_install:
+  - gem install bundler --version '~> 1.17.3' --no-document
+  - bundle _1.17.3_ install --without development
 before_script:
   - bundle exec rake db:create db:schema:load
 


### PR DESCRIPTION
 - travis has been ignoring restriction and building with 2.0.2
   commit fixes bundler to 1.17.3 matching Gemfile.lock
   warning appears as:
   rails (4.2.11.1) has dependency bundler (< 2.0, >= 1.3.0),
   which is unsatisfied by the current bundler version 2.0.2,
   so the dependency is being ignored
 - rails_5 remove restriction

---
In development we use bundler 1.17.X we can see it in the Gemfile.lock at the bottom

However, Travis has been using 2.0.2 :-|

![travis-putting-own-bundler-in](https://user-images.githubusercontent.com/1710795/67679627-66a99d00-f981-11e9-9e25-665e8cb089b6.png)
Say what now?
![Screenshot 2019-10-28 at 12 51 16](https://user-images.githubusercontent.com/1710795/67679855-f18a9780-f981-11e9-9474-9ad330583b58.png)




