### PR TITLE
travis move rake tasks to script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ rvm:
   - 2.4.2
 services:
   - postgresql
-before_script:
-  - bundle exec rake db:create db:schema:load
-
 script:
+  - bundle exec rake db:create db:schema:load
   - bundle exec rake
 addons:
   code_climate:


### PR DESCRIPTION
  - most travis users keep rake tasks in the script and use
    the before_script for copying files. We should to
  - simplifies the script

---
[Actually depends on this first and then needs merge](https://github.com/codebar/planner/pull/1128)

Edit:
after dependency - @matyikriszta ready for review
