### PR TITLE
[Rubocop] Change update_attribute to update (again)

### DIFF
--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -10,7 +10,7 @@ describe Workshop do
 
     context 'date_and_time' do
       it 'saves the local time in UTC' do
-        workshop.update_attributes!(
+        workshop.update!(
           local_date: '12/06/2015',
           local_time: '18:30'
         )
@@ -28,7 +28,7 @@ describe Workshop do
 
     context 'rsvp_opens_at' do
       it 'saves the local time in UTC' do
-        workshop.update_attributes!(
+        workshop.update!(
           rsvp_open_local_date: '12/06/2015',
           rsvp_open_local_time: '18:30'
         )

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -78,7 +78,7 @@ shared_examples 'invitation route' do
     end
 
     scenario 'when already RSVPd to another event on same evening' do
-      invitation.update_attributes(attending: true, member_id: member.id)
+      invitation.update(attending: true, member_id: member.id)
 
       invitation2 = Fabricate(:coach_workshop_invitation)
       invitation2_route = invitation_path(invitation2)
@@ -91,7 +91,7 @@ shared_examples 'invitation route' do
     end
 
     scenario 'when already RSVPd to another event on same evening and attempting to RSVP directly through the link' do
-      invitation.update_attributes(attending: true, member_id: member.id)
+      invitation.update(attending: true, member_id: member.id)
 
       invitation2 = Fabricate(:coach_workshop_invitation)
       invitation2_route = invitation_path(invitation2)


### PR DESCRIPTION
  - rails 4 aliased update_attribute to update
  - rails 6 deprecates update_attributes
  - rails 6.1 removes update_attributes
  - https://edgeguides.rubyonrails.org/6_0_release_notes.html#active-record-deprecations
---
@matyikriszta  ready to review: We did these previously but I missed these from the spec directory