### PR TITLE
[Rubocop] Refactor unless/x.present? to if/x.blank?

### DIFF
--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -17,7 +17,7 @@ class Admin::SponsorsController < Admin::ApplicationController
 
   def create
     @sponsor = Sponsor.new(sponsor_params)
-    @sponsor.build_address unless @sponsor.address.present?
+    @sponsor.build_address if @sponsor.address.blank?
     authorize @sponsor
     if @sponsor.save
       flash[:notice] = "Sponsor #{@sponsor.name} created"
@@ -31,7 +31,7 @@ class Admin::SponsorsController < Admin::ApplicationController
   def edit
     @sponsor = Sponsor.find(params[:id])
     authorize @sponsor
-    @sponsor.build_address unless @sponsor.address.present?
+    @sponsor.build_address if @sponsor.address.blank?
     @sponsor.contacts.build
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -70,8 +70,8 @@ class Event < ActiveRecord::Base
   end
 
   def invitability
-    errors.add(:coach_spaces, 'must be set') unless self.coach_spaces.present?
-    errors.add(:student_space, 'must be set') unless self.student_spaces.present?
+    errors.add(:coach_spaces, 'must be set') if self.coach_spaces.blank?
+    errors.add(:student_space, 'must be set') if self.student_spaces.blank?
     errors.add(:invitable, 'Fill in all invitations details to make the event invitable') \
       unless self.coach_spaces.present? && self.student_spaces.present?
   end


### PR DESCRIPTION
 - rails defines present? as !blank? if we take advantage of that
   we can make it easier to reason
 - rubocop --only Rails/Blank
 - rubocop rails default

---

```
  # activesupport/lib/active_support/core_ext/object/blank.rb
  # An object is present if it's not blank.
  #
  # @return [true, false]
  def present?
    !blank?
  end

```

[Rubocop Rails Blank
](https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/Blank)