### PR TITLE
Refactor conditionals to guard clauses

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -122,12 +122,11 @@ class Admin::WorkshopsController < Admin::ApplicationController
 
   def set_host(host_id)
     return unless host_id
-
     host = @workshop.workshop_sponsors.find_or_initialize_by(sponsor_id: host_id)
-    unless @workshop.host.eql?(host.sponsor)
-      @workshop.workshop_sponsors.where(sponsor: @workshop.host).destroy_all
-      host.update(host: true)
-    end
+    return if @workshop.host.eql?(host.sponsor)
+
+    @workshop.workshop_sponsors.where(sponsor: @workshop.host).destroy_all
+    host.update(host: true)
   end
 
   def set_organisers(organiser_ids)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -29,11 +29,10 @@ class EventsController < ApplicationController
 
     @event = EventPresenter.new(event)
     @host_address = AddressPresenter.new(@event.venue.address)
+    return unless logged_in?
 
-    if logged_in?
-      invitation = Invitation.find_by(member: current_user, event: event, attending: true)
-      return redirect_to event_invitation_path(@event, invitation) if invitation
-    end
+    invitation = Invitation.find_by(member: current_user, event: event, attending: true)
+    return redirect_to event_invitation_path(@event, invitation) if invitation
   end
 
   def student

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -13,10 +13,10 @@ class MembersController < ApplicationController
   def step1
     @suppress_notices = true
     @member = current_user
-    if request.post? || request.put?
-      if @member.update(member_params)
-        return redirect_to step2_member_path
-      end
+    return unless request.post? || request.put?
+
+    if @member.update(member_params)
+      return redirect_to step2_member_path
     end
   end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -44,9 +44,9 @@ class Chapter < ActiveRecord::Base
   private
 
   def time_zone_exists
-    if time_zone && ActiveSupport::TimeZone[time_zone].nil?
-      errors.add(:time_zone, 'does not exist')
-    end
+    return unless time_zone && ActiveSupport::TimeZone[time_zone].nil?
+
+    errors.add(:time_zone, 'does not exist')
   end
 
   def set_slug

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -11,10 +11,9 @@ class Feedback < ActiveRecord::Base
 
   def coach_field_has_a_coach_role?
     return false unless coach_id
+    return if Member.find(coach_id).groups.coaches.any?
 
-    unless Member.find(coach_id).groups.coaches.any?
-      errors.add(:coach, "Coach member doesn't have 'coach' role.")
-    end
+    errors.add(:coach, "Coach member doesn't have 'coach' role.")
   end
 
   def self.submit_feedback(params, token)

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -32,8 +32,8 @@ class WorkshopInvitation < ActiveRecord::Base
   end
 
   def email
-    if for_student?
-      WorkshopInvitationMailer.invite_student(self.workshop, self.member, self).deliver_now
-    end
+    return unless for_student?
+
+    WorkshopInvitationMailer.invite_student(self.workshop, self.member, self).deliver_now
   end
 end

--- a/app/presenters/sponsor_presenter.rb
+++ b/app/presenters/sponsor_presenter.rb
@@ -12,9 +12,9 @@ class SponsorPresenter < BasePresenter
   end
 
   def contact_full_name
-    if model.contact_first_name && model.contact_surname
-      "#{model.contact_first_name.capitalize} #{model.contact_surname.capitalize}"
-    end
+    return unless model.contact_first_name && model.contact_surname
+
+    "#{model.contact_first_name.capitalize} #{model.contact_surname.capitalize}"
   end
 
   private


### PR DESCRIPTION
This is a Rubocop but not automatic replacement - so it needs to be read through a little slower.  It does tell you what you need to do. The replacement pattern is: 
 
| Old Conditional | New guard clause |
|:-----------|:--------------|
|  `if ( clause ) ` |  `return unless (clause)` |
|  `unless ( clause )`  |  `return if (clause`) |

### Tests

Before I changed anything I put `raise 'error'` in the conditional to see if some tests fail - these all do so there is some protection.  There are a couple of them I haven't converted, yet, because they had no tests to protect them.

```ruby
unless (clause)
  raise "error"
  # code to run if clause passed
end
```

#### To see the errors:

`rubocop --only Style/GuardClause`
