### PR TITLE
[Rubocop] Freeze mutable constants

### DIFF
--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -2,7 +2,7 @@ class EventPresenter < BasePresenter
   PRESENTER = { workshop: 'WorkshopPresenter',
                 course: 'CoursePresenter',
                 meeting: 'MeetingPresenter',
-                event: 'EventPresenter' }
+                event: 'EventPresenter' }.freeze
 
   def self.decorate_collection(collection)
     collection.map { |e| PRESENTER[e.class.to_s.downcase.to_sym].constantize.new(e) }


### PR DESCRIPTION
 - without this change constants can be changed without any
   error.
 - rubocop --only Style/MutableConstant
 - also changed parenthesis to square brackets
---

[Rubocop Mutable Constant](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/MutableConstant)


### Further Reading
[Why are there frozen constants everywhere?](https://stackoverflow.com/questions/27702540/why-are-there-frozen-constants-everywhere)
