### PR TITLE
Fix spec: remove order dependence from scope test (flaky)

### DIFF
--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -45,11 +45,18 @@ describe WorkshopInvitation do
       expect(WorkshopInvitation.year((Time.zone.now - 2.years).year).count).to eq(5)
     end
 
-    it '#not_reminded' do
-      not_reminded = Fabricate.times(3, :student_workshop_invitation, reminded_at: nil)
-      Fabricate.times(2, :workshop_invitation, reminded_at: 3.hours.ago)
+    context '#not_reminded' do
+      it 'includes invitations without reminders' do
+        not_reminded = Fabricate(:student_workshop_invitation, reminded_at: nil)
 
-      expect(WorkshopInvitation.not_reminded).to eq(not_reminded)
+        expect(WorkshopInvitation.not_reminded).to include(not_reminded)
+      end
+
+      it 'excludes invitations with reminders' do
+        reminded = Fabricate(:workshop_invitation, reminded_at: 3.hours.ago)
+
+        expect(WorkshopInvitation.not_reminded).not_to include(reminded)
+      end
     end
 
     it '#on_waiting_list' do


### PR DESCRIPTION
- flaky test 
- test expected an array of ordered items
   - sql does not guarantee any order of items (unless order
     applied)
   - the test will occasionally fail
 - test should be if the scope includes or excludes an item
---

The test structure I chose follows the advice of the RSpec inventor - I have updated his example from the older `should` style to `expect` style:


> Small style matter, but I've leaning towards more declarative sounding
> example names:
> 

```
describe User, ".admins" do
  it "includes users with admin flag" do
    admin = User.create! :admin => true
    expect(User.admin).to include(admin)
  end

  it "excludes users without admin flag" do
    non_admin = User.create! :admin => false
    expect(User.admin).to_not include(non_admin)
  end
end

class User < ActiveRecord::Base
  named_scope :admins, :conditions => {:admin => true}
end
...

FWIW,
David
```
### Reference

[ David Chelimsky (the inventor of RSpec) on testing scopes with RSpec](https://groups.google.com/forum/#!topic/rspec/ZwbD8szu-X8)

