### PR TITLE
Change Dockerfile to install google-chrome-stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -ex; \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable --no-install-recommends \
+    && apt-get install -y google-chrome-stable --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /planner


### PR DESCRIPTION
- change google chrome to stable version instead of an unstable newer version
- today:
  - stable chrome is   78
  - unstable chrome is 80
- depending on where we are in the chrome release cycle the drivers may not work.

---
Fixes https://github.com/codebar/planner/issues/1144

We require ChromeDriver to run our browser tests. This is currently installed by Chromedriver helper which by default installs the latest driver. 

[New ChromeDrivers are released when Chrome goes beta](https://sites.google.com/a/chromium.org/chromedriver/) - See image below: 
![Screenshot 2019-11-03 at 23 32 05](https://user-images.githubusercontent.com/1710795/68094133-7fd8af00-fe95-11e9-8958-86227802d432.png)

So, as of today Chrome 79 is in beta and this is the latest driver.  However, Planner’s Docker image installs the [pre-beta, unstable, Chrome 80 version.](https://www.ubuntuupdates.org/ppa/google_chrome)

![Screenshot 2019-11-03 at 23 37 07](https://user-images.githubusercontent.com/1710795/68094178-0db49a00-fe96-11e9-80c2-9c1895a343c3.png)

We are installing a Chrome version, 80, that has no chromedriver. When we run tests they fail. Saying we don't support this version of Chrome: 

![Screenshot 2019-11-03 at 23 51 12](https://user-images.githubusercontent.com/1710795/68094281-af3beb80-fe96-11e9-82c1-8da111319412.png)

This change installs Stable which will be covered by Chromedriver.


