### PR TITLE
Changed log_level in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Planner::Application.configure do
   config.assets.debug = true
 
   config.logger = Logger.new(STDOUT)
-  config.log_level = :debug
+  config.log_level = :info
 
   config.after_initialize do
     Bullet.enable = true


### PR DESCRIPTION
I changed the log_level from debug to info in order to cut down on excessive screen output.  Now the build process clearly displays the deprecation warnings that were previously pushed off the terminal scrollback by gratuitous news of successful database transactions.