### PR TITLE
Fix flaky test: avoid ActionMailer static text test over newline

### DIFF
--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -27,8 +27,7 @@ describe WorkshopInvitationMailer do
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match('you should keep your laptop with you and check your email during the afternoon on the day of the workshop.')
-    expect(email.body.encoded).to match("This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
+    expect(email.body.encoded).to match("the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end


### PR DESCRIPTION
 - waitlist_reminder test is matching text written into the
   view. As you would expect this works 99% of the time. However,
   occasionally, it fails to match in the CI, Travis, and produces
   an error that it can't find the string.
 - Best guess is that it is because of the newline added by the mailer
   system (=0D)
 - Testing a static string in the view adds no value
   - we can see the text in waiting_list_reminder.html.haml
   - we already test the subject which is also unique
 - Keep the dynamic text test but with shorter static text
 - Summary: I do not know why this error occurs. Just testing long
   static text adds nothing except another flaky test. We should
   want to avoid it.

---
Fix to avoid this problem
https://github.com/codebar/planner/pull/1157#pullrequestreview-323301483

@matyikriszta - ready to review
