### PR TITLE
Accept CoC as Terms and Conditions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_service
 
   before_action :set_locale
+  before_action :accept_terms, if: :logged_in?
 
   def render_not_found
     respond_to do |format|
@@ -54,6 +55,11 @@ class ApplicationController < ActionController::Base
 
   def logged_in?
     current_user?
+  end
+
+  def accept_terms
+    store_path
+    redirect_to terms_and_conditions_path if current_user.accepted_toc_at.blank?
   end
 
   def authenticate_member!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,6 +64,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def store_path
+    session[:previous_request_url] = request.url
+  end
+
+  def previous_path
+    session[:previous_request_url]
+  end
+
   def finish_registration
     if current_user.requires_additional_details?
       redirect_to step1_member_path unless providing_additional_details?

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -48,7 +48,7 @@ class AuthServicesController < ApplicationController
         session[:oauth_token]        = omnihash[:credentials][:token]
         session[:oauth_token_secret] = omnihash[:credentials][:secret]
 
-        redirect_to step1_member_path(member_type: member_type), notice: 'Thanks for signing up. Please fill in your details to complete the registration process.'
+        redirect_to step1_member_path(member_type: member_type)
       end
     end
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,7 @@
 class DashboardController < ApplicationController
-  before_action :is_logged_in?, only: [:dashboard]
+  before_action :is_logged_in?, only: %i[dashboard]
+  skip_before_action :accept_terms, except: %i[dashboard show]
+
   DEFAULT_UPCOMING_EVENTS = 5
 
   helper_method :year_param

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -11,8 +11,11 @@ class MembersController < ApplicationController
   end
 
   def step1
-    @suppress_notices = true
+    store_path and return redirect_to(terms_and_conditions_path) if current_user.accepted_toc_at.blank?
+
     @member = current_user
+    @suppress_notices = true
+    flash[notice] = 'Thanks for signing up. Please fill in your details to complete the registration process.'
     return unless request.post? || request.put?
 
     if @member.update(member_params)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -11,7 +11,7 @@ class MembersController < ApplicationController
   end
 
   def step1
-    store_path and return redirect_to(terms_and_conditions_path) if current_user.accepted_toc_at.blank?
+    accept_terms
 
     @member = current_user
     @suppress_notices = true

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -15,7 +15,7 @@ class MembersController < ApplicationController
 
     @member = current_user
     @suppress_notices = true
-    flash[notice] = 'Thanks for signing up. Please fill in your details to complete the registration process.'
+    flash[notice] = I18n.t('notifications.signing_up')
     return unless request.post? || request.put?
 
     if @member.update(member_params)

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -1,0 +1,25 @@
+class TermsAndConditionsController < ApplicationController
+  before_action :logged_in?
+
+  def show
+    @terms_and_conditions_form = TermsAndConditionsForm.new
+  end
+
+  def update
+    @terms_and_conditions_form = TermsAndConditionsForm.new(terms_params)
+    if @terms_and_conditions_form.valid?
+      member = current_user
+      member.update_attribute(:accepted_toc_at, Time.zone.now)
+      redirect_to previous_path
+    else
+      flash[notice] = I18n.t('members.terms_and_conditions.messages.notice')
+      render :show
+    end
+  end
+
+  private
+
+  def terms_params
+    params.require(:terms_and_conditions_form).permit(:terms)
+  end
+end

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -1,5 +1,6 @@
 class TermsAndConditionsController < ApplicationController
   before_action :logged_in?
+  skip_before_action :accept_terms
 
   def show
     @terms_and_conditions_form = TermsAndConditionsForm.new

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -13,7 +13,7 @@ class TermsAndConditionsController < ApplicationController
       member.update_attribute(:accepted_toc_at, Time.zone.now)
       redirect_to previous_path
     else
-      flash[notice] = I18n.t('members.terms_and_conditions.messages.notice')
+      flash[notice] = I18n.t('terms_and_conditions.messages.notice')
       render :show
     end
   end

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -10,7 +10,8 @@ class TermsAndConditionsController < ApplicationController
     @terms_and_conditions_form = TermsAndConditionsForm.new(terms_params)
     if @terms_and_conditions_form.valid?
       member = current_user
-      member.update_attribute(:accepted_toc_at, Time.zone.now)
+      member.accepted_toc_at = Time.zone.now
+      member.save(validate: false)
       redirect_to previous_path
     else
       flash[notice] = I18n.t('terms_and_conditions.messages.notice')

--- a/app/form_models/terms_and_conditions_form.rb
+++ b/app/form_models/terms_and_conditions_form.rb
@@ -1,0 +1,7 @@
+class TermsAndConditionsForm
+  include ActiveModel::Model
+
+  attr_accessor :terms
+
+  validates :terms, acceptance: true
+end

--- a/app/views/terms_and_conditions/show.html.haml
+++ b/app/views/terms_and_conditions/show.html.haml
@@ -4,13 +4,13 @@
       %h1= t('members.terms_and_conditions.title')
       %p
         = t('members.terms_and_conditions.body')
-        = link_to t('members.terms_and_conditions.link_text'), code_of_conduct_path
+        %br
+          = link_to t('members.terms_and_conditions.link_text'), code_of_conduct_path, target: '_blank'
 
   = simple_form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|
     .row
-      .large-6.large-offset-3.columns
-        = f.check_box :terms
-        = f.label :terms, t('members.terms_and_conditions.agree')
+      .large-12.columns
+        = f.input :terms, as: :boolean, label: t('members.terms_and_conditions.agree'), wrapper: :checkbox
     .row
-      .large-6.large-offset-3.columns
+      .large-12.columns
         = f.submit t('members.terms_and_conditions.accept'), class: 'button round right'

--- a/app/views/terms_and_conditions/show.html.haml
+++ b/app/views/terms_and_conditions/show.html.haml
@@ -1,0 +1,16 @@
+%section#banner
+  .row
+    .medium-12.columns
+      %h1= t('members.terms_and_conditions.title')
+      %p
+        = t('members.terms_and_conditions.body')
+        = link_to t('members.terms_and_conditions.link_text'), code_of_conduct_path
+
+  = simple_form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|
+    .row
+      .large-6.large-offset-3.columns
+        = f.check_box :terms
+        = f.label :terms, t('members.terms_and_conditions.agree')
+    .row
+      .large-6.large-offset-3.columns
+        = f.submit t('members.terms_and_conditions.accept'), class: 'button round right'

--- a/app/views/terms_and_conditions/show.html.haml
+++ b/app/views/terms_and_conditions/show.html.haml
@@ -1,16 +1,16 @@
 %section#banner
   .row
     .medium-12.columns
-      %h1= t('members.terms_and_conditions.title')
+      %h1= t('terms_and_conditions.title')
       %p
-        = t('members.terms_and_conditions.body')
+        = t('terms_and_conditions.body')
         %br
-          = link_to t('members.terms_and_conditions.link_text'), code_of_conduct_path, target: '_blank'
+          = link_to t('terms_and_conditions.link_text'), code_of_conduct_path, target: '_blank'
 
   = simple_form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|
     .row
       .large-12.columns
-        = f.input :terms, as: :boolean, label: t('members.terms_and_conditions.agree'), wrapper: :checkbox
+        = f.input :terms, as: :boolean, wrapper: :checkbox
     .row
       .large-12.columns
-        = f.submit t('members.terms_and_conditions.accept'), class: 'button round right'
+        = f.submit t('terms_and_conditions.accept'), class: 'button round right'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,14 +193,6 @@ en:
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"
-    terms_and_conditions:
-      title: 'Terms and Conditions'
-      body: 'Before you can proceed you must first read our Code of Conduct and agree to abide by it.'
-      link_text: 'Read codebar''s Code of Conduct'
-      agree: 'I have read codebar''s Code of Conduct and agree with all of its terms.'
-      accept: 'Accept'
-      messages:
-        notice: 'You have to accept the Terms and Conditions before you are able to proceed.'
     new:
       intro: "We offer a welcoming, inclusive and learning-friendly environment, and have a zero tolerance policy towards any form of harassment or inappropriate behavior. Before you sign up, read our"
       students:
@@ -209,6 +201,13 @@ en:
         criteria_brief: "as our workshops are only available to women, LGBTQ, people from underrepresented minority groups."
         github: "Lastly, when you click the sign up button, you'll be taken to something called GitHub. After logging in with a GitHub account, you'll be taken back to the codebar website. If you don't have an account yet, you'll need to create one. It doesn't take long and it's something that will come in handy when you get started with coding!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
+  terms_and_conditions:
+    title: 'Terms and Conditions'
+    body: 'Before you can proceed you must first read our Code of Conduct and agree to abide by it.'
+    link_text: 'Read codebar''s Code of Conduct'
+    accept: 'Accept'
+    messages:
+      notice: 'You have to accept the Terms and Conditions before you are able to proceed.'
   footer:
     email_us: "Send us an email at"
     contact_info: "Contact Info:"
@@ -473,6 +472,9 @@ en:
       job:
         remote: Only check if the role is remote only
         salary: Annual pay before tax, without commas or decimal points
+    labels:
+      terms_and_conditions_form:
+        terms: 'I have read codebar''s Code of Conduct and agree with all of its terms.'
   activerecord:
     attributes:
       job:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,14 @@ en:
     sign_up_as_student: "I understand and meet the eligibility criteria. Sign me up as a student"
     sign_up_as_coach: "Sign up as a coach"
     code_of_conduct: "code of conduct"
+    terms_and_conditions:
+      title: 'Terms and Conditions'
+      body: 'Before you can proceed you must first read our Code of Conduct and agree to abide by it.'
+      link_text: 'Read codebar''s Code of Conduct'
+      agree: 'I have read codebar''s Code of Conduct and agree with all of its terms.'
+      accept: 'Accept'
+      messages:
+        notice: 'You have to accept the Terms and Conditions before you are able to proceed.'
     new:
       intro: "We offer a welcoming, inclusive and learning-friendly environment, and have a zero tolerance policy towards any form of harassment or inappropriate behavior. Before you sign up, read our"
       students:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
   notifications:
     provider_already_connected: 'You are already signed in!'
     not_logged_in: "You must be logged in to access this page."
+    signing_up: 'Thanks for signing up. Please fill in your details to complete the registration process.'
   navigation:
     dashboard: "Dashboard"
     code_of_conduct: "Code of conduct"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Planner::Application.routes.draw do
     get 'step2'
   end
 
+  resource :terms_and_conditions, only: %i[show update patch]
+
   resources :jobs, only: %i[index show]
 
   namespace :member, path: 'my' do

--- a/db/migrate/20200120111440_add_accepted_toc_at_to_member.rb
+++ b/db/migrate/20200120111440_add_accepted_toc_at_to_member.rb
@@ -1,0 +1,5 @@
+class AddAcceptedTocAtToMember < ActiveRecord::Migration
+  def change
+    add_column :members, :accepted_toc_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191018175052) do
+ActiveRecord::Schema.define(version: 20200120111440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -398,6 +398,7 @@ ActiveRecord::Schema.define(version: 20191018175052) do
     t.boolean  "received_coach_welcome_email",   default: false
     t.boolean  "received_student_welcome_email", default: false
     t.string   "pronouns"
+    t.datetime "accepted_toc_at"
   end
 
   create_table "members_permissions", id: false, force: :cascade do |t|

--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -8,6 +8,10 @@ Fabricator(:member) do
   auth_services(count: 1) { Fabricate(:auth_service) }
 end
 
+Fabricator(:member_with_toc, from: :member) do
+  accepted_toc_at { Time.zone.now }
+end
+
 Fabricator(:student, from: :member) do
   groups(count: 2) { |attrs, i| Fabricate(:students) }
 end

--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -6,10 +6,11 @@ Fabricator(:member) do
   about_you { Faker::Lorem.sentence }
   twitter { Faker::Name.first_name }
   auth_services(count: 1) { Fabricate(:auth_service) }
+  accepted_toc_at { Time.zone.now }
 end
 
-Fabricator(:member_with_toc, from: :member) do
-  accepted_toc_at { Time.zone.now }
+Fabricator(:member_without_toc, from: :member) do
+  accepted_toc_at { nil }
 end
 
 Fabricator(:student, from: :member) do

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.feature 'Accepting Terms and Conditions', type: :feature, wip: true do
+  before do
+    mock_github_auth
+  end
+
+  context 'When a user signs up to codebar' do
+    scenario 'they can''t proceed unless they accept the ToCs' do
+      visit root_path
+      click_on 'Sign up as a student'
+      click_on 'I understand and meet the eligibility criteria. Sign me up as a student'
+
+      expect(page).to have_current_path(terms_and_conditions_path)
+
+      click_on 'Accept'
+      expect(page).to have_current_path(terms_and_conditions_path)
+      expect(page).to have_content('You have to accept the Terms and Conditions before you are able to proceed.')
+    end
+
+    scenario 'they can fill in their details after they accept the ToCs' do
+      visit root_path
+      click_on 'Sign up as a student'
+      click_on 'I understand and meet the eligibility criteria. Sign me up as a student'
+
+      expect(page).to have_current_path(terms_and_conditions_path)
+
+      check I18n.t('members.terms_and_conditions.agree')
+      click_on 'Accept'
+
+      expect(page).to have_current_path(step1_member_path(member_type: 'student'))
+    end
+  end
+
+  context 'When an existing member logs in' do
+    context 'and they have not yet accepted codebar''s ToCs' do
+      scenario 'they have to accept before proceeding' do
+        pending
+      end
+    end
+
+    context 'and they have already accepted codebar''s ToCs' do
+      scenario 'they will be redirected to the link they were trying to access' do
+        pending
+      end
+    end
+  end
+end

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -19,6 +19,21 @@ RSpec.feature 'Accepting Terms and Conditions', type: :feature do
       expect(page).to have_content('You have to accept the Terms and Conditions before you are able to proceed.')
     end
 
+    scenario 'they can read the Code of Conduct before accepting the ToCs', js: true do
+      visit root_path
+      click_on 'Sign up as a student'
+      click_on 'I understand and meet the eligibility criteria. Sign me up as a student'
+
+      expect(page).to have_current_path(terms_and_conditions_path)
+
+      click_on I18n.t('members.terms_and_conditions.link_text')
+      page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
+
+      expect(page).to have_content(I18n.t('code_of_conduct.title'))
+      expect(page).to have_content(I18n.t('code_of_conduct.summary.title'))
+      expect(page).to have_content(I18n.t('code_of_conduct.content.title'))
+    end
+
     scenario 'they can fill in their details after they accept the ToCs' do
       visit root_path
       click_on 'Sign up as a student'

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Accepting Terms and Conditions', type: :feature do
 
       expect(page).to have_current_path(terms_and_conditions_path)
 
-      click_on I18n.t('members.terms_and_conditions.link_text')
+      click_on I18n.t('terms_and_conditions.link_text')
       page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 
       expect(page).to have_content(I18n.t('code_of_conduct.title'))
@@ -41,7 +41,7 @@ RSpec.feature 'Accepting Terms and Conditions', type: :feature do
 
       expect(page).to have_current_path(terms_and_conditions_path)
 
-      check I18n.t('members.terms_and_conditions.agree')
+      check :terms
       click_on 'Accept'
 
       expect(page).to have_current_path(step1_member_path(member_type: 'student'))

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
-RSpec.feature 'Accepting Terms and Conditions', type: :feature, wip: true do
-  before do
-    mock_github_auth
-  end
+RSpec.feature 'Accepting Terms and Conditions', type: :feature do
 
   context 'When a user signs up to codebar' do
+    before do
+      mock_github_auth
+    end
+
     scenario 'they can''t proceed unless they accept the ToCs' do
       visit root_path
       click_on 'Sign up as a student'
@@ -33,15 +34,26 @@ RSpec.feature 'Accepting Terms and Conditions', type: :feature, wip: true do
   end
 
   context 'When an existing member logs in' do
+
     context 'and they have not yet accepted codebar''s ToCs' do
-      scenario 'they have to accept before proceeding' do
-        pending
+      scenario 'they have to accept before continuing to the page they want to get' do
+        member = Fabricate(:member_without_toc)
+        login(member)
+        visit root_path
+        expect(page).to have_current_path(terms_and_conditions_path)
+
+        accept_toc
+        expect(page).to have_current_path(root_path)
       end
     end
 
     context 'and they have already accepted codebar''s ToCs' do
       scenario 'they will be redirected to the link they were trying to access' do
-        pending
+        member = Fabricate(:member)
+        login(member)
+
+        visit dashboard_path
+        expect(page).to have_current_path(dashboard_path)
       end
     end
   end

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'A new student signs up', type: :feature do
   end
 
   scenario 'A visitor must fill in all mandatory fields in order to sign up' do
-    member = Fabricate(:member_with_toc, name: nil, surname: nil, email: nil, about_you: nil)
+    member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil)
     member.update(can_log_in: true)
     login member
 

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -9,11 +9,14 @@ RSpec.feature 'A new student signs up', type: :feature do
     visit root_path
     click_on 'Sign up as a student'
     click_on 'I understand and meet the eligibility criteria. Sign me up as a student'
+
+    accept_toc
+
     expect(page).to have_current_path(step1_member_path(member_type: 'student'))
   end
 
   scenario 'A visitor must fill in all mandatory fields in order to sign up' do
-    member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil)
+    member = Fabricate(:member_with_toc, name: nil, surname: nil, email: nil, about_you: nil)
     member.update(can_log_in: true)
     login member
 
@@ -30,6 +33,8 @@ RSpec.feature 'A new student signs up', type: :feature do
   scenario 'A new member details are successfully captured' do
     visit new_member_path
     click_on 'Sign up as a coach'
+
+    accept_toc
 
     fill_in 'member_pronouns', with: 'she'
     fill_in 'member_name', with: 'Jane'

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -2,15 +2,7 @@ require 'spec_helper'
 
 RSpec.feature 'A new student signs up', type: :feature do
   before do
-    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
-      provider: 'github',
-      uid: '42',
-      credentials: { token: 'Fake token' },
-      info: {
-        email: Faker::Internet.email,
-        name: Faker::Name.name
-      }
-    )
+    mock_github_auth
   end
 
   scenario 'A visitor can access signups through the landing page' do

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'A new student signs up', type: :feature do
 
     accept_toc
 
+    expect(page).to have_content('Thanks for signing up. Please fill in your details to complete the registration process.')
     expect(page).to have_current_path(step1_member_path(member_type: 'student'))
   end
 

--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -24,6 +24,19 @@ module LoginHelpers
     member.add_role(:organiser, chapter)
     login(member)
   end
+
+  def mock_github_auth
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+      provider: 'github',
+      uid: '42',
+      credentials: { token: 'Fake token' },
+      info: {
+        email: Faker::Internet.email,
+        name: Faker::Name.name
+      }
+    )
+
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -37,6 +37,11 @@ module LoginHelpers
     )
 
   end
+
+  def accept_toc
+    check I18n.t('members.terms_and_conditions.agree')
+    click_on 'Accept'
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -39,7 +39,7 @@ module LoginHelpers
   end
 
   def accept_toc
-    check I18n.t('members.terms_and_conditions.agree')
+    check :terms
     click_on 'Accept'
   end
 end


### PR DESCRIPTION
New and existing members must accept codebar's CoC before they can continue to the website to either complete their registration or get to any page that requires authentication.

This excludes information pages (everything under dashboard besides /dashboard and /, so they should be able to get to FAQ, Coach and Student guide, Coc, Coaches list)