### PR TITLE
(fix) Resolve issue with incorrect capitalisation of sponsor contact …

### DIFF
--- a/app/presenters/sponsor_presenter.rb
+++ b/app/presenters/sponsor_presenter.rb
@@ -14,7 +14,7 @@ class SponsorPresenter < BasePresenter
   def contact_full_name
     return unless model.contact_first_name && model.contact_surname
 
-    "#{model.contact_first_name.capitalize} #{model.contact_surname.capitalize}"
+    "#{model.contact_first_name.camelize} #{model.contact_surname.camelize}"
   end
 
   private

--- a/spec/presenters/sponsor_presenter_spec.rb
+++ b/spec/presenters/sponsor_presenter_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe SponsorPresenter do
+  let(:sponsor_presenter) { SponsorPresenter.new(sponsor)}
+
+  context '#contact_full_name' do
+    let(:sponsor) { double(:sponsor, contact_first_name: 'leonardo', contact_surname: 'da Vinci') }
+
+    it 'should be stylised as camelcase' do
+      expect(sponsor_presenter.contact_full_name).to eq('Leonardo Da Vinci')
+    end
+  end
+end


### PR DESCRIPTION
…name

The database has some instances with either fully lowercase or fully upcase contact first name and surnames, so in order to not remove this functionality and resolve the current issues I have switched `capitalize` to `camelize`.

Fixes #1126 