### PR TITLE
Ensure bash is used on Linux

### DIFF
--- a/bin/dadmin
+++ b/bin/dadmin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 if [ $# -gt 0 ]

--- a/bin/dbuild
+++ b/bin/dbuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set +e
 docker-compose down -v --remove-orphans
 docker-compose build

--- a/bin/drails
+++ b/bin/drails
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/drake
+++ b/bin/drake
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/dspec
+++ b/bin/dspec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/dstart
+++ b/bin/dstart
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Running Ubuntu 18.04 LTS the executable at `/bin/sh` is Dash (not Bash as on MacOS) which doesn't support the function syntax. When running `bin/drake`:
`bin/drake: 5: bin/drake: function: not found`

I also have the same issue running `bin/dstart`:
`bin/dstart: 5: bin/dstart: function: not found`

I've updated shebangs to use `/usr/bin/env bash` for cross-platform support.