### PR TITLE
Add page title across app commonly used pages

### DIFF
--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -1,3 +1,5 @@
+- title t('workshop.invitation.title', date: humanize_date(@workshop.date_and_time))
+
 .stripe.reverse
   .row
     .large-12.columns

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -1,3 +1,4 @@
+- title t('jobs.title')
 .stripe.reverse
   .row
     .large-12.columns

--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -1,3 +1,5 @@
+- title "#{@job.title} | #{t('jobs.title')}"
+
 =render partial: 'jobs/show', locals: { admin: false }
 %script.jobref{type: 'application/ld+json'}
   = raw(render partial: 'job.json.jbuilder', locals: { job: @job })

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -1,3 +1,5 @@
+- title t('meeting.title', name: @meeting.name, date: humanize_date(@meeting.date_and_time))
+
 %section.stripe.reverse
   .row
     .medium-6.columns

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -1,3 +1,5 @@
+- title t('workshop.title', host: @workshop.host.name, date: humanize_date(@workshop.date_and_time))
+
 = render partial: 'meta_tags', locals: { workshop: @workshop }
 
 .stripe.reverse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,8 @@ en:
     title: Workshop at %{host} - %{date}
     invitation:
       title: Workshop invitation - %{date}
+  meeting:
+    title: "%{name} - %{date}"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     rejected_invitation: "We are so sad you can't make it, but thanks for letting us know %{name}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,9 @@ en:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  workshop:
+    invitation:
+      title: Workshop invitation - %{date}
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     rejected_invitation: "We are so sad you can't make it, but thanks for letting us know %{name}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     chapters:
       title: "Chapters"
   workshop:
+    title: Workshop at %{host} - %{date}
     invitation:
       title: Workshop invitation - %{date}
   messages:

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 RSpec.feature 'Jobs', type: :feature do
   context 'Listing' do
     context 'a visitor to the website' do
+      scenario 'can see the correct page title' do
+        visit jobs_path
+
+        expect(page).to have_title('Jobs | codebar.io')
+      end
+
       scenario 'can see a message when there are no available jobs' do
         visit root_path
         click_link('Jobs', match: :first)
@@ -22,6 +28,13 @@ RSpec.feature 'Jobs', type: :feature do
       end
 
       context 'can view job posts' do
+        it 'can see the correct page title' do
+          job = Fabricate(:published_job)
+          visit job_path(job)
+
+          expect(page).to have_title("#{job.title} | Jobs | codebar.io")
+        end
+
         it 'when a job post is active' do
           job = Fabricate(:published_job)
           visit job_path(job)

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -3,10 +3,19 @@ require 'spec_helper'
 RSpec.feature 'viewing a meeting', type: :feature do
   let!(:meeting) { Fabricate(:meeting) }
 
-  scenario "i can view a meeting's information" do
-    visit meeting_path(meeting)
+  context 'a visitor' do
+    before(:each) do
+      visit meeting_path(meeting)
+    end
 
-    expect(page).to have_content meeting.name
-    expect(page).to have_content meeting.venue.name
+    scenario 'can view the page title' do
+      expect(page).to have_title("#{meeting.name} - #{humanize_date(meeting.date_and_time)}")
+    end
+
+    scenario "can view a meeting's information" do
+
+      expect(page).to have_content meeting.name
+      expect(page).to have_content meeting.venue.name
+    end
   end
 end

--- a/spec/features/workshops_spec.rb
+++ b/spec/features/workshops_spec.rb
@@ -8,15 +8,19 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
   let(:student) { Fabricate(:student) }
 
   context 'visitor' do
-    scenario 'can view a workshop' do
+    before(:each) do
       visit workshop_path(workshop)
+    end
 
+    scenario 'can view a workshop' do
       expect(page).to be
     end
 
-    scenario 'can sign up or sign in' do
-      visit workshop_path workshop
+    scenario 'can view the page title' do
+      expect(page).to have_title("Workshop at #{workshop.host.name} - #{humanize_date(workshop.date_and_time)}")
+    end
 
+    scenario 'can sign up or sign in' do
       expect(page).to have_content('Sign up')
       expect(page).to have_content('Log in')
     end

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -1,4 +1,12 @@
 RSpec.shared_examples 'invitation route' do
+  context 'viewing an invitation' do
+    scenario 'renders a descriptive page title' do
+      visit invitation_route
+
+      expect(page).to have_title("Workshop invitation - #{humanize_date(invitation.workshop.date_and_time)} | codebar.io")
+    end
+  end
+
   context 'accept an invitation' do
     scenario 'when there are available spots' do
       Tutorial.create(title: 'title')


### PR DESCRIPTION
There is a lot more work to be done in order for all pages to have appropriate page titles but I thought I'd make a start by tackling some of the most commonly used pages like workshop invitation, workshop, meeting and jobs.

Currently there is no related open issue (maybe it would be worth to add one so we can track all pages that need titles?)  but it is related to #1077 