### PR TITLE
Localise admin/members_controller

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -15,20 +15,21 @@ class Admin::MembersController < Admin::ApplicationController
 
   def update_subscriptions
     subscription = @member.subscriptions.find_by(group_id: params[:group])
-    flash[:notice] = "You have unsubscribed #{@member.full_name} from #{subscription.group.chapter.city}'s #{subscription.group.name} group"
-
+    flash[:notice] = t('admin.members.unsubscribed', member: @member.full_name,
+                                                     city: subscription.group.chapter.city,
+                                                     group: subscription.group.name)
     subscription.destroy
     redirect_to :back
   end
 
   def send_eligibility_email
     @member.send_eligibility_email(current_user)
-    redirect_to [:admin, @member], notice: 'You have sent an eligibility confirmation request.'
+    redirect_to [:admin, @member], notice: t('admin.members.eligibility_confirmation_request')
   end
 
   def send_attendance_email
     @member.send_attendance_email(current_user)
-    redirect_to [:admin, @member], notice: 'You have sent an attendance warning.'
+    redirect_to [:admin, @member], notice: t('admin.members.attendance_warning')
   end
 
   private

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -47,7 +47,7 @@
           %label.label.warning Banned
         - if @member.groups.any?
           %h3 Subscriptions
-          %ul.no-bullet
+          %ul.no-bullet#subscriptions
             - @member.groups.each do |group|
               %li
                 = link_to [:admin, group] do

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -432,6 +432,10 @@ de:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'Studenten und Trainer zum Workshop einladen. Die Bestätigungs-E-Mail wird ausgelöst und sie werden von der Warteliste entfernt.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,6 +475,10 @@ en:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -432,6 +432,10 @@ en-AU:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -432,6 +432,10 @@ en-GB:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -432,6 +432,10 @@ en-US:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -432,6 +432,10 @@ es:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -432,6 +432,10 @@ fi:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -432,6 +432,10 @@ fr:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -432,6 +432,10 @@
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
         cannot_approve: 'You cannot approve expired job listings'
         confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+    members:
+      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
+      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
+      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.feature 'Managing users', type: :feature do
   let(:member) { Fabricate(:member) }
+  let(:student) { Fabricate(:student) }
   let(:admin) { Fabricate(:chapter_organiser) }
   let!(:invitation) { Fabricate(:attended_workshop_invitation, attending: true, member: member) }
   let!(:attending_invitation) { Fabricate(:attending_workshop_invitation, member: member) }
@@ -39,5 +40,30 @@ RSpec.feature 'Managing users', type: :feature do
     click_on 'Ban user'
 
     expect(page).to have_content 'The user has been banned'
+  end
+
+  scenario 'unsubscribe a user from group', js: true do
+    visit admin_member_path student
+    within '#subscriptions > li:first-child' do
+      expect do
+        accept_confirm { find('.fa-times').click }
+      end.to change { student.subscriptions.count }.by(0)
+    end
+
+    expect(page).to have_content "You have unsubscribed #{student.full_name}"
+  end
+
+  scenario 'Send eligibility email to user' do
+    visit admin_member_path student
+    click_on 'Eligibility'
+
+    expect(page).to have_content 'You have sent an eligibility confirmation request.'
+  end
+
+  scenario 'Warn a user' do
+    visit admin_member_path member
+    click_on 'Attendance'
+
+    expect(page).to have_content 'You have sent an attendance warning.'
   end
 end


### PR DESCRIPTION
The aim is to get the Rubocop branch in and a requested change was that the admin/members controller should have the messages localised. 

The PR was complicated by the code that exercised the localisation messages was, unusually, untested - so I split it into it's own PR.
