### PR TITLE
Localise WorkshopInvitationMailer email subjects

### DIFF
--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -4,28 +4,6 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
   helper ApplicationHelper
 
-  def invite_student(workshop, member, invitation)
-    @workshop = WorkshopPresenter.new(workshop)
-    @member = member
-    @invitation = invitation
-
-    subject = t('mailer.workshop_invitation.invite_student.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
-
-    mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
-  end
-
-  def invite_coach(workshop, member, invitation)
-    @workshop = workshop
-    @member = member
-    @invitation = invitation
-
-    subject = t('mailer.workshop_invitation.invite_coach.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
-
-    mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
-  end
-
   def attending(workshop, member, invitation, waiting_list = false)
     @workshop = WorkshopPresenter.new(workshop)
     @host_address = AddressPresenter.new(@workshop.host.address)
@@ -39,6 +17,17 @@ class WorkshopInvitationMailer < ActionMailer::Base
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
                                    content: WorkshopCalendar.new(workshop).calendar.to_ical }
 
+    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
+  end
+
+  def attending_reminder(workshop, member, invitation)
+    @workshop = WorkshopPresenter.new(workshop)
+    @host_address = AddressPresenter.new(@workshop.host.address)
+    @member = member
+    @invitation = invitation
+
+    subject = t('mailer.workshop_invitation.attending_reminder.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 
@@ -57,26 +46,26 @@ class WorkshopInvitationMailer < ActionMailer::Base
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 
-  def attending_reminder(workshop, member, invitation)
-    @workshop = WorkshopPresenter.new(workshop)
-    @host_address = AddressPresenter.new(@workshop.host.address)
+  def invite_coach(workshop, member, invitation)
+    @workshop = workshop
     @member = member
     @invitation = invitation
 
-    subject = t('mailer.workshop_invitation.attending_reminder.subject',
+    subject = t('mailer.workshop_invitation.invite_coach.subject',
                 date_time: humanize_date(@workshop.date_and_time, with_time: true))
-    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
+
+    mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
 
-  def waiting_list_reminder(workshop, member, invitation)
+  def invite_student(workshop, member, invitation)
     @workshop = WorkshopPresenter.new(workshop)
-    @host_address = AddressPresenter.new(@workshop.host.address)
     @member = member
     @invitation = invitation
 
-    subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
+    subject = t('mailer.workshop_invitation.invite_student.subject',
                 date_time: humanize_date(@workshop.date_and_time, with_time: true))
-    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
+
+    mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
 
   def notify_waiting_list(invitation)
@@ -88,6 +77,17 @@ class WorkshopInvitationMailer < ActionMailer::Base
     subject = t('mailer.workshop_invitation.notify_waiting_list.subject')
 
     mail(mail_args(@member, subject, @workshop.chapter.email), &:html)
+  end
+
+  def waiting_list_reminder(workshop, member, invitation)
+    @workshop = WorkshopPresenter.new(workshop)
+    @host_address = AddressPresenter.new(@workshop.host.address)
+    @member = member
+    @invitation = invitation
+
+    subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 
   private

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -4,8 +4,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
   helper ApplicationHelper
 
-  def invite_student(workshops, member, invitation)
-    @workshop = WorkshopPresenter.new(workshops)
+  def invite_student(workshop, member, invitation)
+    @workshop = WorkshopPresenter.new(workshop)
     @member = member
     @invitation = invitation
 
@@ -15,8 +15,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
 
-  def invite_coach(workshops, member, invitation)
-    @workshop = workshops
+  def invite_coach(workshop, member, invitation)
+    @workshop = workshop
     @member = member
     @invitation = invitation
 
@@ -26,8 +26,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
 
-  def attending(workshops, member, invitation, waiting_list = false)
-    @workshop = WorkshopPresenter.new(workshops)
+  def attending(workshop, member, invitation, waiting_list = false)
+    @workshop = WorkshopPresenter.new(workshop)
     @host_address = AddressPresenter.new(@workshop.host.address)
     @member = member
     @invitation = invitation
@@ -37,13 +37,13 @@ class WorkshopInvitationMailer < ActionMailer::Base
                 date_time: humanize_date(@workshop.date_and_time, with_time: true))
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
-                                   content: WorkshopCalendar.new(workshops).calendar.to_ical }
+                                   content: WorkshopCalendar.new(workshop).calendar.to_ical }
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 
-  def change_of_details(workshops, sponsor, member, invitation, title = 'Change of details')
-    @workshop = workshops
+  def change_of_details(workshop, sponsor, member, invitation, title = 'Change of details')
+    @workshop = workshop
     @sponsor = sponsor
     @host_address = AddressPresenter.new(@workshop.host.address)
     @member = member

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -9,7 +9,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Invitation #{humanize_date(@workshop.date_and_time, with_time: true)}"
+    subject = t('mailer.workshop_invitation.invite_student.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -19,7 +20,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Coach Invitation #{humanize_date(@workshop.date_and_time, with_time: true)}"
+    subject = t('mailer.workshop_invitation.invite_coach.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -31,7 +33,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @invitation = invitation
     @waiting_list = waiting_list
 
-    subject = "Attendance Confirmation for #{humanize_date(@workshop.date_and_time, with_time: true)}"
+    subject = t('mailer.workshop_invitation.attending.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
                                    content: WorkshopCalendar.new(workshops).calendar.to_ical }
@@ -46,7 +49,10 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "#{title}: #{@workshop.title} by codebar - #{humanize_date(@workshop.date_and_time, with_time: true)}"
+    subject = t('mailer.workshop_invitation.change_of_details.subject',
+                title: title,
+                workshop_title: @workshop.title,
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
@@ -57,7 +63,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Workshop Reminder #{humanize_date(@workshop.date_and_time, with_time: true)}"
+    subject = t('mailer.workshop_invitation.attending_reminder.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 
@@ -67,7 +74,8 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
 
-    subject = "Reminder: you're on the codebar waiting list (#{humanize_date(@workshop.date_and_time, with_time: true)})"
+    subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
+                date_time: humanize_date(@workshop.date_and_time, with_time: true))
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 
@@ -77,7 +85,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @member = invitation.member
     @invitation = invitation
 
-    subject = 'A spot just became available'
+    subject = t('mailer.workshop_invitation.notify_waiting_list.subject')
 
     mail(mail_args(@member, subject, @workshop.chapter.email), &:html)
   end

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -21,14 +21,9 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   def attending_reminder(workshop, member, invitation)
-    @workshop = WorkshopPresenter.new(workshop)
-    @host_address = AddressPresenter.new(@workshop.host.address)
-    @member = member
-    @invitation = invitation
-
     subject = t('mailer.workshop_invitation.attending_reminder.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
-    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
+                date_time: humanize_date(workshop.date_and_time, with_time: true))
+    reminder_setup(workshop, member, invitation, subject)
   end
 
   def change_of_details(workshop, sponsor, member, invitation, title = 'Change of details')
@@ -80,14 +75,9 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   def waiting_list_reminder(workshop, member, invitation)
-    @workshop = WorkshopPresenter.new(workshop)
-    @host_address = AddressPresenter.new(@workshop.host.address)
-    @member = member
-    @invitation = invitation
-
     subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
-    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
+                date_time: humanize_date(workshop.date_and_time, with_time: true))
+    reminder_setup(workshop, member, invitation, subject)
   end
 
   private
@@ -96,5 +86,14 @@ class WorkshopInvitationMailer < ActionMailer::Base
     def full_url_for(path)
       "#{@host}#{path}"
     end
+  end
+
+  def reminder_setup(workshop, member, invitation, subject)
+    @workshop = WorkshopPresenter.new(workshop)
+    @host_address = AddressPresenter.new(@workshop.host.address)
+    @member = member
+    @invitation = invitation
+
+    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -65,6 +65,22 @@ de:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Vielen Dank für die Rückmeldung, %{name}. Wir sehen uns beim Workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,22 @@ en:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   workshop:
     title: Workshop at %{host} - %{date}
     invitation:

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -65,6 +65,22 @@ en-AU:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -65,6 +65,22 @@ en-GB:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -65,6 +65,22 @@ en-US:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -65,6 +65,22 @@ es:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -65,6 +65,22 @@ fi:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,6 +65,22 @@ fr:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -65,6 +65,22 @@
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+  mailer:
+    workshop_invitation:
+      attending:
+        subject: "Attendance Confirmation for %{date_time}"
+      attending_reminder:
+        subject: "Workshop Reminder %{date_time}"
+      change_of_details:
+        subject: "%{title}: %{workshop_title} by codebar - %{date_time}"
+      invite_coach:
+        subject: "Workshop Coach Invitation %{date_time}"
+      invite_student:
+        subject: "Workshop Invitation %{date_time}"
+      notify_waiting_list:
+        subject: "A spot just became available"
+      waiting_list_reminder:
+        subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -7,28 +7,19 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer  do
   let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
   let(:sponsor) { Fabricate(:sponsor) }
 
-  it '#invite_student' do
-    email_subject = "Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
-
-    WorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
-
-    expect(email.subject).to eq(email_subject)
-    expect(email.body.encoded).to match(workshop.chapter.email)
-  end
-
-  it '#invite_coach' do
-    email_subject = "Workshop Coach Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
-
-    WorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
-
-    expect(email.subject).to eq(email_subject)
-    expect(email.body.encoded).to match(workshop.chapter.email)
-  end
-
   it "#attending" do
     email_subject = "Attendance Confirmation for #{humanize_date(workshop.date_and_time, with_time: true)}"
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(workshop.chapter.email)
+  end
+
+  it '#attending_reminder' do
+    email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
+
+    WorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
@@ -44,13 +35,30 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer  do
     expect(email.from).to eq([workshop.chapter.email])
   end
 
-  it '#attending_reminder' do
-    email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
+  it '#invite_coach' do
+    email_subject = "Workshop Coach Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
 
-    WorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
+    WorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
+  end
+
+  it '#invite_student' do
+    email_subject = "Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+
+    WorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(workshop.chapter.email)
+  end
+
+  it '#notify_waiting_list' do
+    WorkshopInvitationMailer.notify_waiting_list(invitation).deliver_now
+
+    expect(email.subject).to eq('A spot just became available')
+    expect(email.from).to eq([workshop.chapter.email])
+    expect(email.body.encoded).to match('A spot just opened up for the workshop')
   end
 
   it '#waitlist_reminder' do
@@ -62,13 +70,5 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer  do
     expect(email.from).to eq([workshop.chapter.email])
     expect(email.body.encoded).to match("the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
-  end
-
-  it '#notify_waiting_list' do
-    WorkshopInvitationMailer.notify_waiting_list(invitation).deliver_now
-
-    expect(email.subject).to eq('A spot just became available')
-    expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match('A spot just opened up for the workshop')
   end
 end

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -5,24 +5,57 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer  do
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
   let(:member) { Fabricate(:member) }
   let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
+  let(:sponsor) { Fabricate(:sponsor) }
 
   it '#invite_student' do
     email_subject = "Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+
     WorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
+  it '#invite_coach' do
+    email_subject = "Workshop Coach Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+
+    WorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(workshop.chapter.email)
+  end
+
+  it "#attending" do
+    email_subject = "Attendance Confirmation for #{humanize_date(workshop.date_and_time, with_time: true)}"
+
+    WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match(workshop.chapter.email)
+  end
+
+  it "#change_of_details" do
+    title = 'Change of details'
+    email_subject = "#{title}: #{workshop.title} by codebar - #{humanize_date(workshop.date_and_time, with_time: true)}"
+
+    WorkshopInvitationMailer.change_of_details(workshop, sponsor, member, invitation).deliver_now
+
+    expect(email.subject).to eq(email_subject)
+    expect(email.from).to eq([workshop.chapter.email])
+  end
+
   it '#attending_reminder' do
     email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
+
     WorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
+
     expect(email.subject).to eq(email_subject)
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
   it '#waitlist_reminder' do
     email_subject = "Reminder: you're on the codebar waiting list (#{humanize_date(workshop.date_and_time, with_time: true)})"
+
     WorkshopInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)


### PR DESCRIPTION
Hi @despo

I have had a look at the workshop_invitation_mailer - I couldn't find any localised mailer strings. so I tried.

YML Pattern
`  mailer.[Mailer Type].[Message Type].[key]`
  
Example:
`  mailer.workshop_invitation.invite_student.subject`

You were interested in making the line shorter and I've managed to do the complete opposite. Are you OK with me continuing or do you have a different YML pattern to follow?