### PR TITLE
(fix) flaky meeting_preseter_spec sql does not guarantee order

### DIFF
--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MeetingPresenter do
   it '#organisers' do
     permissions = Fabricate(:permission, resource: meeting, name: 'organiser')
 
-    expect(event.organisers).to eq(permissions.members)
+    expect(event.organisers).to match_array(permissions.members)
   end
 
   it '#attendees_emails' do


### PR DESCRIPTION
 - "organisers" test expects that the array order is the same
   however SQL only guarantees the returned rows and not the
   order they are returned


Fixes this flaky test:
https://travis-ci.org/github/codebar/planner/builds/661635502?utm_source=github_status&utm_medium=notification