### PR TITLE
ApplicationHelper contact_email without instance variable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,8 +40,8 @@ module ApplicationHelper
     Planner::Application.config.twitter_id
   end
 
-  def contact_email
-    @contact_email ||= @workshop.present? ? @workshop.chapter.email : 'hello@codebar.io'
+  def contact_email(workshop: nil)
+    @contact_email ||= workshop.present? ? workshop.chapter.email : 'hello@codebar.io'
   end
 
   def active_link_class(link_path)

--- a/app/views/feedback_request_mailer/request_feedback.html.haml
+++ b/app/views/feedback_request_mailer/request_feedback.html.haml
@@ -29,7 +29,7 @@
                   =link_to "Submit feedback", full_url_for(feedback_url(@feedback_request.token)), class: 'btn'
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/shared_mailers/_social.html.haml
+++ b/app/views/shared_mailers/_social.html.haml
@@ -1,3 +1,4 @@
+- workshop ||= local_assigns[:workshop] = local_assigns.fetch(:workshop, nil)
 %table.social{ width: "100%" }
   %tr
     %td
@@ -20,6 +21,6 @@
             %p
               Email:
               %strong
-                =mail_to contact_email, contact_email
+                =mail_to contact_email(workshop: workshop), contact_email(workshop: workshop)
 
       %span.clear

--- a/app/views/virtual_workshop_invitation_mailer/attending.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending.html.haml
@@ -46,7 +46,7 @@
                       = organiser.full_name
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
@@ -41,7 +41,7 @@
                       = organiser.full_name
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -44,7 +44,7 @@
                     %br
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
@@ -38,7 +38,7 @@
                     %br
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -44,7 +44,7 @@
                       = organiser.full_name
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -49,7 +49,7 @@
                       = organiser.mobile
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -44,7 +44,7 @@
                       = organiser.mobile
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -43,7 +43,7 @@
                 = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -38,7 +38,7 @@
                 = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -40,7 +40,7 @@
                         = organiser.mobile
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -41,7 +41,7 @@
                 = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
 
         .content
-          = render partial: 'shared_mailers/social'
+          = render partial: 'shared_mailers/social', locals: { workshop: @workshop }
       %td
 
   = render partial: 'shared_mailers/footer'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#contact_email' do
     it "returns the workshop chapter's email" do
-      @workshop = Fabricate(:workshop)
-      expect(helper.contact_email).to eq(@workshop.chapter.email)
+      workshop = Fabricate(:workshop)
+      expect(helper.contact_email(workshop: workshop)).to eq(workshop.chapter.email)
     end
 
     it 'returns hello@codebar.io when no workshop is set' do
-      expect(helper.contact_email).to eq('hello@codebar.io')
+      expect(helper.contact_email(workshop: nil)).to eq('hello@codebar.io')
     end
   end
 

--- a/spec/mailers/course_invitation_mailer_spec.rb
+++ b/spec/mailers/course_invitation_mailer_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe CourseInvitationMailer, type: :mailer  do
     CourseInvitationMailer.invite_student(course, member, invitation_token).deliver_now
 
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match('hello@codebar.io')
   end
 end

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe EventInvitationMailer, type: :mailer  do
     EventInvitationMailer.invite_student(event, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match('hello@codebar.io')
   end
 
   it '#invite_coach' do
@@ -18,6 +19,7 @@ RSpec.describe EventInvitationMailer, type: :mailer  do
     EventInvitationMailer.invite_coach(event, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match('hello@codebar.io')
   end
 
   it '#attending' do
@@ -25,5 +27,6 @@ RSpec.describe EventInvitationMailer, type: :mailer  do
     EventInvitationMailer.attending(event, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
+    expect(email.body.encoded).to match('hello@codebar.io')
   end
 end

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe FeedbackRequestMailer, type: :mailer  do
     FeedbackRequestMailer.request_feedback(workshop, member, feedback_request).deliver_now
 
     expect(email.subject).to eq(email_subject)
+    expect(email.from).to eq(['meetings@codebar.io'])
   end
 end

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('We\'re back for another installment of codebar Monthlies')
+      expect(mail.body.encoded).to match('hello@codebar.io')
     end
   end
 
@@ -31,6 +32,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('You\'re confirmed for the next codebar Monthly')
+      expect(mail.body.encoded).to match('hello@codebar.io')
     end
   end
 
@@ -46,6 +48,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('A spot opened up for the next codebar Monthly')
+      expect(mail.body.encoded).to match('hello@codebar.io')
     end
   end
 
@@ -61,6 +64,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('This is a quick email to remind you that you have signed up for tomorrow\'s codebar Monthly')
+      expect(mail.body.encoded).to match('hello@codebar.io')
     end
   end
 end


### PR DESCRIPTION
So relying on instance variables (in this case @workshop) to change a conditional makes code hard to follow and re-use - it "feels" like adding a global to the application.

If @workshop was defined as an instance variable the code does one thing and if it isn't it does another. So I added a workshop parameter to the method  and worked through the codebase passing @workshop wherever I found it defined in controller or view code.

---

This is part of the Rubocop errors that occur when [Rubocop / codeclimate integration setup is changed.  ](https://github.com/codebar/planner/pull/1046). However, this PR stands on it's own.