### PR TITLE
(feature) add pairing csv

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -40,7 +40,10 @@ class Admin::WorkshopsController < Admin::ApplicationController
   def show
     authorize @workshop
     @workshop = WorkshopPresenter.decorate(@workshop)
-    return render text: @workshop.attendees_csv if request.format.csv?
+    if request.format.csv?
+      csv_to_render = params[:type].eql?('labels') ? @workshop.attendees_csv : @workshop.pairing_csv
+      return render text: csv_to_render
+    end
 
     set_admin_workshop_data
   end

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -12,20 +12,14 @@ class EventPresenter < BasePresenter
     model.try(:chapter)
   end
 
-  def venue
-    model.venue
-  end
-
-  def sponsors
-    model.sponsors
-  end
+  delegate :venue, :sponsors, to: :model
 
   def invitable
     model.invitable || false
   end
 
   def description
-    model.description rescue nil
+    model&.description
   end
 
   def short_description
@@ -81,10 +75,14 @@ class EventPresenter < BasePresenter
   end
 
   def attendees_csv
-    CSV.generate { |csv| attendee_array.each { |a| csv << a } }
+    generate_csv_from_array(attendee_array)
   end
 
   private
+
+  def generate_csv_from_array(attendees)
+    CSV.generate { |csv| attendees.each { |a| csv << a } }
+  end
 
   def attendee_array
     model.attendances.map { |i| [i.member.full_name, i.role.upcase] }

--- a/app/presenters/member_presenter.rb
+++ b/app/presenters/member_presenter.rb
@@ -18,4 +18,18 @@ class MemberPresenter < BasePresenter
   def subscribed_to_newsletter?
     opt_in_newsletter_at.present?
   end
+
+  def pairing_details_array(role, note)
+    role.eql?('Coach') ? coach_pairing_details : student_pairing_details(note)
+  end
+
+  private
+
+  def coach_pairing_details
+    [newbie?, full_name, 'Coach', 'N/A', skill_list.to_s]
+  end
+
+  def student_pairing_details(note)
+    [newbie?, full_name, 'Student', note, 'N/A']
+  end
 end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -3,6 +3,8 @@ class WorkshopPresenter < EventPresenter
   include ActionView::Context
   include ActionView::Helpers::DateHelper
 
+  PAIRING_HEADINGS = ['New attendee', 'Name', 'Role', 'Study note', 'Skills'].freeze
+
   def self.decorate(workshop)
     return VirtualWorkshopPresenter.new(workshop) if workshop.virtual?
 
@@ -81,6 +83,14 @@ class WorkshopPresenter < EventPresenter
 
   def student_spaces
     venue.seats
+  end
+
+  def pairing_csv
+    pairing_details = model.attendances.inject([PAIRING_HEADINGS]) do |content, invitation|
+      member = MemberPresenter.new(invitation.member)
+      content << member.pairing_details_array(invitation.role, invitation.note)
+    end
+    generate_csv_from_array(pairing_details)
   end
 
   private

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -1,4 +1,4 @@
-.icon-bar.six-up
+.icon-bar.seven-up
   = link_to edit_admin_workshop_path(@workshop), class: 'item' do
     %i.fa.fa-pencil
     %label Edit
@@ -14,7 +14,10 @@
     = link_to '#', class: 'item disabled', title: t('admin.workshop.not_invitable.') do
       %i.fa.fa-send-o
       %label Invite
-  = link_to admin_workshop_path(format: 'csv'), class: 'item', title: 'CSV for labels' do
+  = link_to admin_workshop_path(format: 'csv'), class: 'item', title: 'CSV for pairing' do
+    %i.fa.fa-users
+    %label Pairing CSV
+  = link_to admin_workshop_path(type: 'labels', format: 'csv'), class: 'item', title: 'CSV for labels' do
     %i.fa.fa-users
     %label Labels
   = link_to admin_workshop_attendees_checklist_path(@workshop, format: 'text'), title: 'Attendee checklist', class: 'item' do

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -193,5 +193,29 @@ RSpec.feature 'An admin managing workshops', type: :feature do
         expect(page).to have_content('The requested format is invalid: text/html')
       end
     end
+
+    context 'attendee CSV' do
+      it 'returns a CSV with all workshop attendees' do
+        workshop = Fabricate(:workshop)
+        visit admin_workshop_path(workshop)
+        click_on 'Pairing CSV'
+
+        expect(page.current_path).to eq(admin_workshop_path(workshop, format: 'csv'))
+        expect(page).to have_content(WorkshopPresenter::PAIRING_HEADINGS.join(','))
+        expect(page).not_to have_content('ORGANISER')
+      end
+    end
+
+    context 'Labels' do
+      it 'returns a CSV with all workshop participants that can be used to generate the labels' do
+        workshop = Fabricate(:workshop)
+        visit admin_workshop_path(workshop)
+        click_on 'Labels'
+
+        expect(page.current_path).to eq(admin_workshop_path(workshop, format: 'csv'))
+        expect(page).to have_content('ORGANISER')
+        expect(page).not_to have_content(WorkshopPresenter::PAIRING_HEADINGS.join(','))
+      end
+    end
   end
 end

--- a/spec/presenters/member_presenter_spec.rb
+++ b/spec/presenters/member_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe MemberPresenter do
-  let(:member) { Fabricate(:member) }
+  let(:member) { Fabricate(:member, skill_list: 'java, ruby') }
   let(:member_presenter) { MemberPresenter.new(member) }
 
   it '#organiser?' do
@@ -14,5 +14,17 @@ RSpec.describe MemberPresenter do
     expect(member).to receive(:opt_in_newsletter_at)
 
     member_presenter.subscribed_to_newsletter?
+  end
+
+  context '#pairing_details_array' do
+    it 'returns student pairing information' do
+      expect(member_presenter.pairing_details_array('Student', 'Study note'))
+        .to eq([member_presenter.newbie?, member.full_name, 'Student', 'Study note', 'N/A'])
+    end
+
+    it 'returns coach pairing information' do
+      expect(member_presenter.pairing_details_array('Coach', nil))
+        .to eq([member_presenter.newbie?, member.full_name, 'Coach', 'N/A', 'java, ruby'])
+    end
   end
 end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe WorkshopPresenter do
     end
   end
 
+  context '#pairing_csv' do
+    let(:workshop) { double(:workshop, attendances: [invitation]) }
+    let(:student) { Fabricate(:student) }
+    let(:invitation) { Fabricate(:workshop_invitation, member: student) }
+
+    it 'returns a csv with all the details required to enable organisers to pair the participants' do
+      student_pairing_array = [true, student.full_name, 'Student', invitation.note, 'N/A']
+      student_presenter = MemberPresenter.new(student)
+
+      expect(presenter.pairing_csv)
+        .to eq(WorkshopPresenter::PAIRING_HEADINGS.join(',') + "\n" +
+               student_pairing_array.join(',') + "\n")
+    end
+  end
+
   it '#attendees_emails' do
     workshop = Fabricate(:workshop)
     presenter = WorkshopPresenter.new(workshop)


### PR DESCRIPTION
Relies on #1220 being merged (so only look at last 3 commits for now)

Attempting to make pairing a little bit easier by providing student and coach details on a CSV the organisers can download. As `Labels` returns a CSV with all attendees and their roles as dictated by the service we use to generate the name labels, I decided to expose a new file rather than to modify the existing one. 

It should also give an incentive to ask coaches to make sure their skills are up to date in their codebar profile.

<img width="784" alt="pairing_csv" src="https://user-images.githubusercontent.com/159200/76809357-7156b880-67e2-11ea-92f0-a83469fe5a41.png">

Example import into Google spreadsheets:
<img width="1085" alt="imported_csv" src="https://user-images.githubusercontent.com/159200/76809454-d4484f80-67e2-11ea-9579-c18b085fa8d3.png">
