### PR TITLE
Preview VirtualWorkshopInvitationMailer mails

### DIFF
--- a/spec/mailers/previews/virtual_workshop_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/virtual_workshop_invitation_mailer_preview.rb
@@ -1,0 +1,21 @@
+class VirtualWorkshopInvitationMailerPreview < ActionMailer::Preview
+  def attending
+    VirtualWorkshopInvitationMailer.attending(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def attending_reminder
+    VirtualWorkshopInvitationMailer.attending_reminder(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def invite_coach
+    VirtualWorkshopInvitationMailer.invite_coach(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def invite_student
+    VirtualWorkshopInvitationMailer.invite_student(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+
+  def waiting_list_reminder
+    VirtualWorkshopInvitationMailer.waiting_list_reminder(Workshop.last, Member.last, WorkshopInvitation.first)
+  end
+end


### PR DESCRIPTION
Also, I notice that the attending email used "virtual" in the title but the others didn't

-  attending subject uses humanize_date with_time: false whereas WorkshopInvitationMailer.attending displays time:

```ruby
# app/mailers/virtual_workshop_invitation_mailer.rb
def attending(workshop, member, invitation, waiting_list = false)
    setup(workshop, invitation, member)
    @waiting_list = waiting_list

    subject = "Attendance Confirmation: #{I18n.t('workshop.virtual.title',
                                                 chapter: @workshop.chapter.name, 
                                                 #
                                                 # humanize_date not with_time: true?
                                                 #
                                                 date: humanize_date(@workshop.date_and_time))}"

    mail(mail_args(member, subject, @workshop.chapter.email), &:html)
  end
```