### PR TITLE
[WIP] Pr format humanize date

### DIFF
--- a/app/controllers/admin/portal_controller.rb
+++ b/app/controllers/admin/portal_controller.rb
@@ -4,7 +4,7 @@ class Admin::PortalController < Admin::ApplicationController
 
     @jobs_pending_approval = Job.where(approved: false, submitted: true).count
     @chapters = Chapter.active.all.order(name: :asc)
-    @workshops = Workshop.upcoming
+    @workshops = Workshop.includes(:chapter).upcoming
     @groups = Group.joins(:chapter).merge(@chapters)
     @subscribers = Subscription.joins(:chapter).merge(@chapters)
                                .ordered.limit(20).includes(:member, :group)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,4 @@
 module ApplicationHelper
-  def humanize_date(date, with_time: false, with_year: false)
-    human_date = "#{I18n.l(date, format: :day_in_words)}, "
-    human_date << "#{ActiveSupport::Inflector.ordinalize(date.day)} "
-    human_date << I18n.l(date, format: :month)
-    human_date << " #{I18n.l(date, format: :year)}" if with_year
-    human_date << " at #{I18n.l(date.time, format: :time)}" if with_time
-    human_date
-  end
-
   def title(title = nil)
     return unless title
 

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -10,7 +10,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @rsvp_url = meeting_url(@meeting)
 
-    subject = "You are invited to codebar's #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
+    subject = "You are invited to codebar's #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 
@@ -20,7 +20,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @cancellation_url = meeting_url(@meeting)
 
-    subject = "See you at #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
+    subject = "See you at #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 
@@ -30,7 +30,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @cancellation_url = meeting_url(@meeting)
 
-    subject = "A spot opened up for #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
+    subject = "A spot opened up for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 
@@ -40,7 +40,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @cancellation_url = meeting_url(@meeting)
 
-    subject = "Reminder: You have a spot for #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
+    subject = "Reminder: You have a spot for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -5,35 +5,31 @@ class MeetingInvitationMailer < ActionMailer::Base
   helper ApplicationHelper
 
   def invite(meeting, member)
-    setup(meeting, member)
-    @rsvp_url = meeting_url(@meeting)
-
-    subject = "You are invited to codebar's #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
-    mail(mail_args(@member, subject), &:html)
+    setup(meeting, member) do
+      @rsvp_url = meeting_url(@meeting)
+      "You are invited to codebar's #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
+    end
   end
 
   def attending(meeting, member)
-    setup(meeting, member)
-    @cancellation_url = meeting_url(@meeting)
-
-    subject = "See you at #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
-    mail(mail_args(@member, subject), &:html)
+    setup(meeting, member) do
+      @cancellation_url = meeting_url(@meeting)
+      "See you at #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
+    end
   end
 
   def approve_from_waitlist(meeting, member)
-    setup(meeting, member)
-    @cancellation_url = meeting_url(@meeting)
-
-    subject = "A spot opened up for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
-    mail(mail_args(@member, subject), &:html)
+    setup(meeting, member) do
+      @cancellation_url = meeting_url(@meeting)
+      "A spot opened up for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
+    end
   end
 
   def attendance_reminder(meeting, member)
-    setup(meeting, member)
-    @cancellation_url = meeting_url(@meeting)
-
-    subject = "Reminder: You have a spot for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
-    mail(mail_args(@member, subject), &:html)
+    setup(meeting, member) do
+      @cancellation_url = meeting_url(@meeting)
+      "Reminder: You have a spot for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
+    end
   end
 
   private
@@ -48,5 +44,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @member = member
     @meeting = meeting
     @host_address = AddressPresenter.new(@meeting.venue.address)
+    subject = yield
+    mail(mail_args(@member, subject), &:html)
   end
 end

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -5,9 +5,7 @@ class MeetingInvitationMailer < ActionMailer::Base
   helper ApplicationHelper
 
   def invite(meeting, member)
-    @member = member
-    @meeting = meeting
-    @host_address = AddressPresenter.new(@meeting.venue.address)
+    setup(meeting, member)
     @rsvp_url = meeting_url(@meeting)
 
     subject = "You are invited to codebar's #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
@@ -15,9 +13,7 @@ class MeetingInvitationMailer < ActionMailer::Base
   end
 
   def attending(meeting, member)
-    @member = member
-    @meeting = meeting
-    @host_address = AddressPresenter.new(@meeting.venue.address)
+    setup(meeting, member)
     @cancellation_url = meeting_url(@meeting)
 
     subject = "See you at #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
@@ -25,9 +21,7 @@ class MeetingInvitationMailer < ActionMailer::Base
   end
 
   def approve_from_waitlist(meeting, member)
-    @member = member
-    @meeting = meeting
-    @host_address = AddressPresenter.new(@meeting.venue.address)
+    setup(meeting, member)
     @cancellation_url = meeting_url(@meeting)
 
     subject = "A spot opened up for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
@@ -35,9 +29,7 @@ class MeetingInvitationMailer < ActionMailer::Base
   end
 
   def attendance_reminder(meeting, member)
-    @member = member
-    @meeting = meeting
-    @host_address = AddressPresenter.new(@meeting.venue.address)
+    setup(meeting, member)
     @cancellation_url = meeting_url(@meeting)
 
     subject = "Reminder: You have a spot for #{@meeting.name} on #{l(@meeting.date_and_time, format: :humanize_date)}"
@@ -50,5 +42,11 @@ class MeetingInvitationMailer < ActionMailer::Base
     def full_url_for(path)
       "#{@host}#{path}"
     end
+  end
+
+  def setup(meeting, member)
+    @member = member
+    @meeting = meeting
+    @host_address = AddressPresenter.new(@meeting.venue.address)
   end
 end

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -10,7 +10,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @rsvp_url = meeting_url(@meeting)
 
-    subject = "You are invited to codebar's #{@meeting.name} on #{humanize_date(@meeting.date_and_time)}"
+    subject = "You are invited to codebar's #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 
@@ -20,7 +20,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @cancellation_url = meeting_url(@meeting)
 
-    subject = "See you at #{@meeting.name} on #{humanize_date(@meeting.date_and_time)}"
+    subject = "See you at #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 
@@ -30,7 +30,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @cancellation_url = meeting_url(@meeting)
 
-    subject = "A spot opened up for #{@meeting.name} on #{humanize_date(@meeting.date_and_time)}"
+    subject = "A spot opened up for #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 
@@ -40,7 +40,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @cancellation_url = meeting_url(@meeting)
 
-    subject = "Reminder: You have a spot for #{@meeting.name} on #{humanize_date(@meeting.date_and_time)}"
+    subject = "Reminder: You have a spot for #{@meeting.name} on #{l(@meeting.date_and_time, format: :_humanize_date)}"
     mail(mail_args(@member, subject), &:html)
   end
 

--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -20,7 +20,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def attending_reminder(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.virtual.attending_reminder.subject',
-                date_time: humanize_date(workshop.date_and_time, with_time: true))
+                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
@@ -28,7 +28,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def invite_coach(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.virtual.invite_coach.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -36,7 +36,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def invite_student(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.virtual.invite_student.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -44,7 +44,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def waiting_list_reminder(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
-                date_time: humanize_date(workshop.date_and_time, with_time: true))
+                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end

--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -12,7 +12,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
 
     subject = "Attendance Confirmation: #{I18n.t('workshop.virtual.title',
                                                  chapter: @workshop.chapter.name,
-                                                 date: l(@workshop.date_and_time, format: :_humanize_date_with_time))}"
+                                                 date: l(@workshop.date_and_time, format: :humanize_date_with_time))}"
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
@@ -20,7 +20,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def attending_reminder(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.virtual.attending_reminder.subject',
-                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
@@ -28,7 +28,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def invite_coach(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.virtual.invite_coach.subject',
-                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -36,7 +36,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def invite_student(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.virtual.invite_student.subject',
-                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -44,7 +44,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   def waiting_list_reminder(workshop, member, invitation)
     setup(workshop, invitation, member)
     subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
-                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end

--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -12,7 +12,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
 
     subject = "Attendance Confirmation: #{I18n.t('workshop.virtual.title',
                                                  chapter: @workshop.chapter.name,
-                                                 date: humanize_date(@workshop.date_and_time))}"
+                                                 date: l(@workshop.date_and_time, format: :_humanize_date_with_time))}"
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end

--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -52,7 +52,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   private
 
   def setup(workshop, invitation, member)
-    @workshop = workshop
+    @workshop = WorkshopPresenter.new(workshop)
     @member = member
     @invitation = invitation
   end

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -44,10 +44,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   def invite_coach(workshop, member, invitation)
-    @workshop = WorkshopPresenter.new(workshop)
-    @member = member
-    @invitation = invitation
-
+    invite_setup(workshop, member, invitation)
     subject = t('mailer.workshop_invitation.invite_coach.subject',
                 date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
@@ -55,10 +52,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   def invite_student(workshop, member, invitation)
-    @workshop = WorkshopPresenter.new(workshop)
-    @member = member
-    @invitation = invitation
-
+    invite_setup(workshop, member, invitation)
     subject = t('mailer.workshop_invitation.invite_student.subject',
                 date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
@@ -83,6 +77,12 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   private
+
+  def invite_setup(workshop, member, invitation)
+    @workshop = WorkshopPresenter.new(workshop)
+    @member = member
+    @invitation = invitation
+  end
 
   def reminder_setup(workshop, member, invitation, subject)
     @workshop = WorkshopPresenter.new(workshop)

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -14,7 +14,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @waiting_list = waiting_list
 
     subject = t('mailer.workshop_invitation.attending.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
                                    content: WorkshopCalendar.new(workshop).calendar.to_ical }
@@ -24,7 +24,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
   def attending_reminder(workshop, member, invitation)
     subject = t('mailer.workshop_invitation.attending_reminder.subject',
-                date_time: humanize_date(workshop.date_and_time, with_time: true))
+                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
     reminder_setup(workshop, member, invitation, subject)
   end
 
@@ -38,7 +38,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     subject = t('mailer.workshop_invitation.change_of_details.subject',
                 title: title,
                 workshop_title: @workshop.title,
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
@@ -49,7 +49,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @invitation = invitation
 
     subject = t('mailer.workshop_invitation.invite_coach.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -60,7 +60,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @invitation = invitation
 
     subject = t('mailer.workshop_invitation.invite_student.subject',
-                date_time: humanize_date(@workshop.date_and_time, with_time: true))
+                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -78,7 +78,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
   def waiting_list_reminder(workshop, member, invitation)
     subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
-                date_time: humanize_date(workshop.date_and_time, with_time: true))
+                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
     reminder_setup(workshop, member, invitation, subject)
   end
 

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -44,7 +44,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   def invite_coach(workshop, member, invitation)
-    @workshop = workshop
+    @workshop = WorkshopPresenter.new(workshop)
     @member = member
     @invitation = invitation
 
@@ -66,7 +66,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
   end
 
   def notify_waiting_list(invitation)
-    @workshop = invitation.workshop
+    @workshop = WorkshopPresenter.new(invitation.workshop)
     @host_address = AddressPresenter.new(@workshop.host.address)
     @member = invitation.member
     @invitation = invitation

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -14,7 +14,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @waiting_list = waiting_list
 
     subject = t('mailer.workshop_invitation.attending.subject',
-                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
                                    content: WorkshopCalendar.new(workshop).calendar.to_ical }
@@ -24,7 +24,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
   def attending_reminder(workshop, member, invitation)
     subject = t('mailer.workshop_invitation.attending_reminder.subject',
-                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(workshop.date_and_time, format: :humanize_date_with_time))
     reminder_setup(workshop, member, invitation, subject)
   end
 
@@ -38,7 +38,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     subject = t('mailer.workshop_invitation.change_of_details.subject',
                 title: title,
                 workshop_title: @workshop.title,
-                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
@@ -49,7 +49,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @invitation = invitation
 
     subject = t('mailer.workshop_invitation.invite_coach.subject',
-                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -60,7 +60,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
     @invitation = invitation
 
     subject = t('mailer.workshop_invitation.invite_student.subject',
-                date_time: l(@workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(@workshop.date_and_time, format: :humanize_date_with_time))
 
     mail(mail_args(member, subject, 'no-reply@codebar.io'), &:html)
   end
@@ -78,7 +78,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
 
   def waiting_list_reminder(workshop, member, invitation)
     subject = t('mailer.workshop_invitation.waiting_list_reminder.subject',
-                date_time: l(workshop.date_and_time, format: :_humanize_date_with_time))
+                date_time: l(workshop.date_and_time, format: :humanize_date_with_time))
     reminder_setup(workshop, member, invitation, subject)
   end
 

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -59,6 +59,10 @@ class WorkshopPresenter < EventPresenter
     start_and_end_time
   end
 
+  def humanize_date_with_time_range
+    I18n.l(model.date_and_time, format: :humanize_date_with_time) + (model.ends_at.blank? ? nil : ' - ' + end_time).to_s
+  end
+
   def path
     Rails.application.routes.url_helpers.workshop_path(model)
   end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -15,6 +15,28 @@ class WorkshopPresenter < EventPresenter
     I18n.t('workshops.title', host: venue.name)
   end
 
+  def time
+    I18n.l(model.time, format: :time)
+  end
+
+  def end_time
+    I18n.l(model.ends_at, format: :time)
+  end
+
+  def start_and_end_time
+    [model.time, model.ends_at].compact.map { |t| I18n.l(t, format: :time) }.join(' - ')
+  end
+
+  def humanize_date_with_time_range
+    I18n.l(model.date_and_time, format: :humanize_date_with_time) + (model.ends_at.blank? ? nil : ' - ' + end_time).to_s
+  end
+
+  def distance_of_time
+    return "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" if past?
+
+    "(in #{distance_of_time_in_words_to_now(date_and_time)})"
+  end
+
   def address
     AddressPresenter.new(venue.address)
   end
@@ -45,36 +67,12 @@ class WorkshopPresenter < EventPresenter
           .pluck(:email).join(', ')
   end
 
-  def time
-    I18n.l(model.time, format: :time)
-  end
-
-  def end_time
-    I18n.l(model.ends_at, format: :time)
-  end
-
-  def start_and_end_time
-    start_and_end_time = time
-    start_and_end_time << " - #{end_time}" if model.ends_at.present?
-    start_and_end_time
-  end
-
-  def humanize_date_with_time_range
-    I18n.l(model.date_and_time, format: :humanize_date_with_time) + (model.ends_at.blank? ? nil : ' - ' + end_time).to_s
-  end
-
   def path
     Rails.application.routes.url_helpers.workshop_path(model)
   end
 
   def admin_path
     Rails.application.routes.url_helpers.admin_workshop_path(model)
-  end
-
-  def distance_of_time
-    return "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" if past?
-
-    "(in #{distance_of_time_in_words_to_now(date_and_time)})"
   end
 
   def send_attending_email(invitation, waitinglist = false)

--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -41,7 +41,7 @@
         - @workshops.each do |workshop|
           %li
             = link_to admin_workshop_path(workshop) do
-              = humanize_date(workshop.date_and_time, with_time: true)
+              = l(workshop.date_and_time, format: :_humanize_time_with_time)
               - if workshop.invitable?
                 (#{workshop.invitations.accepted.count})
     .large-8.columns

--- a/app/views/admin/portal/index.html.haml
+++ b/app/views/admin/portal/index.html.haml
@@ -13,7 +13,7 @@
             = link_to admin_workshop_path(workshop) do
               %strong= workshop.chapter.name
               %br
-              = humanize_date(workshop.date_and_time, with_time: true)
+              = l(workshop.date_and_time, format: :humanize_date_with_time)
     .large-4.columns
       = link_to 'View all sponsors', admin_sponsors_path, class: 'button expand round'
       = link_to 'Admin Guide', admin_guide_path, class: 'button expand round'

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -30,7 +30,7 @@
             = link_to admin_workshop_path(workshop) do
               %strong=workshop.chapter.name
               %br
-              = humanize_date(workshop.date_and_time, with_time: true)
+              = l(workshop.date_and_time, format: :_humanize_date_with_time)
 
   .row
     .medium-6.large-3.columns

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -30,7 +30,7 @@
             = link_to admin_workshop_path(workshop) do
               %strong=workshop.chapter.name
               %br
-              = l(workshop.date_and_time, format: :_humanize_date_with_time)
+              = l(workshop.date_and_time, format: :humanize_date_with_time)
 
   .row
     .medium-6.large-3.columns

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -18,7 +18,7 @@
           %tr
             %td
               = link_to admin_workshop_path(workshop) do
-                = humanize_date(workshop.date_and_time, with_time: true, with_year: true)
+                = l(workshop.date_and_time, format: :_humanize_date_with_year_with_time)
             %td
               = workshop.invitations.accepted.count
             %td

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -18,7 +18,7 @@
           %tr
             %td
               = link_to admin_workshop_path(workshop) do
-                = l(workshop.date_and_time, format: :_humanize_date_with_year_with_time)
+                = l(workshop.date_and_time, format: :humanize_date_with_year_with_time)
             %td
               = workshop.invitations.accepted.count
             %td

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: l(@invitation.course.date_and_time, format: :_humanize_date_with_time) }
+= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: l(@invitation.course.date_and_time, format: :humanize_date_with_time) }
 
 %section
   .inner-nav{ "data-magellan-expedition" => "fixed" }

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: humanize_date(@invitation.course.date_and_time, with_time: true) }
+= render partial: 'shared/title', locals: { title: @invitation.course.to_s, date: l(@invitation.course.date_and_time, format: :_humanize_date_with_time) }
 
 %section
   .inner-nav{ "data-magellan-expedition" => "fixed" }

--- a/app/views/course_invitation_mailer/invite_student.html.haml
+++ b/app/views/course_invitation_mailer/invite_student.html.haml
@@ -39,7 +39,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{l(@course.date_and_time, format: :_humanize_date_with_time)}
+                  %small #{l(@course.date_and_time, format: :humanize_date_with_time)}
                 %p
                   %b Venue
                   #{@course.venue.name}

--- a/app/views/course_invitation_mailer/invite_student.html.haml
+++ b/app/views/course_invitation_mailer/invite_student.html.haml
@@ -39,7 +39,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@course.date_and_time, with_time: true)}
+                  %small #{l(@course.date_and_time, format: :_humanize_date_with_time)}
                 %p
                   %b Venue
                   #{@course.venue.name}

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         = @course.title
         %br
-        %small #{humanize_date(@course.date_and_time, with_time: true)}
+        %small #{l(@course.date_and_time, format: :_humanize_date_with_time)}
       - if @course.date_and_time.past?
         %label.label.warning This event has already taken place.
 

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -4,7 +4,7 @@
       %h2
         = @course.title
         %br
-        %small #{l(@course.date_and_time, format: :_humanize_date_with_time)}
+        %small #{l(@course.date_and_time, format: :humanize_date_with_time)}
       - if @course.date_and_time.past?
         %label.label.warning This event has already taken place.
 
@@ -52,7 +52,7 @@
           = @host_address.to_html
         %iframe{ width: '100%', height: '350', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
         = link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
-    
+
     .large-4.columns
       %h4 Sponsors
       %ul.no-bullet

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: t('feedback_form.title'), date:  l(@workshop.date_and_time, format: :_humanize_date_with_time) }
+= render partial: 'shared/title', locals: { title: t('feedback_form.title'), date:  l(@workshop.date_and_time, format: :humanize_date_with_time) }
 %section#banner
   .row
     .large-12.columns

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: t('feedback_form.title'), date:  humanize_date(@workshop.date_and_time, with_time: true) }
+= render partial: 'shared/title', locals: { title: t('feedback_form.title'), date:  l(@workshop.date_and_time, format: :_humanize_date_with_time) }
 %section#banner
   .row
     .large-12.columns

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -1,4 +1,4 @@
-- title t('workshop.invitation.title', date: humanize_date(@workshop.date_and_time))
+- title t('workshop.invitation.title', date: l(@workshop.date_and_time, format: :_humanize_date))
 
 .stripe.reverse
   .row

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -6,7 +6,7 @@
       %h2
         = @workshop.title
         %br
-        %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
+        %small #{l(@workshop.date_and_time, format: :_humanize_date_with_time)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning= t('workshops.already_taken_place')
 .alert-box.info

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -1,4 +1,4 @@
-- title t('workshop.invitation.title', date: l(@workshop.date_and_time, format: :_humanize_date))
+- title t('workshop.invitation.title', date: l(@workshop.date_and_time, format: :humanize_date))
 
 .stripe.reverse
   .row
@@ -6,7 +6,7 @@
       %h2
         = @workshop.title
         %br
-        %small #{l(@workshop.date_and_time, format: :_humanize_date_with_time)} #{@workshop.distance_of_time}
+        %small #{l(@workshop.date_and_time, format: :humanize_date_with_time)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning= t('workshops.already_taken_place')
 .alert-box.info

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -25,7 +25,7 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{l(invitation.parent.date_and_time, format: :_humanize_date_with_time)}
+                      .date #{l(invitation.parent.date_and_time, format: :humanize_date_with_time)}
                   %br
                   - if invitation.is_a? WorkshopInvitation
                     =link_to attendance_status(invitation), invitation_path(invitation), class: "button round expand"
@@ -51,6 +51,6 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{l(invitation.parent.date_and_time, format: :_humanize_date_with_time)}
+                      .date #{l(invitation.parent.date_and_time, format: :humanize_date_with_time)}
                   %br
                   =link_to "View", invitation_path(invitation), class: "button round expand"

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -25,7 +25,7 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{humanize_date(invitation.parent.date_and_time, with_time: true)}
+                      .date #{l(invitation.parent.date_and_time, format: :_humanize_date_with_time)}
                   %br
                   - if invitation.is_a? WorkshopInvitation
                     =link_to attendance_status(invitation), invitation_path(invitation), class: "button round expand"
@@ -51,6 +51,6 @@
                     %br
                     - if invitation.parent.present?
                       %small.subheader #{invitation.parent.chapter.name} Group: #{invitation.role.pluralize}
-                      .date #{humanize_date(invitation.parent.date_and_time, with_time: true)}
+                      .date #{l(invitation.parent.date_and_time, format: :_humanize_date_with_time)}
                   %br
                   =link_to "View", invitation_path(invitation), class: "button round expand"

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  A spot opened up for the next codebar Monthly on #{l(@meeting.date_and_time, format: :_humanize_date_with_time)} at #{@meeting.venue.name}!
+                  A spot opened up for the next codebar Monthly on #{l(@meeting.date_and_time, format: :humanize_date_with_time)} at #{@meeting.venue.name}!
 
         = render partial: 'agenda'
 

--- a/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
+++ b/app/views/meeting_invitation_mailer/approve_from_waitlist.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  A spot opened up for the next codebar Monthly on #{humanize_date(@meeting.date_and_time, with_time: true)} at #{@meeting.venue.name}!
+                  A spot opened up for the next codebar Monthly on #{l(@meeting.date_and_time, format: :_humanize_date_with_time)} at #{@meeting.venue.name}!
 
         = render partial: 'agenda'
 

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  You're confirmed for the next codebar Monthly on #{humanize_date(@meeting.date_and_time, with_time: true)} at #{@meeting.venue.name}!
+                  You're confirmed for the next codebar Monthly on #{l(@meeting.date_and_time, format: :_humanize_date_with_time)} at #{@meeting.venue.name}!
 
         = render partial: 'agenda'
 

--- a/app/views/meeting_invitation_mailer/attending.html.haml
+++ b/app/views/meeting_invitation_mailer/attending.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  You're confirmed for the next codebar Monthly on #{l(@meeting.date_and_time, format: :_humanize_date_with_time)} at #{@meeting.venue.name}!
+                  You're confirmed for the next codebar Monthly on #{l(@meeting.date_and_time, format: :humanize_date_with_time)} at #{@meeting.venue.name}!
 
         = render partial: 'agenda'
 

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  We're back for another installment of codebar Monthlies on #{l(@meeting.date_and_time, format: :_humanize_date_with_time)} at #{@meeting.venue.name}!
+                  We're back for another installment of codebar Monthlies on #{l(@meeting.date_and_time, format: :humanize_date_with_time)} at #{@meeting.venue.name}!
                 %p
                   = "#{link_to 'You can RSVP here', @rsvp_url}, after logging into your codebar account.".html_safe
 

--- a/app/views/meeting_invitation_mailer/invite.html.haml
+++ b/app/views/meeting_invitation_mailer/invite.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  We're back for another installment of codebar Monthlies on #{humanize_date(@meeting.date_and_time, with_time: true)} at #{@meeting.venue.name}!
+                  We're back for another installment of codebar Monthlies on #{l(@meeting.date_and_time, format: :_humanize_date_with_time)} at #{@meeting.venue.name}!
                 %p
                   = "#{link_to 'You can RSVP here', @rsvp_url}, after logging into your codebar account.".html_safe
 

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -1,4 +1,4 @@
-- title t('meeting.title', name: @meeting.name, date: l(@meeting.date_and_time, format: :_humanize_date))
+- title t('meeting.title', name: @meeting.name, date: l(@meeting.date_and_time, format: :humanize_date))
 
 %section.stripe.reverse
   .row
@@ -6,7 +6,7 @@
       %h2
         =@meeting.name
       %h3
-        %small=l(@meeting.date_and_time, format: :_humanize_date_with_time)
+        %small=l(@meeting.date_and_time, format: :humanize_date_with_time)
 
   .row
     .medium-4.columns

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -6,7 +6,7 @@
       %h2
         =@meeting.name
       %h3
-        %small=humanize_date(@meeting.date_and_time, with_time: true)
+        %small=l(@meeting.date_and_time, format: :_humanize_date_with_time)
 
   .row
     .medium-4.columns

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -1,4 +1,4 @@
-- title t('meeting.title', name: @meeting.name, date: humanize_date(@meeting.date_and_time))
+- title t('meeting.title', name: @meeting.name, date: l(@meeting.date_and_time, format: :_humanize_date))
 
 %section.stripe.reverse
   .row

--- a/app/views/virtual_workshop_invitation_mailer/attending.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending.html.haml
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
@@ -27,7 +27,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  Invites for our next virtual workshop are now open and we are looking for coaches. The workshop will take place on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
+                  Invites for our next virtual workshop are now open and we are looking for coaches. The workshop will take place on #{l(@workshop.date_and_time, format: :humanize_date_with_time)}.
 
                 %p At the workshop you will be helping students remotely as they work their way through one of our tutorials or a personal project they need help on. Don't worry we'll only match you with someone who you'll be able to help.
 

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  Invites for our next virtual workshop are now open and we are looking for coaches. The workshop will take place on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  Invites for our next virtual workshop are now open and we are looking for coaches. The workshop will take place on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
 
                 %p At the workshop you will be helping students remotely as they work their way through one of our tutorials or a personal project they need help on. Don't worry we'll only match you with someone who you'll be able to help.
 

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -34,7 +34,7 @@
                   =@workshop.to_s
                   %br
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?

--- a/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
@@ -28,7 +28,7 @@
                 %h4
                   = @workshop.to_s
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the virtual workshop on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  This is a quick email to remind you that you're on the waiting list for the virtual workshop on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place. We'll email you if this happens.
                   %strong Attendees often drop out at short notice,

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the virtual workshop on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
+                  This is a quick email to remind you that you're on the waiting list for the virtual workshop on #{l(@workshop.date_and_time, format: :humanize_date_with_time)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place. We'll email you if this happens.
                   %strong Attendees often drop out at short notice,

--- a/app/views/virtual_workshops/_meta_tags.html.haml
+++ b/app/views/virtual_workshops/_meta_tags.html.haml
@@ -1,6 +1,6 @@
 - content_for :meta_tags do
   - title = t('workshops.virtual.title', chapter: workshop.chapter.name)
-  - twitter_description = "codebar #{workshop.chapter.name} virtual  workshop on #{humanize_date(workshop.date_and_time, with_time: true)}"
+  - twitter_description = "codebar #{workshop.chapter.name} virtual  workshop on #{l(workshop.date_and_time, format: :_humanize_date_with_time)}"
   - slack_description = "codebar #{workshop.chapter.name} virtual workshop"
   %meta{ property: 'twitter:card', content: 'summary' }
   %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
@@ -14,4 +14,4 @@
   %meta{ name: 'twitter:label1', value: "Where"}
   %meta{ name: 'twitter:data1', value: "online" }
   %meta{ name: 'twitter:label2', value: "When"}
-  %meta{ name: 'twitter:data2', value: "#{humanize_date(workshop.date_and_time, with_time: true)}" }
+  %meta{ name: 'twitter:data2', value: "#{l(workshop.date_and_time, format: :_humanize_date_with_time)}" }

--- a/app/views/virtual_workshops/_meta_tags.html.haml
+++ b/app/views/virtual_workshops/_meta_tags.html.haml
@@ -1,6 +1,6 @@
 - content_for :meta_tags do
   - title = t('workshops.virtual.title', chapter: workshop.chapter.name)
-  - twitter_description = "codebar #{workshop.chapter.name} virtual  workshop on #{l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+  - twitter_description = "codebar #{workshop.chapter.name} virtual  workshop on #{l(workshop.date_and_time, format: :humanize_date_with_time)}"
   - slack_description = "codebar #{workshop.chapter.name} virtual workshop"
   %meta{ property: 'twitter:card', content: 'summary' }
   %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
@@ -14,4 +14,4 @@
   %meta{ name: 'twitter:label1', value: "Where"}
   %meta{ name: 'twitter:data1', value: "online" }
   %meta{ name: 'twitter:label2', value: "When"}
-  %meta{ name: 'twitter:data2', value: "#{l(workshop.date_and_time, format: :_humanize_date_with_time)}" }
+  %meta{ name: 'twitter:data2', value: "#{l(workshop.date_and_time, format: :humanize_date_with_time)}" }

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -1,4 +1,5 @@
-- title t('workshop.virtual.title', chapter: @workshop.chapter.name, date: humanize_date(@workshop.date_and_time))
+- title t('workshop.virtual.title', chapter: @workshop.chapter.name,
+                                    date: l(@workshop.date_and_time, format: :_humanize_date))
 
 = render partial: 'virtual_workshops/meta_tags', locals: { workshop: @workshop }
 
@@ -8,7 +9,7 @@
       %h2
         = t('workshops.virtual.title', chapter: @workshop.chapter.name)
         %br
-        %small #{humanize_date(@workshop.date_and_time)} #{@workshop.distance_of_time}
+        %small #{l(@workshop.date_and_time, format: :_humanize_date)} #{@workshop.distance_of_time}
         #workshop-time.time
           %i.material-icons
             access_time

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -1,5 +1,5 @@
 - title t('workshop.virtual.title', chapter: @workshop.chapter.name,
-                                    date: l(@workshop.date_and_time, format: :_humanize_date))
+                                    date: l(@workshop.date_and_time, format: :humanize_date))
 
 = render partial: 'virtual_workshops/meta_tags', locals: { workshop: @workshop }
 
@@ -9,7 +9,7 @@
       %h2
         = t('workshops.virtual.title', chapter: @workshop.chapter.name)
         %br
-        %small #{l(@workshop.date_and_time, format: :_humanize_date)} #{@workshop.distance_of_time}
+        %small #{l(@workshop.date_and_time, format: :humanize_date)} #{@workshop.distance_of_time}
         #workshop-time.time
           %i.material-icons
             access_time

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -27,7 +27,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -33,7 +33,7 @@
                 %h4
                   Workshop
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  Invites for our next workshop are now open and we are looking for coaches. The workshop will take place on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
+                  Invites for our next workshop are now open and we are looking for coaches. The workshop will take place on #{l(@workshop.date_and_time, format: :humanize_date_with_time)}.
 
                 %p At the workshop you will be helping students as they work their way through one of our tutorials or a personal project they need help. Don't worry we'll only match you with someone who you'll be able to help.
 

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  Invites for our next workshop are now open and we are looking for coaches. The workshop will take place on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  Invites for our next workshop are now open and we are looking for coaches. The workshop will take place on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
 
                 %p At the workshop you will be helping students as they work their way through one of our tutorials or a personal project they need help. Don't worry we'll only match you with someone who you'll be able to help.
 

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -28,7 +28,7 @@
                 %h4
                   Workshop
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -22,7 +22,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the workshop on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
+                  This is a quick email to remind you that you're on the waiting list for the workshop on #{l(@workshop.date_and_time, format: :humanize_date_with_time)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place. We'll email you if this happens.
                   %strong Attendees often drop out at short notice,

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the workshop on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  This is a quick email to remind you that you're on the waiting list for the workshop on #{l(@workshop.date_and_time, format: :_humanize_date_with_time)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place. We'll email you if this happens.
                   %strong Attendees often drop out at short notice,

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -31,7 +31,7 @@
                 %h4
                   Workshop
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{@workshop.humanize_date_with_time_range}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4

--- a/app/views/workshops/_meta_tags.html.haml
+++ b/app/views/workshops/_meta_tags.html.haml
@@ -1,6 +1,6 @@
 - content_for :meta_tags do
   - title = "Workshop at #{workshop.host.name}"
-  - twitter_description = "codebar #{workshop.chapter.name} workshop at #{workshop.host.name} on #{l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+  - twitter_description = "codebar #{workshop.chapter.name} workshop at #{workshop.host.name} on #{l(workshop.date_and_time, format: :humanize_date_with_time)}"
   - slack_description = "codebar #{workshop.chapter.name}"
   %meta{ property: 'twitter:card', content: 'summary' }
   %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
@@ -14,4 +14,4 @@
   %meta{ name: 'twitter:label1', value: "Where"}
   %meta{ name: 'twitter:data1', value: "#{workshop.host.name}, #{@host_address}" }
   %meta{ name: 'twitter:label2', value: "When"}
-  %meta{ name: 'twitter:data2', value: "#{l(workshop.date_and_time, format: :_humanize_date_with_time)}" }
+  %meta{ name: 'twitter:data2', value: "#{l(workshop.date_and_time, format: :humanize_date_with_time)}" }

--- a/app/views/workshops/_meta_tags.html.haml
+++ b/app/views/workshops/_meta_tags.html.haml
@@ -1,6 +1,6 @@
 - content_for :meta_tags do
   - title = "Workshop at #{workshop.host.name}"
-  - twitter_description = "codebar #{workshop.chapter.name} workshop at #{workshop.host.name} on #{humanize_date(workshop.date_and_time, with_time: true)}"
+  - twitter_description = "codebar #{workshop.chapter.name} workshop at #{workshop.host.name} on #{l(workshop.date_and_time, format: :_humanize_date_with_time)}"
   - slack_description = "codebar #{workshop.chapter.name}"
   %meta{ property: 'twitter:card', content: 'summary' }
   %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
@@ -14,4 +14,4 @@
   %meta{ name: 'twitter:label1', value: "Where"}
   %meta{ name: 'twitter:data1', value: "#{workshop.host.name}, #{@host_address}" }
   %meta{ name: 'twitter:label2', value: "When"}
-  %meta{ name: 'twitter:data2', value: "#{humanize_date(workshop.date_and_time, with_time: true)}" }
+  %meta{ name: 'twitter:data2', value: "#{l(workshop.date_and_time, format: :_humanize_date_with_time)}" }

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -1,4 +1,5 @@
-- title t('workshop.title', host: @workshop.host.name, date: humanize_date(@workshop.date_and_time))
+- title t('workshop.title', host: @workshop.host.name,
+                            date: l(@workshop.date_and_time, format: :_humanize_date))
 
 = render partial: 'meta_tags', locals: { workshop: @workshop }
 
@@ -8,7 +9,7 @@
       %h2
         = t('workshops.title', host: @workshop.host.name)
         %br
-        %small #{humanize_date(@workshop.date_and_time)} #{@workshop.distance_of_time}
+        %small #{l(@workshop.date_and_time, format: :_humanize_date)} #{@workshop.distance_of_time}
         #workshop-time.time
           %i.material-icons
             access_time

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -1,5 +1,5 @@
 - title t('workshop.title', host: @workshop.host.name,
-                            date: l(@workshop.date_and_time, format: :_humanize_date))
+                            date: l(@workshop.date_and_time, format: :humanize_date))
 
 = render partial: 'meta_tags', locals: { workshop: @workshop }
 
@@ -9,7 +9,7 @@
       %h2
         = t('workshops.title', host: @workshop.host.name)
         %br
-        %small #{l(@workshop.date_and_time, format: :_humanize_date)} #{@workshop.distance_of_time}
+        %small #{l(@workshop.date_and_time, format: :humanize_date)} #{@workshop.distance_of_time}
         #workshop-time.time
           %i.material-icons
             access_time

--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -1,0 +1,12 @@
+{
+  en: {
+    time: {
+      formats: {
+        _humanize_date: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B" },
+        _humanize_date_with_year: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B %Y" },
+        _humanize_date_with_time: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B at %R" },
+        _humanize_date_with_year_with_time: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B %Y at %R" }
+      }
+    }
+  }
+}

--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -2,10 +2,10 @@
   en: {
     time: {
       formats: {
-        _humanize_date: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B" },
-        _humanize_date_with_year: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B %Y" },
-        _humanize_date_with_time: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B at %R" },
-        _humanize_date_with_year_with_time: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B %Y at %R" }
+        humanize_date: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B" },
+        humanize_date_with_year: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B %Y" },
+        humanize_date_with_time: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B at %R" },
+        humanize_date_with_year_with_time: ->(datetime, _) { "%a, #{datetime.day.ordinalize} %B %Y at %R" }
       }
     }
   }

--- a/spec/features/admin/accessing_portal_spec.rb
+++ b/spec/features/admin/accessing_portal_spec.rb
@@ -16,13 +16,19 @@ RSpec.feature 'admin portal', type: :feature do
       login_as_admin(member)
     end
 
-    scenario 'can view all active chapters listed' do
+    scenario 'can view all active chapters and upcoming workshops listed' do
       chapter = Fabricate(:chapter_with_groups)
+      workshop = Fabricate.times(2, :workshop)
       inactive_chapter = Fabricate(:chapter_with_groups, active: false)
       visit admin_root_path
 
       chapter.groups.each do |group|
         expect(page).to have_content(group.to_s)
+      end
+
+      workshops.each do |workshop|
+        expect(page).to have_content(workshop.chapter.name)
+        expect(page).to have_content(I18n.l(workshop.date_and_time, format: :humanize_date_with_time))
       end
 
       inactive_chapter.groups.each do |group|

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
       visit admin_chapter_workshops_path(chapter)
 
       workshops.each do |workshop|
-        expect(page).to have_content(I18n.l(workshop.date_and_time, format: :_humanize_date_with_year_with_time))
+        expect(page).to have_content(I18n.l(workshop.date_and_time, format: :humanize_date_with_year_with_time))
       end
     end
 

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
       visit admin_chapter_workshops_path(chapter)
 
       workshops.each do |workshop|
-        expect(page).to have_content(humanize_date(workshop.date_and_time, with_time: true, with_year: true))
+        expect(page).to have_content(I18n.l(workshop.date_and_time, format: :_humanize_date_with_year_with_time))
       end
     end
 

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -15,6 +15,13 @@ RSpec.feature 'member feedback', type: :feature do
     Fabricate(:attended_workshop_invitation, workshop: feedback_request.workshop, member: coach, role: 'Coach')
   end
 
+  scenario 'I can display member feedbacks' do
+    visit feedback_path(valid_token)
+
+    expect(page).to have_content("Workshop feedback")
+    expect(page).to have_content("#{I18n.l(feedback_request.workshop.date_and_time, format: :_humanize_date_with_time)}")
+  end
+
   context 'Feedback form' do
     scenario 'I can access the feedback form when the token is valid' do
       visit feedback_path(valid_token)

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'member feedback', type: :feature do
     visit feedback_path(valid_token)
 
     expect(page).to have_content("Workshop feedback")
-    expect(page).to have_content("#{I18n.l(feedback_request.workshop.date_and_time, format: :_humanize_date_with_time)}")
+    expect(page).to have_content("#{I18n.l(feedback_request.workshop.date_and_time, format: :humanize_date_with_time)}")
   end
 
   context 'Feedback form' do

--- a/spec/features/viewing_a_course_spec.rb
+++ b/spec/features/viewing_a_course_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'viewing a course', type: :feature do
     visit course_path(course)
 
     expect(page).to have_content course.title
-    expect(page).to have_content I18n.l(course.date_and_time, format: :_humanize_date_with_time)
+    expect(page).to have_content I18n.l(course.date_and_time, format: :humanize_date_with_time)
     expect(page).to have_content course.description
     expect(page).to have_content course.short_description
     expect(page).to have_link "Read more", href: course.url

--- a/spec/features/viewing_a_course_spec.rb
+++ b/spec/features/viewing_a_course_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'viewing a course', type: :feature do
     visit course_path(course)
 
     expect(page).to have_content course.title
+    expect(page).to have_content I18n.l(course.date_and_time, format: :_humanize_date_with_time)
     expect(page).to have_content course.description
     expect(page).to have_content course.short_description
     expect(page).to have_link "Read more", href: course.url

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'viewing a meeting', type: :feature do
     scenario "can view a meeting's information" do
 
       expect(page).to have_content meeting.name
+      expect(page).to have_content I18n.l(meeting.date_and_time, format: :_humanize_date)
       expect(page).to have_content meeting.venue.name
     end
   end

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -10,13 +10,13 @@ RSpec.feature 'viewing a meeting', type: :feature do
 
     scenario 'can view the page title' do
       expect(page).to have_title("#{meeting.name} - " \
-                                 "#{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
+                                 "#{I18n.l(meeting.date_and_time, format: :humanize_date)}")
     end
 
     scenario "can view a meeting's information" do
 
       expect(page).to have_content meeting.name
-      expect(page).to have_content I18n.l(meeting.date_and_time, format: :_humanize_date)
+      expect(page).to have_content I18n.l(meeting.date_and_time, format: :humanize_date)
       expect(page).to have_content meeting.venue.name
     end
   end

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature 'viewing a meeting', type: :feature do
     end
 
     scenario 'can view the page title' do
-      expect(page).to have_title("#{meeting.name} - #{humanize_date(meeting.date_and_time)}")
+      expect(page).to have_title("#{meeting.name} - " \
+                                 "#{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
     end
 
     scenario "can view a meeting's information" do

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
     let(:workshop) { Fabricate(:workshop) }
 
     scenario 'workshop and page title' do
-      expect(page).to have_title("Workshop invitation - #{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
+      expect(page).to have_title("Workshop invitation - #{I18n.l(workshop.date_and_time, format: :humanize_date)}")
       expect(page).to have_content("Workshop at #{workshop.host.name}")
     end
 
@@ -58,7 +58,7 @@ RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
     let(:workshop) { Fabricate(:virtual_workshop) }
 
     scenario 'workshop and page title' do
-      expect(page).to have_title("Workshop invitation - #{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
+      expect(page).to have_title("Workshop invitation - #{I18n.l(workshop.date_and_time, format: :humanize_date)}")
       expect(page).to have_content("Virtual workshop for #{workshop.chapter.name}")
     end
 

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
     let(:workshop) { Fabricate(:workshop) }
 
     scenario 'workshop and page title' do
-      expect(page).to have_title("Workshop invitation - #{humanize_date(workshop.date_and_time)}")
+      expect(page).to have_title("Workshop invitation - #{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
       expect(page).to have_content("Workshop at #{workshop.host.name}")
     end
 
@@ -58,7 +58,7 @@ RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
     let(:workshop) { Fabricate(:virtual_workshop) }
 
     scenario 'workshop and page title' do
-      expect(page).to have_title("Workshop invitation - #{humanize_date(workshop.date_and_time)}")
+      expect(page).to have_title("Workshop invitation - #{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
       expect(page).to have_content("Virtual workshop for #{workshop.chapter.name}")
     end
 

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
       describe '#details' do
         scenario 'workshop and page title' do
           expect(page).to have_title("Workshop at #{workshop.host.name} - " \
-                                     "#{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
+                                     "#{I18n.l(workshop.date_and_time, format: :humanize_date)}")
           expect(page).to have_content("Workshop at #{workshop.host.name}")
         end
 
@@ -40,7 +40,7 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
       describe '#details' do
         scenario 'workshop and page title' do
           expect(page).to have_title("Virtual workshop for #{workshop.chapter.name} - " \
-                                     "#{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
+                                     "#{I18n.l(workshop.date_and_time, format: :humanize_date)}")
           expect(page).to have_content("Virtual workshop for #{workshop.chapter.name}")
         end
 

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
 
       describe '#details' do
         scenario 'workshop and page title' do
-          expect(page).to have_title("Workshop at #{workshop.host.name} - #{humanize_date(workshop.date_and_time)}")
+          expect(page).to have_title("Workshop at #{workshop.host.name} - " \
+                                     "#{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
           expect(page).to have_content("Workshop at #{workshop.host.name}")
         end
 
@@ -38,8 +39,8 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
 
       describe '#details' do
         scenario 'workshop and page title' do
-          expect(page)
-            .to have_title("Virtual workshop for #{workshop.chapter.name} - #{humanize_date(workshop.date_and_time)}")
+          expect(page).to have_title("Virtual workshop for #{workshop.chapter.name} - " \
+                                     "#{I18n.l(workshop.date_and_time, format: :_humanize_date)}")
           expect(page).to have_content("Virtual workshop for #{workshop.chapter.name}")
         end
 

--- a/spec/formats/humanize_spec.rb
+++ b/spec/formats/humanize_spec.rb
@@ -6,22 +6,22 @@ RSpec.describe 'Humanize' do
   end
 
   it "humanizes date without time or year" do
-    expect(I18n.l(Time.zone.now, format: :_humanize_date))
+    expect(I18n.l(Time.zone.now, format: :humanize_date))
       .to eq "Wed, 15th January"
   end
 
   it "humanizes date without time but with year" do
-    expect(I18n.l(Time.zone.now, format: :_humanize_date_with_year))
+    expect(I18n.l(Time.zone.now, format: :humanize_date_with_year))
       .to eq "Wed, 15th January 2020"
   end
 
   it "humanizes date with time but not year" do
-    expect(I18n.l(Time.zone.now, format: :_humanize_date_with_time))
+    expect(I18n.l(Time.zone.now, format: :humanize_date_with_time))
       .to eq "Wed, 15th January at 12:30"
   end
 
   it "humanizes date with time and year" do
-    expect(I18n.l(Time.zone.now, format: :_humanize_date_with_year_with_time))
+    expect(I18n.l(Time.zone.now, format: :humanize_date_with_year_with_time))
       .to eq "Wed, 15th January 2020 at 12:30"
   end
 

--- a/spec/formats/humanize_spec.rb
+++ b/spec/formats/humanize_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe 'Humanize' do
+  before do
+    travel_to Time.local(2020, 1, 15, 12, 30)
+  end
+
+  it "humanizes date without time or year" do
+    expect(I18n.l(Time.zone.now, format: :_humanize_date))
+      .to eq "Wed, 15th January"
+  end
+
+  it "humanizes date without time but with year" do
+    expect(I18n.l(Time.zone.now, format: :_humanize_date_with_year))
+      .to eq "Wed, 15th January 2020"
+  end
+
+  it "humanizes date with time but not year" do
+    expect(I18n.l(Time.zone.now, format: :_humanize_date_with_time))
+      .to eq "Wed, 15th January at 12:30"
+  end
+
+  it "humanizes date with time and year" do
+    expect(I18n.l(Time.zone.now, format: :_humanize_date_with_year_with_time))
+      .to eq "Wed, 15th January 2020 at 12:30"
+  end
+
+  after do
+    travel_back
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,39 @@
 require 'spec_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
+  describe '#humanize_date' do
+    before do
+      travel_to Time.local(2020, 1, 15, 12, 30)
+    end
+
+    # humainize_week_day_with_date
+    it "humanizes date without time or year" do
+      expect(humanize_date(Time.zone.now, with_time: false, with_year: false))
+        .to eq "Wed, 15th January"
+    end
+
+    # humainize_week_day_with_date
+    it "humanizes date without time but with year" do
+      expect(humanize_date(Time.zone.now, with_time: false, with_year: true))
+        .to eq "Wed, 15th January 2020"
+    end
+
+
+    it "humanizes date with time but not year" do
+      expect(humanize_date(Time.zone.now, with_time: true, with_year: false))
+        .to eq "Wed, 15th January at 12:30"
+    end
+
+    it "humanizes date with time and year" do
+      expect(humanize_date(Time.zone.now, with_time: true, with_year: true))
+        .to eq "Wed, 15th January 2020 at 12:30"
+    end
+
+    after do
+      travel_back
+    end
+  end
+
   describe '#contact_email' do
     it "returns the workshop chapter's email" do
       @workshop = Fabricate(:workshop)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,39 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe '#humanize_date' do
-    before do
-      travel_to Time.local(2020, 1, 15, 12, 30)
-    end
-
-    # humainize_week_day_with_date
-    it "humanizes date without time or year" do
-      expect(humanize_date(Time.zone.now, with_time: false, with_year: false))
-        .to eq "Wed, 15th January"
-    end
-
-    # humainize_week_day_with_date
-    it "humanizes date without time but with year" do
-      expect(humanize_date(Time.zone.now, with_time: false, with_year: true))
-        .to eq "Wed, 15th January 2020"
-    end
-
-
-    it "humanizes date with time but not year" do
-      expect(humanize_date(Time.zone.now, with_time: true, with_year: false))
-        .to eq "Wed, 15th January at 12:30"
-    end
-
-    it "humanizes date with time and year" do
-      expect(humanize_date(Time.zone.now, with_time: true, with_year: true))
-        .to eq "Wed, 15th January 2020 at 12:30"
-    end
-
-    after do
-      travel_back
-    end
-  end
-
   describe '#contact_email' do
     it "returns the workshop chapter's email" do
       @workshop = Fabricate(:workshop)

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.invite(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("You are invited to codebar\'s #{meeting.name} on #{humanize_date(meeting.date_and_time)}")
+      expect(mail.subject).to eq("You are invited to codebar's #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])
@@ -23,7 +23,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.attending(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("See you at #{meeting.name} on #{humanize_date(meeting.date_and_time)}")
+      expect(mail.subject).to eq("See you at #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])
@@ -38,7 +38,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.approve_from_waitlist(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("A spot opened up for #{meeting.name} on #{humanize_date(meeting.date_and_time)}")
+      expect(mail.subject).to eq("A spot opened up for #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])
@@ -53,7 +53,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.attendance_reminder(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("Reminder: You have a spot for #{meeting.name} on #{humanize_date(meeting.date_and_time)}")
+      expect(mail.subject).to eq("Reminder: You have a spot for #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.invite(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("You are invited to codebar's #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
+      expect(mail.subject).to eq("You are invited to codebar's #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])
@@ -16,7 +16,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('We\'re back for another installment of codebar Monthlies')
-      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :_humanize_date_with_time))
+      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :humanize_date_with_time))
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.attending(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("See you at #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
+      expect(mail.subject).to eq("See you at #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])
@@ -32,7 +32,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('You\'re confirmed for the next codebar Monthly')
-      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :_humanize_date_with_time))
+      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :humanize_date_with_time))
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.approve_from_waitlist(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("A spot opened up for #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
+      expect(mail.subject).to eq("A spot opened up for #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])
@@ -48,7 +48,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('A spot opened up for the next codebar Monthly')
-      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :_humanize_date_with_time))
+      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :humanize_date_with_time))
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     let(:mail) { MeetingInvitationMailer.attendance_reminder(meeting, member).deliver_now }
 
     it 'renders the headers' do
-      expect(mail.subject).to eq("Reminder: You have a spot for #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :_humanize_date)}")
+      expect(mail.subject).to eq("Reminder: You have a spot for #{meeting.name} on #{I18n.l(meeting.date_and_time, format: :humanize_date)}")
       expect(mail.to).to eq([member.email])
       expect(mail.from).to eq(['meetings@codebar.io'])
       expect(mail.cc).to eq([])

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('We\'re back for another installment of codebar Monthlies')
+      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :_humanize_date_with_time))
     end
   end
 
@@ -31,6 +32,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('You\'re confirmed for the next codebar Monthly')
+      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :_humanize_date_with_time))
     end
   end
 
@@ -46,6 +48,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.body.encoded).to match('A spot opened up for the next codebar Monthly')
+      expect(mail.body.encoded).to match(I18n.l(meeting.date_and_time, format: :_humanize_date_with_time))
     end
   end
 

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
 
   it '#attending' do
     email_subject = "Attendance Confirmation: Virtual workshop for #{workshop.chapter.name} " \
-                    "- #{humanize_date(workshop.date_and_time)}"
+                    "- #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
 
   it '#attending' do
     email_subject = "Attendance Confirmation: Virtual workshop for #{workshop.chapter.name} " \
-                    "- #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+                    "- #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 
@@ -18,7 +18,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
   end
 
   it '#attending_reminder' do
-    email_subject = "Virtual Workshop Reminder #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+    email_subject = "Virtual Workshop Reminder #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
 
@@ -29,7 +29,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
 
   it '#invite_coach' do
     email_subject = "Virtual Workshop Coach Invitation " \
-                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+                    "#{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
 
@@ -38,7 +38,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
   end
 
   it '#invite_student' do
-    email_subject = "Virtual Workshop Invitation #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+    email_subject = "Virtual Workshop Invitation #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
@@ -48,14 +48,14 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
 
   it '#waitlist_reminder' do
     email_subject = "Reminder: you're on the codebar waiting list " \
-                    "(#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)})"
+                    "(#{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)})"
 
     VirtualWorkshopInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
     expect(email.body.encoded)
-      .to match("the virtual workshop on #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}")
+      .to match("the virtual workshop on #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
   end
 
   it '#attending_reminder' do
-    email_subject = "Virtual Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "Virtual Workshop Reminder #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
 
@@ -28,7 +28,8 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
   end
 
   it '#invite_coach' do
-    email_subject = "Virtual Workshop Coach Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "Virtual Workshop Coach Invitation " \
+                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
 
@@ -37,7 +38,7 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
   end
 
   it '#invite_student' do
-    email_subject = "Virtual Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "Virtual Workshop Invitation #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     VirtualWorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
@@ -47,13 +48,14 @@ RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
 
   it '#waitlist_reminder' do
     email_subject = "Reminder: you're on the codebar waiting list " \
-                    "(#{humanize_date(workshop.date_and_time, with_time: true)})"
+                    "(#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)})"
 
     VirtualWorkshopInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match("the virtual workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
+    expect(email.body.encoded)
+      .to match("the virtual workshop on #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
 
   it "#attending" do
     email_subject = "Attendance Confirmation for " \
-                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+                    "#{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 
@@ -18,7 +18,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   end
 
   it '#attending_reminder' do
-    email_subject = "Workshop Reminder #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+    email_subject = "Workshop Reminder #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     WorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
 
@@ -29,7 +29,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   it '#change_of_details' do
     title = 'Change of details'
     email_subject = "#{title}: #{workshop.title} by codebar - " \
-                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+                    "#{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     WorkshopInvitationMailer.change_of_details(workshop, sponsor, member, invitation).deliver_now
 
@@ -39,7 +39,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
 
   it '#invite_coach' do
     email_subject = "Workshop Coach Invitation " \
-                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+                    "#{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     WorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
 
@@ -48,7 +48,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   end
 
   it '#invite_student' do
-    email_subject = "Workshop Invitation #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
+    email_subject = "Workshop Invitation #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}"
 
     WorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
@@ -66,13 +66,13 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
 
   it '#waitlist_reminder' do
     email_subject = "Reminder: you're on the codebar waiting list " \
-                    "(#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)})"
+                    "(#{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)})"
 
     WorkshopInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match("the workshop on #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}")
+    expect(email.body.encoded).to match("the workshop on #{I18n.l(workshop.date_and_time, format: :humanize_date_with_time)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
   let(:sponsor) { Fabricate(:sponsor) }
 
-  it '#attending' do
-    email_subject = "Attendance Confirmation for #{humanize_date(workshop.date_and_time, with_time: true)}"
+  it "#attending" do
+    email_subject = "Attendance Confirmation for " \
+                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 
@@ -17,7 +18,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   end
 
   it '#attending_reminder' do
-    email_subject = "Workshop Reminder #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "Workshop Reminder #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     WorkshopInvitationMailer.attending_reminder(workshop, member, invitation).deliver_now
 
@@ -28,7 +29,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   it '#change_of_details' do
     title = 'Change of details'
     email_subject = "#{title}: #{workshop.title} by codebar - " \
-                    "#{humanize_date(workshop.date_and_time, with_time: true)}"
+                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     WorkshopInvitationMailer.change_of_details(workshop, sponsor, member, invitation).deliver_now
 
@@ -37,7 +38,8 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   end
 
   it '#invite_coach' do
-    email_subject = "Workshop Coach Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "Workshop Coach Invitation " \
+                    "#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     WorkshopInvitationMailer.invite_coach(workshop, member, invitation).deliver_now
 
@@ -46,7 +48,7 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
   end
 
   it '#invite_student' do
-    email_subject = "Workshop Invitation #{humanize_date(workshop.date_and_time, with_time: true)}"
+    email_subject = "Workshop Invitation #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}"
 
     WorkshopInvitationMailer.invite_student(workshop, member, invitation).deliver_now
 
@@ -64,13 +66,13 @@ RSpec.describe WorkshopInvitationMailer, type: :mailer do
 
   it '#waitlist_reminder' do
     email_subject = "Reminder: you're on the codebar waiting list " \
-                    "(#{humanize_date(workshop.date_and_time, with_time: true)})"
+                    "(#{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)})"
 
     WorkshopInvitationMailer.waiting_list_reminder(workshop, member, invitation).deliver_now
 
     expect(email.subject).to eq(email_subject)
     expect(email.from).to eq([workshop.chapter.email])
-    expect(email.body.encoded).to match("the workshop on #{humanize_date(workshop.date_and_time, with_time: true)}")
+    expect(email.body.encoded).to match("the workshop on #{I18n.l(workshop.date_and_time, format: :_humanize_date_with_time)}")
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe WorkshopPresenter do
                       attending_students: double(:attending_students, count: attending_students))
   end
 
-
   context '#decorate' do
     it 'returns a workshop decorated with the WorkshopPresenter' do
       workshop = double(:workshop, virtual?: false)
@@ -48,7 +47,6 @@ RSpec.describe WorkshopPresenter do
       expect(presenter.attending_and_available_coach_spots).to eq('3/15')
     end
   end
-
 
   context '#title' do
     it 'returns the title of a workshop' do
@@ -117,6 +115,26 @@ RSpec.describe WorkshopPresenter do
       end
 
       after { travel_back }
+    end
+
+    context '#distance_of_time' do
+      it 'displays if the workshop is in the past' do
+        travel_to Time.local(2020, 1, 1, 18, 30)
+
+        presenter = WorkshopPresenter.new(Fabricate(:workshop, date_and_time: Time.zone.now - 1.day))
+        expect(presenter.distance_of_time).to eq '(1 day ago)'
+
+        travel_back
+      end
+
+      it 'displays if the workshop is the future' do
+        travel_to Time.local(2020, 1, 1, 18, 30)
+
+        presenter = WorkshopPresenter.new(Fabricate(:workshop, date_and_time: Time.zone.now + 1.day))
+        expect(presenter.distance_of_time).to eq '(in 1 day)'
+
+        travel_back
+      end
     end
   end
 

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -98,6 +98,26 @@ RSpec.describe WorkshopPresenter do
           .to eq("#{I18n.l(workshop.time, format: :time)} - #{I18n.l(workshop.ends_at, format: :time)}")
       end
     end
+
+    context '#humanize_date_with_time_range' do
+      before { travel_to Time.local(2020, 1, 1, 18, 30) }
+
+      it 'displays range when available' do
+        presenter = WorkshopPresenter.new(Fabricate(:workshop, date_and_time: Time.zone.now,
+                                                              ends_at: Time.zone.now + 2.hours))
+
+        expect(presenter.humanize_date_with_time_range) .to eq 'Wed, 1st January at 18:30 - 20:30'
+      end
+
+      it 'displays start time only if end unavailable' do
+        presenter = WorkshopPresenter.new(Fabricate(:workshop, date_and_time: Time.zone.now,
+                                                              ends_at: nil))
+
+        expect(presenter.humanize_date_with_time_range) .to eq 'Wed, 1st January at 18:30'
+      end
+
+      after { travel_back }
+    end
   end
 
   context '#attendees_csv' do

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'invitation route' do
       visit invitation_route
 
       expect(page).to have_title("Workshop invitation - " \
-                                 "#{I18n.l(invitation.workshop.date_and_time, format: :_humanize_date)} " \
+                                 "#{I18n.l(invitation.workshop.date_and_time, format: :humanize_date)} " \
                                  "| codebar.io")
 
     end

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -3,7 +3,10 @@ RSpec.shared_examples 'invitation route' do
     scenario 'renders a descriptive page title' do
       visit invitation_route
 
-      expect(page).to have_title("Workshop invitation - #{humanize_date(invitation.workshop.date_and_time)} | codebar.io")
+      expect(page).to have_title("Workshop invitation - " \
+                                 "#{I18n.l(invitation.workshop.date_and_time, format: :_humanize_date)} " \
+                                 "| codebar.io")
+
     end
   end
 

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
Closes https://github.com/codebar/planner/issues/1204

Introduces an I18n date format to replace the helper method humanize_date

| Format | humanize_date call                                                                                                      |
|:--------|:---------------------------------------------------------------------------------|
| humanize_date | humanize_date(date, with_time: false, with_year: false)                              |
| humanize_date_with_year  |  humanize_date(date, with_time: false, with_year: true)             |
| humanize_date_with_time |  humanize_date(date, with_time: true, with_year: false)              |
| humanize_date_with_year_with_time  |  humanize_date(date, with_time: true, with_year: true) |

- Commits put together the code change with the associated test. 
- The format should match the humanize_date call date (and times)
  - with the exception of 2f751ce which I thought might be wrong
  - one of the tests got away with testing for date when it should have been date and time - the test was changed to date and time

462ff8d introduced `humanize_date_with_time_range` - which allowed me to replace and test the ternary operator used in many views for date time ranges (see 462ff8d for examples) . 

Testing put `format: :humanize_date` on both the specs and the production code. I'm not sure how much value testing a format is outside of branch logic - as long as you have literally used the right text it works. When ordinalization is supported natively in rails 6 there's less to go wrong. However, I've kept all the testing and added a few more for consistency.

d3a7316  - did not have direct tests but if you got the formatting wrong it would break the build. Writing a test to confirm the formatting did not make sense as it was no code logic and there wasn't a test for anything else in the view. 

c0bf1f9  - whatever I did in these files would not break the build. I did stay away from a few files where I couldn't work out where to test them / if they were tested. 🐔 
