### PR TITLE
Fix Assignment Branch condition size with Admin portal presenter

### DIFF
--- a/app/controllers/admin/portal_controller.rb
+++ b/app/controllers/admin/portal_controller.rb
@@ -2,12 +2,7 @@ class Admin::PortalController < Admin::ApplicationController
   def index
     authorize :admin_portal
 
-    @jobs_pending_approval = Job.where(approved: false, submitted: true).count
-    @chapters = Chapter.active.all.order(name: :asc)
-    @workshops = Workshop.upcoming
-    @groups = Group.joins(:chapter).merge(@chapters)
-    @subscribers = Subscription.joins(:chapter).merge(@chapters)
-                               .ordered.limit(20).includes(:member, :group)
+    @portal = AdminPortalPresenter.new
   end
 
   def guide

--- a/app/presenters/admin_portal_presenter.rb
+++ b/app/presenters/admin_portal_presenter.rb
@@ -1,0 +1,22 @@
+class AdminPortalPresenter
+  def jobs_pending_approval
+    @jobs_pending_approval ||= Job.where(approved: false, submitted: true).count
+  end
+
+  def active_chapters
+    @active_chapters ||= Chapter.active.all.order(name: :asc)
+  end
+
+  def upcoming_workshops
+    @upcoming_workshops ||= Workshop.upcoming
+  end
+
+  def active_chapter_groups
+    @active_chapter_groups ||= Group.joins(:chapter).merge(active_chapters)
+  end
+
+  def subscribers(limit: 20)
+    @subscribers ||= Subscription.joins(:chapter).merge(active_chapters)
+                                 .ordered.limit(limit).includes(:member, :group)
+  end
+end

--- a/app/views/admin/portal/index.html.haml
+++ b/app/views/admin/portal/index.html.haml
@@ -3,12 +3,12 @@
     .large-4.columns
       %h3 Chapters
       %ul.side-nav
-        - @chapters.each do |chapter|
+        - @portal.active_chapters.each do |chapter|
           %li= link_to chapter.name, [ :admin, chapter ]
     .large-4.columns
       %h3 Upcoming Workshops
       %ul.side-nav
-        - @workshops.each do |workshop|
+        - @portal.upcoming_workshops.each do |workshop|
           %li
             = link_to admin_workshop_path(workshop) do
               %strong= workshop.chapter.name
@@ -24,11 +24,11 @@
     .large-3.columns
       %h3 Groups
       %ul.side-nav
-        - @groups.each do |group|
+        - @portal.active_chapter_groups.each do |group|
           %li
             = link_to [:admin, group] do
               #{group.name} (#{group.chapter.name})
 
     .large-9.columns
       %h3 Latest Subscribers
-      = render partial: 'admin/subscriptions/index', locals: { subscribers: @subscribers }
+      = render partial: 'admin/subscriptions/index', locals: { subscribers: @portal.subscribers }

--- a/spec/fabricators/chapter_fabricator.rb
+++ b/spec/fabricators/chapter_fabricator.rb
@@ -4,6 +4,7 @@ Fabricator(:chapter) do
   name { Fabricate.sequence(:name) }
   city { Faker::Lorem.word }
   email { Faker::Internet.email }
+  active { true }
   time_zone { 'London' }
 
   after_save do |chapter|
@@ -13,11 +14,6 @@ Fabricator(:chapter) do
 end
 
 Fabricator(:chapter_with_groups, from: :chapter) do
-  name { Fabricate.sequence(:name) }
-  city { Faker::Lorem.word }
-  email { Faker::Internet.email }
-  time_zone { 'London' }
-
   after_save do |chapter|
     Fabricate(:students, chapter: chapter)
     Fabricate(:coaches, chapter: chapter)

--- a/spec/presenters/admin_portal_presenter_spec.rb
+++ b/spec/presenters/admin_portal_presenter_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.describe AdminPortalPresenter do
+  describe '#chapters' do
+    it 'includes active chapters' do
+      active_chapter = Fabricate(:chapter, active: true)
+
+      expect(subject.active_chapters).to include(active_chapter)
+    end
+
+    it 'excludes inactive chapters' do
+      inactive_chapter = Fabricate(:chapter, active: false)
+
+      expect(subject.active_chapters).not_to include(inactive_chapter)
+    end
+  end
+
+  describe '#jobs_pending_approval' do
+    it 'includes submitted jobs that are not approved' do
+      Fabricate(:pending_job, approved: false, submitted: true)
+
+      expect(subject.jobs_pending_approval).to eq 1
+    end
+
+    it 'excludes submitted jobs that have been approved' do
+      Fabricate(:published_job, approved: true, submitted: true)
+
+      expect(subject.jobs_pending_approval).to eq 0
+    end
+  end
+
+  describe '#workshops_upcoming' do
+    it 'includes upcoming workshops' do
+      upcoming_workshop = Fabricate(:workshop, date_and_time: Time.zone.now + 2.days)
+
+      expect(subject.upcoming_workshops).to include(upcoming_workshop)
+    end
+
+    it 'excludes past workshops' do
+      past_workshop = Fabricate(:past_workshop, date_and_time: Time.zone.now - 2.days)
+
+      expect(subject.upcoming_workshops).not_to include(past_workshop)
+    end
+  end
+
+  describe '#active_chapter_groups' do
+    it 'includes groups with active chapters' do
+      active_chaptered_group = Fabricate(:group, chapter: Fabricate(:chapter, active: true))
+
+      expect(subject.active_chapter_groups).to include(active_chaptered_group)
+    end
+
+    it 'excludes groups without active chapters' do
+      inactive_chaptered_group = Fabricate(:group, chapter: Fabricate(:chapter, active: false))
+
+      expect(subject.active_chapter_groups).not_to include(inactive_chaptered_group)
+    end
+  end
+
+  describe '#subscribers' do
+    it 'includes subscribers of the active chapters' do
+      without_bullet do
+        chapter = Fabricate(:chapter_with_groups, active: true)
+
+        expect(subject.subscribers).to match_array(chapter.subscriptions)
+      end
+    end
+
+    it 'excludes subscribers not associated with active chapters' do
+      without_bullet do
+        chapter = Fabricate(:chapter_with_groups, active: false)
+
+        expect(subject.subscribers).not_to match_array(chapter.subscriptions)
+      end
+    end
+  end
+end

--- a/spec/support/bullet.rb
+++ b/spec/support/bullet.rb
@@ -1,0 +1,5 @@
+def without_bullet
+  Bullet.raise = false if Bullet.enable?
+  Bullet.profile { yield }
+  Bullet.raise = true if Bullet.enable?
+end


### PR DESCRIPTION
> Assignment Branch Condition size for index is too high.

I was getting the above Rubocop error (above) when I made a modest change to one of the assignments in the PortalController#index method [as part of another PR](https://github.com/codebar/planner/pull/1231). These changes should fix this.

```ruby
  def index
    authorize :admin_portal

    @jobs_pending_approval = Job.where(approved: false, submitted: true).count
    @chapters = Chapter.active.all.order(name: :asc)
    @workshops = Workshop.upcoming
    @groups = Group.joins(:chapter).merge(@chapters)
    @subscribers = Subscription.joins(:chapter).merge(@chapters)
                               .ordered.limit(20).includes(:member, :group)
  end
```
1. [Minor fix to the Chapter Fabricator that was duplicating the config code](d0df65e )
2. [Support method to disable bullet on demand](https://github.com/codebar/planner/commit/de1436a1b6591c207a0135a26dd8fcde1b089121)
    - Needed during portal assignment testing (below) because I was not using group data returned in the subscribers method Bullet considered it was an eager loading issue.
3. [Add Presenter object which wraps up Portal assignments and tests each assignment.](https://github.com/codebar/planner/commit/fd0b9aa13b34c1318d564bff1882b4e6f3fcfa3c )
4. (fix) [Switched the code to the Portal object away from the multiple instance variables](https://github.com/codebar/planner/commit/7452945a65692df9b13547b4274b9cc8958791fc)