### PR TITLE
(Refactor) Remove @contact_email instance variable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,7 +41,7 @@ module ApplicationHelper
   end
 
   def contact_email(workshop: nil)
-    @contact_email ||= workshop.present? ? workshop.chapter.email : 'hello@codebar.io'
+    workshop.present? ? workshop.chapter.email : 'hello@codebar.io'
   end
 
   def active_link_class(link_path)


### PR DESCRIPTION
 - variable only used for memoization
 - only called once per request/response cycle and very light work
     - no obvious reason to memoize
---

This is another rubocop fix but you won't see the "error" unless you turn on `rubocop-rails` [which you can see in this PR.](https://github.com/codebar/planner/pull/1046)