### PR TITLE
(Fix flaky) attendance_reminder match short text to avoid newline

### DIFF
--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe MeetingInvitationMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match('This is a quick email to remind you that you have signed up for tomorrow\'s codebar Monthly')
+      expect(mail.body.encoded).to match('codebar Monthly Attendance Reminder')
       expect(mail.body.encoded).to match('hello@codebar.io')
     end
   end


### PR DESCRIPTION
 - currently expect matches a long line of static text (there
   is no condition for the text to appear or not)
 - What happens is that it puts carriage returns =0D in the middle
   of the text stopping the match.
 - I have never got to the bottom of this problem (it only happens
   sometimes) and only on Travis.
 - It doesn't seem like a useful test, I think it is a way to make
   sure the expected template was used - so instead I will match
   to a shorter email heading.
--
[Example of the flaky test](https://travis-ci.org/github/codebar/planner/builds/672490520)
