### PR TITLE
Update copy on various job listing pages

### DIFF
--- a/app/views/member/jobs/_form.html.haml
+++ b/app/views/member/jobs/_form.html.haml
@@ -1,5 +1,5 @@
 #new_job
-  %h4 Job details
+  %h4 Job post details
   .row
     .large-6.columns
       = f.input :title, required: true
@@ -35,8 +35,9 @@
     .large-6.columns
       = f.input :location, required: true
 
-  %small
-    = t('member.jobs.new.optional_details_message')
+  .row
+    %small
+      = t('member.jobs.new.optional_details_message')
 
   .row
     .large-6.columns
@@ -46,4 +47,4 @@
       = f.input :company_postcode
   .row
     .large-12.columns
-      = f.submit "Submit job", class: "button"
+      = f.submit "Submit job for approval", class: "button"

--- a/app/views/member/jobs/new.html.haml
+++ b/app/views/member/jobs/new.html.haml
@@ -7,6 +7,11 @@
           %li=link_to  t('member.jobs.title'), member_jobs_path
           %li.current
             %span=t('member.jobs.new.title')
+
+    .row
+      .large-12.columns
+        %p=t('member.jobs.new.description')
+
     .row
       .large-12.columns
         .panel

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -361,13 +361,14 @@ de:
         none: Du hast keine Jobeinträge in Prüfung.
       new:
         title: Job eintragen
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Bitte prüfe vor dem Abschicken, dass:"
         details: dein Eintrag detailliert die zu erledigende Arbeit darstellt
         suitability: "der Job passend für Menschen ist, die nach Praktika und Junior-Positionen suchen, die ihnen helfen ihre Karriere aufzubauen"
         salary: der Job ein angemessenes Gehalt bietet
         short: "der Eintrag kurz und auf den Punkt ist"
         approval_info: "*Nach dem Abschicken wird der Job sichtbar sobald er geprüft und bestätigt wurde."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@ de:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,7 +392,7 @@ en:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -410,22 +410,23 @@ en:
         title: Almost there...
         summary: We need some more details from you to finish creating your account. We use these to help run our events.
         coach:
-          about_you: What experience do you have? What languages do you like to use? Tell us a little about yourself!
+          about_you: What experience do you have? What languages do you like to use? Tell us a little bit about yourself!
         student:
-          about_you: What do you want to work on at codebar? What have you done in the past? Tell us a little about yourself!
+          about_you: What do you want to work on at codebar? What have you done in the past? Tell us a little bit about yourself!
         submit: Next
     jobs:
       title: My jobs
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
@@ -433,7 +434,7 @@ en:
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
         optional_details_message: "The information below is only required if you want this job post to be shared with Google Search UK."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -593,7 +594,7 @@ en:
       member:
         email: 'This is needed so we can email you invitations to our events'
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
       workshop:
         slack_channel: 'Create a workshop specific channel in the codebar Slack. This is the place you will use for socialising and sharing details about the workshop.'

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -336,7 +336,7 @@ en-AU:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -354,20 +354,21 @@ en-AU:
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs. Please consider submitting a paid internship, apprenticeship or junior developer role to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@ en-AU:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -336,7 +336,7 @@ en-GB:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -354,20 +354,21 @@ en-GB:
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@ en-GB:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -334,7 +334,7 @@ en-US:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -352,20 +352,21 @@ en-US:
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -486,7 +487,7 @@ en-US:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -336,7 +336,7 @@ es:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -354,20 +354,21 @@ es:
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@ es:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -336,7 +336,7 @@ fi:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -354,20 +354,21 @@ fi:
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@ fi:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -336,7 +336,7 @@ fr:
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -354,20 +354,21 @@ fr:
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@ fr:
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -336,7 +336,7 @@
     title: Jobs
     index:
       description: There are %{count} jobs listed
-      none: There are no jobs available.
+      none: There are no jobs listed at this time. Please check back soon as positions get added regularly.
   feedback_form:
     title: 'Workshop feedback'
     description: Your submission will be completely anonymous. We read every piece of feedback and use it to help us improve our workshops.
@@ -354,20 +354,21 @@
       preview: Preview
       index:
         description: You have %{count} jobs listed
-        none: You have not posted any jobs
+        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
         none: You have no pending job posts.
       new:
         title: List a job
+        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board will fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or developers with 2 years of experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         rules_intro: "Before posting make sure that:"
         details: Your post details the work that will have to be undertaken
         suitability: "It's suitable for people looking for Internships and Junior roles that will enable them to build up their career"
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the requirement payment of £35 through %{link}
+        pay: You have made the required payment of £50 through %{link}
         donation: a donation
         button:
           pay: Make a payment
@@ -488,7 +489,7 @@
         location: 'e.g. London or Berlin'
     hints:
       job:
-        remote: Only check if the role is remote only
+        remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
   activerecord:
     attributes:

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Jobs', type: :feature do
         click_link('Jobs', match: :first)
 
         expect(page).to have_content('Jobs')
-        expect(page).to have_content('There are no jobs available')
+        expect(page).to have_content('There are no jobs listed at this time. Please check back soon as positions get added regularly.')
       end
 
       scenario 'can view all active jobs' do


### PR DESCRIPTION
Updated some bits of copy of various job pages, as well as changing the job listing fee to £50.

I've also added a description to our job page giving some information about what we expect from a job post (picture below) and the types of jobs we approve.

<img width="1292" alt="Screenshot 2020-04-09 at 16 48 40" src="https://user-images.githubusercontent.com/2683270/78917923-80e6bb80-7a87-11ea-811f-981f15afba8e.png">
