### PR TITLE
(fix) Update FeedbackRequestMailer so it can handle virtual workshops

### DIFF
--- a/app/mailers/feedback_request_mailer.rb
+++ b/app/mailers/feedback_request_mailer.rb
@@ -5,11 +5,10 @@ class FeedbackRequestMailer < ActionMailer::Base
 
   def request_feedback(workshops, member, feedback_request)
     @workshop = workshops
-    @host_address = AddressPresenter.new(@workshop.host.address)
     @member = member
     @feedback_request = feedback_request
 
-    subject = "Workshop Feedback for #{l(@workshop.date_and_time, format: :email_title)}"
+    subject = "#{@workshop} Feedback for #{l(@workshop.date_and_time, format: :email_title)}"
 
     mail(mail_args(member, subject), &:html)
   end

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -2,16 +2,33 @@ require 'spec_helper'
 
 RSpec.describe FeedbackRequestMailer, type: :mailer  do
   let(:email) { ActionMailer::Base.deliveries.last }
-  let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
   let(:member) { Fabricate(:member) }
   let(:feedback_request) { Fabricate(:feedback_request, workshop: workshop, member: member) }
 
-  it '#request_feedback' do
-    email_subject = "Workshop Feedback for #{I18n.l(workshop.date_and_time, format: :email_title)}"
+  context 'workshop' do
+    let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
 
-    FeedbackRequestMailer.request_feedback(workshop, member, feedback_request).deliver_now
+    it '#request_feedback' do
+      email_subject = "Workshop Feedback for #{I18n.l(workshop.date_and_time, format: :email_title)}"
 
-    expect(email.subject).to eq(email_subject)
-    expect(email.from).to eq(['meetings@codebar.io'])
+      FeedbackRequestMailer.request_feedback(workshop, member, feedback_request).deliver_now
+
+      expect(email.subject).to eq(email_subject)
+      expect(email.from).to eq(['meetings@codebar.io'])
+    end
+  end
+
+  context 'virtual workshop' do
+    let(:workshop) { Fabricate(:virtual_workshop) }
+
+    it '#request_feedback' do
+      email_subject = "Virtual Workshop Feedback for #{I18n.l(workshop.date_and_time, format: :email_title)}"
+
+      FeedbackRequestMailer.request_feedback(workshop, member, feedback_request).deliver_now
+
+      expect(email.subject).to eq(email_subject)
+      expect(email.from).to eq(['meetings@codebar.io'])
+      puts email.body
+    end
   end
 end


### PR DESCRIPTION
- Removed host_address as this was throwing an error when a workshop was virtual (and was also not used for standard workshops anyway)
- Updated the email subject so it reflects the workshop type

Resolves #1255 