### PR TITLE
(fix) Update feedback rake task logger

### DIFF
--- a/lib/tasks/feedback.rake
+++ b/lib/tasks/feedback.rake
@@ -2,12 +2,13 @@ namespace :feedback do
   desc 'Request feedback from students that attended our latest workshop'
   task request: :environment do
     workshops = Workshop.completed_since_yesterday
+    Rails.logger.info 'Sending Feedback request emails' if workshops.any?
     workshops.each do |workshop|
-      Rails.logger.info "Sending emails for feedback requests for workshop at #{workshop.host.name}"
       WorkshopInvitation.accepted.where(workshop: workshop, role: 'Student').map do |invitation|
         FeedbackRequest.create(member: invitation.member, workshop: workshop, submited: false)
       end
-      Rails.logger.info "Feedback requests sent: #{FeedbackRequest.where(workshop: workshop).select('count()')}"
+      Rails.logger.info "Feedback requests sent for #{workshop.chapter.name}'s #{workshop}: \
+                         #{FeedbackRequest.where(workshop: workshop).count}"
     end
   end
 end

--- a/spec/lib/tasks/feedback_rake_spec.rb
+++ b/spec/lib/tasks/feedback_rake_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe 'rake feedback:request', type: :task do
 
       yesterdays_workshops = [Fabricate(:workshop, date_and_time: 1.hour.ago),
                               Fabricate(:workshop, date_and_time: 20.hours.ago),
-                              Fabricate(:workshop, date_and_time: (23.hours + 59.minutes).ago)]
+                              Fabricate(:workshop, date_and_time: (23.hours + 59.minutes).ago),
+                              Fabricate(:virtual_workshop, date_and_time: 23.hours.ago)]
 
       past_workshops.each { |w| Fabricate(:attending_workshop_invitation, member: student, workshop: w) }
       yesterdays_workshops.each { |w| Fabricate(:attending_workshop_invitation, member: student, workshop: w) }


### PR DESCRIPTION
It currently references `workshop.host.name` which breaks emailing feedback to virtual workshop students