### PR TITLE
Add calendar entry to Virtual workshop invitations

### DIFF
--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -14,6 +14,8 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
                                                  chapter: @workshop.chapter.name,
                                                  date: humanize_date(@workshop.date_and_time))}"
 
+    attachments['codebar.ics'] = { mime_type: 'text/calendar',
+                                   content: WorkshopCalendar.new(workshop, invitation_url(invitation)).calendar.to_ical }
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 

--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -15,7 +15,8 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
                                                  date: humanize_date(@workshop.date_and_time))}"
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
-                                   content: WorkshopCalendar.new(workshop, invitation_url(invitation)).calendar.to_ical }
+                                   content: WorkshopCalendar.new(workshop, invitation_url(invitation)).ical }
+
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end
 

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -17,7 +17,7 @@ class WorkshopInvitationMailer < ActionMailer::Base
                 date_time: humanize_date(@workshop.date_and_time, with_time: true))
 
     attachments['codebar.ics'] = { mime_type: 'text/calendar',
-                                   content: WorkshopCalendar.new(workshop).calendar.to_ical }
+                                   content: WorkshopCalendar.new(workshop, invitation_url(invitation)).ical }
 
     mail(mail_args(member, subject, @workshop.chapter.email), &:html)
   end

--- a/app/models/workshop_calendar.rb
+++ b/app/models/workshop_calendar.rb
@@ -1,9 +1,10 @@
 class WorkshopCalendar
-  attr_reader :workshop
+  attr_reader :workshop, :invitation_url
 
-  def initialize(workshop)
+  def initialize(workshop, invitation_url)
     @workshop = workshop
-    setup_event
+    @invitation_url = invitation_url
+    @workshop.virtual? ? setup_virtual_event : setup_event
   end
 
   def calendar
@@ -15,13 +16,37 @@ class WorkshopCalendar
   def setup_event
     start_date = workshop.date_and_time.strftime('%Y%m%d')
     start_time = workshop.time.strftime('%H%M')
+    end_time = workshop.ends_at.strftime('%H%M')
     address = AddressPresenter.new(workshop.host.address)
     calendar.event do |e|
+      e.url = invitation_url
       e.organizer = workshop.chapter.email.to_s
       e.dtstart = Time.zone.parse("#{start_date}#{start_time}")
-      e.dtend = e.dtstart + 2.hours + 30.minutes
-      e.summary = "codebar @ #{workshop.host.name}"
+      e.dtstart = Time.zone.parse("#{start_date}#{start_time}")
+      e.dtend =  Time.zone.parse("#{start_date}#{end_time}")
+      e.summary = I18n.t('workshop.calendar.summary', host_name: workshop.host.name)
       e.location = address.to_s
+      e.description = I18n.t('workshop.calendar.description', invitation_link: invitation_url)
+      e.ip_class = 'PRIVATE'
+    end
+  end
+
+  def setup_virtual_event
+    start_date = workshop.date_and_time.strftime('%Y%m%d')
+    start_time = workshop.time.strftime('%H%M')
+    end_time = workshop.ends_at.strftime('%H%M')
+    calendar.event do |e|
+      e.url = invitation_url
+      e.organizer = workshop.chapter.email.to_s
+      e.dtstart = Time.zone.parse("#{start_date}#{start_time}")
+      e.dtend =  Time.zone.parse("#{start_date}#{end_time}")
+      e.summary = I18n.t('workshop.calendar.summary', host_name: 'Slack')
+      e.location = I18n.t('workshop.virtual.calendar.location')
+      e.description = I18n.t('workshop.virtual.calendar.description',
+                             slack_channel: workshop.slack_channel,
+                             slack_channel_link: workshop.slack_channel_link,
+                             discord_invitation: I18n.t('social_media_links.discord_invitation'))
+      e.description << I18n.t('workshop.calendar.description', invitation_link: invitation_url)
       e.ip_class = 'PRIVATE'
     end
   end

--- a/app/models/workshop_calendar.rb
+++ b/app/models/workshop_calendar.rb
@@ -14,32 +14,19 @@ class WorkshopCalendar
   private
 
   def setup_event
-    start_date = workshop.date_and_time.strftime('%Y%m%d')
-    start_time = workshop.time.strftime('%H%M')
-    end_time = workshop.ends_at.strftime('%H%M')
-    address = AddressPresenter.new(workshop.host.address)
     calendar.event do |e|
-      e.url = invitation_url
-      e.organizer = workshop.chapter.email.to_s
-      e.dtstart = Time.zone.parse("#{start_date}#{start_time}")
-      e.dtstart = Time.zone.parse("#{start_date}#{start_time}")
-      e.dtend =  Time.zone.parse("#{start_date}#{end_time}")
+      configure(e)
+
       e.summary = I18n.t('workshop.calendar.summary', host_name: workshop.host.name)
-      e.location = address.to_s
+      e.location = address(workshop)
       e.description = I18n.t('workshop.calendar.description', invitation_link: invitation_url)
-      e.ip_class = 'PRIVATE'
     end
   end
 
   def setup_virtual_event
-    start_date = workshop.date_and_time.strftime('%Y%m%d')
-    start_time = workshop.time.strftime('%H%M')
-    end_time = workshop.ends_at.strftime('%H%M')
     calendar.event do |e|
-      e.url = invitation_url
-      e.organizer = workshop.chapter.email.to_s
-      e.dtstart = Time.zone.parse("#{start_date}#{start_time}")
-      e.dtend =  Time.zone.parse("#{start_date}#{end_time}")
+      configure(e)
+
       e.summary = I18n.t('workshop.calendar.summary', host_name: 'Slack')
       e.location = I18n.t('workshop.virtual.calendar.location')
       e.description = I18n.t('workshop.virtual.calendar.description',
@@ -47,7 +34,30 @@ class WorkshopCalendar
                              slack_channel_link: workshop.slack_channel_link,
                              discord_invitation: I18n.t('social_media_links.discord_invitation'))
       e.description << I18n.t('workshop.calendar.description', invitation_link: invitation_url)
-      e.ip_class = 'PRIVATE'
     end
+  end
+
+  def configure(event)
+    event.url = invitation_url
+    event.organizer = workshop.chapter.email.to_s
+    event.dtstart = Time.zone.parse(start_datetime(workshop))
+    event.dtend =  Time.zone.parse(end_datetime(workshop))
+    event.ip_class = 'PRIVATE'
+  end
+
+  def address(workshop)
+    AddressPresenter.new(workshop.host.address).to_s
+  end
+
+  def start_datetime(workshop)
+    date = workshop.date_and_time.strftime('%Y%m%d')
+    start_time = workshop.time.strftime('%H%M')
+    "#{date}#{start_time}"
+  end
+
+  def end_datetime(workshop)
+    date = workshop.date_and_time.strftime('%Y%m%d')
+    end_time = workshop.ends_at.strftime('%H%M')
+    "#{date}#{end_time}"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,8 +93,27 @@ en:
           subject: "Reminder: you're on the codebar waiting list (%{date_time})"
   workshop:
     title: Workshop at %{host} - %{date}
+    calendar:
+      summary: codebar @ %{host_name}
+      description:  "Declining or removing this event from your calendar does not update your invitation. If you are unable to attend please follow the link found on this calendar entry and update your attendance status. Missing codebar events repeatedly will result in a ban.\n
+
+                     Invitation link: %{invitation_link}"
     virtual:
       title: Virtual workshop for %{chapter} - %{date}
+      calendar:
+        location: codebar Slack (https://slack.codebar.io)
+        description: "How to join\n
+                      ---------------\n
+                      1. Join the workshop's Slack channel: #%{slack_channel} (%{slack_channel_link})\n
+                      Not in codebar's Slack? Request an invitation: https://slack.codebar.io\n
+                      \n
+                      2. Accept the invitation to our discord %{discord_invitation} - this software will enable you to collaborate with a student/coach by screen sharing.\n
+                      \n
+                      Requirements\n
+                      ---------------\n
+                      Download the discord Desktop app: https://discord.com/download\n
+                      \n
+                      ---------------\n"
       invitation:
         shared_intro_3_html: 'PS: If you have any questions about the workshop or will not be able to attend on short notice please send us an email at %{email_link} as that will make pairing everyone up easier for us.'
         info:

--- a/spec/models/workshop_calendar_spec.rb
+++ b/spec/models/workshop_calendar_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+describe WorkshopCalendar do
+  let(:invitation_url) { Faker::Internet.url }
+  let(:calendar) { WorkshopCalendar.new(workshop, invitation_url).calendar }
+
+  describe 'workshop calendar entry' do
+    let(:workshop) { Fabricate(:workshop) }
+    it 'has an event associated with it' do
+      expect(calendar.events.count).to eq(1)
+    end
+
+    context 'physical workshop' do
+      it 'all required details are set' do
+        event = calendar.events.first
+        expect(event.organizer.to_s).to eq(workshop.chapter.email)
+        expect(event.summary).to eq("codebar @ #{workshop.host.name}")
+        expect(event.location.to_s).to eq(AddressPresenter.new(workshop.host.address).to_s)
+        expect(event.url.to_s).to eq(invitation_url)
+        expect(event.description).to include("Declining or removing this event from your calendar does not update your invitation")
+        expect(event.description).to include(invitation_url)
+      end
+    end
+
+    context 'virtual workshop' do
+      let(:workshop) { Fabricate(:virtual_workshop) }
+
+      it 'all required details are set' do
+        event = calendar.events.first
+        expect(event.organizer.to_s).to eq(workshop.chapter.email)
+        expect(event.summary).to eq('codebar @ Slack')
+        expect(event.location.to_s).to eq('codebar Slack (https://slack.codebar.io)')
+        expect(event.description).to include("##{workshop.slack_channel} (#{workshop.slack_channel_link}")
+        expect(event.description).to include(invitation_url)
+        expect(event.url.to_s).to eq(invitation_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adds calendar entry to virtual workshop invitations
- Updates existing physical workshop invitation calendar entry to include more details
- Add tests for WorkshopCalendar


<img width="295" alt="workshop-cal-1" src="https://user-images.githubusercontent.com/159200/81421345-42592500-9149-11ea-9d74-30c10be018d4.png">
<img width="291" alt="workshop-cal-2" src="https://user-images.githubusercontent.com/159200/81421353-45541580-9149-11ea-9adc-23d9ee5a1643.png">



Fixes #1254 