### PR TITLE
Ensure rsvp_time is always logged

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -14,6 +14,7 @@ class Admin::InvitationsController < Admin::ApplicationController
         @invitation.update_attribute(:attending, true)
         @workshop.send_attending_email(@invitation) if @workshop.future?
 
+        @invitation.update(rsvp_time: Time.zone.now, automated_rsvp: true)
         message = "You have added #{@invitation.member.full_name} to the workshop as a #{@invitation.role}."
       else
         @invitation.update_attribute(:attending, false)

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -11,10 +11,9 @@ class Admin::InvitationsController < Admin::ApplicationController
       attending = params[:attending]
 
       if attending.eql?('true')
-        @invitation.update_attribute(:attending, true)
+        @invitation.update(attending: true, rsvp_time: Time.zone.now, automated_rsvp: true)
         @workshop.send_attending_email(@invitation) if @workshop.future?
 
-        @invitation.update(rsvp_time: Time.zone.now, automated_rsvp: true)
         message = "You have added #{@invitation.member.full_name} to the workshop as a #{@invitation.role}."
       else
         @invitation.update_attribute(:attending, false)

--- a/app/controllers/concerns/invitation_controller_concerns.rb
+++ b/app/controllers/concerns/invitation_controller_concerns.rb
@@ -51,8 +51,7 @@ module InvitationControllerConcerns
           if next_spot.present?
             invitation = next_spot.invitation
             next_spot.destroy
-            invitation.update_attribute(:attending, true)
-
+            invitation.update(attending: true, rsvp_time: Time.zone.now, automated_rsvp: true)
             @workshop.send_attending_email(@invitation, true)
           end
 

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -27,7 +27,9 @@
               - else
                 = invitation.member.full_name
           %td.small-6.columns
-            %small=invitation.note
+            -if invitation.note?
+              %small=invitation.note
+              %br
             - if invitation.rsvp_time.present?
               %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true',  title: 'Time of RSVP' }
                 %small

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -31,5 +31,15 @@
             - if invitation.rsvp_time.present?
               %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true',  title: 'Time of RSVP' }
                 %small
-                  %i.fa.fa-clock-o
+                  %i.fa.fa-history
                   =l(invitation.rsvp_time)
+              - if invitation.automated_rsvp?
+                %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true',  title: 'Waiting list or admin addition' }
+                  %small
+                    %i.fa.fa-magic
+              %br
+            - if invitation.reminded_at.present?
+              %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true',  title: 'Reminder emailed at' }
+                %small
+                  %i.fa.fa-clock-o
+                  =l(invitation.reminded_at)

--- a/db/migrate/20200511151348_add_automated_rsvp_to_workshop_invitation.rb
+++ b/db/migrate/20200511151348_add_automated_rsvp_to_workshop_invitation.rb
@@ -1,0 +1,5 @@
+class AddAutomatedRsvpToWorkshopInvitation < ActiveRecord::Migration
+  def change
+    add_column :workshop_invitations, :automated_rsvp, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200313211614) do
+ActiveRecord::Schema.define(version: 20200511151348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -533,6 +533,7 @@ ActiveRecord::Schema.define(version: 20200313211614) do
     t.string   "role"
     t.datetime "reminded_at"
     t.datetime "rsvp_time"
+    t.boolean  "automated_rsvp"
   end
 
   add_index "workshop_invitations", ["member_id"], name: "index_workshop_invitations_on_member_id", using: :btree
@@ -556,15 +557,15 @@ ActiveRecord::Schema.define(version: 20200313211614) do
     t.datetime "date_and_time"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "invitable",      default: true
+    t.boolean  "invitable",          default: true
     t.string   "sign_up_url"
     t.integer  "chapter_id"
     t.datetime "rsvp_closes_at"
     t.datetime "rsvp_opens_at"
     t.datetime "ends_at"
-    t.boolean  "virtual",        default: false
-    t.integer  "student_spaces", default: 0
-    t.integer  "coach_spaces",   default: 0
+    t.boolean  "virtual",            default: false
+    t.integer  "student_spaces",     default: 0
+    t.integer  "coach_spaces",       default: 0
     t.string   "slack_channel"
     t.string   "slack_channel_link"
   end

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -46,15 +46,17 @@ RSpec.feature 'managing workshop attendances', type: :feature do
 
       visit admin_workshop_path(workshop)
       expect(page).to have_content('1 are attending as students')
+      expect(page).to_not have_selector('i.fa-magic')
 
       # Unclear why this has to be done twice, when tested manually it works
       # the first time.
-      find('span', text: 'Select a member to RSVP').click
-      find('span', text: 'Select a member to RSVP').click
-
+      2.times { find('span', text: 'Select a member to RSVP').click }
       find("li", text: "#{other_invitation.member.full_name} (#{other_invitation.role})").click
 
       expect(page).to have_content('2 are attending as students')
+
+      expect(page).to have_content(I18n.l(other_invitation.reload.rsvp_time))
+      expect(page).to have_selector('i.fa-magic')
     end
   end
 end

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -37,6 +37,8 @@ RSpec.feature 'managing workshop attendances', type: :feature do
       find('.waiting_list').click
 
       expect(page).to have_content('2 are attending as students')
+      expect(page).to have_content(I18n.l(other_invitation.reload.rsvp_time))
+      expect(page).to have_selector('i.fa-magic')
     end
 
     scenario 'can rsvp an invited student to the workshop', js: true do

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -16,6 +16,15 @@ RSpec.shared_examples 'invitation route' do
       expect(page).to have_link 'I can no longer attend'
       expect(page).to have_content("Thanks for getting back to us #{invitation.member.name}.")
       expect(page.current_path).to eq(invitation_route)
+
+      # admin view
+      login_as_admin(member)
+      visit admin_workshop_path(invitation.workshop)
+      within 'tr.row.attendee' do
+        expect(page).to have_content(member.full_name)
+        expect(page).to have_selector('i.fa-history')
+        expect(page).to_not have_selector('i.fa-magic')
+      end
     end
 
     scenario 'they can RSVP directly through the invitation' do


### PR DESCRIPTION
- adds new field `automated_rsvp` and set to true when rsvp happens automatically when someone else drops out of workshop or admin moves up from waiting list
- display both `rsvp_time` and `reminded_at` on workshop admin page. This should enable us to figure out if there is an issue with the reminder emails, as at the moment they do seem to be sent out (checked for workshop https://codebar.io/workshops/1707 on our Sendgrid account and was able to confirm that reminders were going out)

### Updated view of member on admin/workshop page

<img width="526" alt="rsvp_reminder_and_automated_rsvp" src="https://user-images.githubusercontent.com/159200/81609917-90cc2500-93d0-11ea-8e72-1f5d911182b8.png">

### Hover over top icon
<img width="449" alt="rsvp_time" src="https://user-images.githubusercontent.com/159200/81609757-5793b500-93d0-11ea-90d6-de5f8c56f0e2.png">

### Hover over bottom icon
<img width="420" alt="reminded_at" src="https://user-images.githubusercontent.com/159200/81609760-58c4e200-93d0-11ea-90f2-3b3dcc025763.png">

## Hover over right hand side icon incidating admin or waitinglist automated addition to attendees
<img width="642" alt="automated_rsvp" src="https://user-images.githubusercontent.com/159200/81609763-59f60f00-93d0-11ea-826c-dc7784fdef6e.png">

(data generated using Faker)
Resolves #1156 