### PR TITLE
[WIP] Pr 1259 event invitation not emailed to banned

### DIFF
--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -13,19 +13,11 @@ module Invitable
     end
 
     def attending_students
-      invitations.where(role: 'Student')
-                 .accepted
-                 .includes(:member)
-                 .joins(:member).merge(Member.not_banned)
-                 .order('members.name, members.surname')
+      attendances.where(role: 'Student').order('members.name, members.surname')
     end
 
     def attending_coaches
-      invitations.where(role: 'Coach')
-                 .accepted
-                 .includes(:member)
-                 .joins(:member).merge(Member.not_banned)
-                 .order('members.name, members.surname')
+      attendances.where(role: 'Coach').order('members.name, members.surname')
     end
   end
 end

--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -8,14 +8,24 @@ module Invitable
   module InstanceMethods
     def attendances
       invitations.accepted
+                 .includes(:member)
+                 .joins(:member).merge Member.not_banned
     end
 
     def attending_students
-      invitations.where(role: 'Student').accepted.includes(:member).order('members.name, members.surname')
+      invitations.where(role: 'Student')
+                 .accepted
+                 .includes(:member)
+                 .joins(:member).merge(Member.not_banned)
+                 .order('members.name, members.surname')
     end
 
     def attending_coaches
-      invitations.where(role: 'Coach').accepted.includes(:member).order('members.name, members.surname')
+      invitations.where(role: 'Coach')
+                 .accepted
+                 .includes(:member)
+                 .joins(:member).merge(Member.not_banned)
+                 .order('members.name, members.surname')
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -28,7 +28,8 @@ class Member < ActiveRecord::Base
                          .where('bans.id is NULL or bans.expires_at < CURRENT_DATE')
                      }
   scope :attending_meeting, lambda { |meeting|
-                              joins(:meeting_invitations)
+                              not_banned
+                                .joins(:meeting_invitations)
                                 .where('meeting_invitations.meeting_id = ? and meeting_invitations.attending = ?',
                                        meeting.id, true)
                             }
@@ -55,7 +56,7 @@ class Member < ActiveRecord::Base
   end
 
   def full_name
-    pronoun = self.pronouns.present? ? "(#{self.pronouns})" : nil
+    pronoun = pronouns.present? ? "(#{pronouns})" : nil
     [name, surname, pronoun].compact.join ' '
   end
 
@@ -80,12 +81,12 @@ class Member < ActiveRecord::Base
 
   def send_eligibility_email(user)
     MemberMailer.eligibility_check(self, user.email).deliver_now
-    self.eligibility_inquiries.create(sent_by_id: user.id)
+    eligibility_inquiries.create(sent_by_id: user.id)
   end
 
   def send_attendance_email(user)
     MemberMailer.attendance_warning(self, user.email).deliver_now
-    self.attendance_warnings.create(sent_by_id: user.id)
+    attendance_warnings.create(sent_by_id: user.id)
   end
 
   def avatar(size = 100)

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -96,7 +96,7 @@ class WorkshopPresenter < EventPresenter
   private
 
   def students_checklist
-    model.attending_students.order('note asc').each_with_index.map do |a, pos|
+    model.attending_students.each_with_index.map do |a, pos|
       "#{member_info(a.member, pos)}\t\t\t#{note(a)}"
     end.join("\n\n")
   end

--- a/spec/fabricators/meeting_invitation_fabricator.rb
+++ b/spec/fabricators/meeting_invitation_fabricator.rb
@@ -8,3 +8,8 @@ end
 Fabricator(:attending_meeting_invitation, from: :meeting_invitation) do
   attending true
 end
+
+Fabricator(:banned_attending_meeting_invitation, from: :meeting_invitation) do
+  member { Fabricate(:banned_member) }
+  attending true
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Event, type: :model  do
   subject(:event) { Fabricate(:event) }
+  include_examples "Invitable", :invitation, :event
 
   it { should be_valid }
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Meeting, type: :model  do
+  include_examples "Invitable", :meeting_invitation, :meeting
+
   context 'validations' do
     subject { Meeting.new }
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -95,15 +95,28 @@ RSpec.describe Member, type: :model  do
       expect(Member.attending_meeting(invitation.meeting).first).to eq(invitation.member)
     end
 
-    it '#in_group' do
-      chapter = Fabricate(:chapter)
-      students = Fabricate(:students, chapter: chapter)
-      coaches = Fabricate(:coaches, chapter: chapter)
-      Fabricate(:coaches)
-      Fabricate(:students)
+    context '#in_group' do
+      it 'includes members in group' do
+        chapter = Fabricate(:chapter)
+        group = Fabricate(:group, chapter: chapter, members: [Fabricate(:member)])
 
-      expect(Member.in_group(chapter.groups.students)).to eq(students.members)
-      expect(Member.in_group(chapter.groups.coaches)).to eq(coaches.members)
+        expect(Member.in_group(chapter.groups)).to eq(group.members)
+      end
+
+      it 'excludes members outside group' do
+        chapter = Fabricate(:chapter)
+        other_chapter = Fabricate(:chapter)
+        group = Fabricate(:group, chapter: other_chapter, members: [Fabricate(:member)])
+
+        expect(Member.in_group(chapter.groups)).to_not eq(group.members)
+      end
+
+      it 'excludes banned members in group' do
+        chapter = Fabricate(:chapter)
+        group = Fabricate(:group, chapter: chapter, members: [Fabricate(:banned_member)])
+
+        expect(Member.in_group(chapter.groups)).not_to eq(group.members)
+      end
     end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -89,10 +89,18 @@ RSpec.describe Member, type: :model  do
   end
 
   context 'scopes' do
-    it '#attending_meeting' do
-      invitation = Fabricate(:attending_meeting_invitation)
+    context '#attending_meeting' do
+      it 'includes attending members' do
+        invitation = Fabricate(:attending_meeting_invitation)
 
-      expect(Member.attending_meeting(invitation.meeting).first).to eq(invitation.member)
+        expect(Member.attending_meeting(invitation.meeting)).to include(invitation.member)
+      end
+
+      it 'excludes banned attending members' do
+        invitation = Fabricate(:banned_attending_meeting_invitation)
+
+        expect(Member.attending_meeting(invitation.meeting)).to_not include(invitation.member)
+      end
     end
 
     context '#in_group' do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Workshop, type: :model  do
   subject(:workshop) { Fabricate(:workshop) }
+  include_examples "Invitable", :workshop_invitation, :workshop
 
   context 'time zone fields' do
     let(:workshop) { Fabricate.build(:workshop, chapter: Fabricate(:chapter, time_zone: 'Pacific Time (US & Canada)')) }
@@ -99,26 +100,6 @@ RSpec.describe Workshop, type: :model  do
     end
 
     context 'attendances' do
-      let(:sponsor) { Fabricate(:sponsor) }
-
-      before do
-        Fabricate(:workshop_sponsor, sponsor: sponsor, workshop: workshop, host: true)
-      end
-
-      it '#attending_students' do
-        3.times { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
-        1.times { Fabricate(:workshop_invitation, workshop: workshop, attending: false) }
-
-        expect(workshop.reload.attending_students.length).to eq(3)
-      end
-
-      it '#attending_members' do
-        2.times { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
-        1.times { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: false) }
-
-        expect(workshop.reload.attending_coaches.length).to eq(2)
-      end
-
       it '#attendee? for students' do
         attendee_invites = 4.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
         nonattendee_invites = 2.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: false) }

--- a/spec/support/shared_examples/behaves_like_invitable.rb
+++ b/spec/support/shared_examples/behaves_like_invitable.rb
@@ -1,0 +1,61 @@
+RSpec.shared_examples 'Invitable' do |invitation_type, invitable_type|
+  let(:invitable) { Fabricate(invitable_type) }
+
+  context '#attendances' do
+    it 'permits accepted' do
+      invitation = Fabricate(invitation_type,
+                             invitable_type => invitable,
+                             attending: true)
+
+      expect(invitable.reload.attendances).to include(invitation)
+    end
+
+    it 'rejects non-accepted' do
+      invitation = Fabricate(invitation_type,
+                             invitable_type => invitable,
+                             attending: false)
+
+      expect(invitable.reload.attendances).to_not include(invitation)
+    end
+  end
+
+  context '#attending_students' do
+    it 'accepts attending students' do
+      invitation_to_student = Fabricate(invitation_type,
+                                        role: 'Student',
+                                        invitable_type => invitable,
+                                        attending: true)
+
+      expect(invitable.reload.attending_students).to include(invitation_to_student)
+    end
+
+    it 'rejects non-attending students' do
+      invitation_to_student = Fabricate(invitation_type,
+                                        role: 'Student',
+                                        invitable_type => invitable,
+                                        attending: false)
+
+      expect(invitable.reload.attending_students).to_not include(invitation_to_student)
+    end
+  end
+
+  context '#attending_coaches' do
+    it 'accepts attending coaches' do
+      invitation_to_coach = Fabricate(invitation_type,
+                                      role: 'Coach',
+                                      invitable_type => invitable,
+                                      attending: true)
+
+      expect(invitable.reload.attending_coaches).to include(invitation_to_coach)
+    end
+
+    it 'rejects non-attending coaches' do
+      invitation_to_coach = Fabricate(invitation_type,
+                                      role: 'Coach',
+                                      invitable_type => invitable,
+                                      attending: false)
+
+      expect(invitable.reload.attending_coaches).to_not include(invitation_to_coach)
+    end
+  end
+end

--- a/spec/support/shared_examples/behaves_like_invitable.rb
+++ b/spec/support/shared_examples/behaves_like_invitable.rb
@@ -17,6 +17,15 @@ RSpec.shared_examples 'Invitable' do |invitation_type, invitable_type|
 
       expect(invitable.reload.attendances).to_not include(invitation)
     end
+
+    it 'rejects banned accepted' do
+      invitation = Fabricate(invitation_type,
+                             member: Fabricate(:banned_member),
+                             invitable_type => invitable,
+                             attending: true)
+
+      expect(invitable.reload.attendances).to_not include(invitation)
+    end
   end
 
   context '#attending_students' do
@@ -37,6 +46,17 @@ RSpec.shared_examples 'Invitable' do |invitation_type, invitable_type|
 
       expect(invitable.reload.attending_students).to_not include(invitation_to_student)
     end
+
+    it 'rejects banned attending students' do
+      invitation_to_banned_student = Fabricate(invitation_type,
+                                        member: Fabricate(:banned_member),
+                                        role: 'Student',
+                                        invitable_type => invitable,
+                                        attending: true)
+
+                                        # byebug
+      expect(invitable.reload.attending_students).to_not include(invitation_to_banned_student)
+    end
   end
 
   context '#attending_coaches' do
@@ -56,6 +76,16 @@ RSpec.shared_examples 'Invitable' do |invitation_type, invitable_type|
                                       attending: false)
 
       expect(invitable.reload.attending_coaches).to_not include(invitation_to_coach)
+    end
+
+    it 'rejects banned attending coaches' do
+      invitation_to_banned_student = Fabricate(invitation_type,
+                                        member: Fabricate(:banned_member),
+                                        role: 'Student',
+                                        invitable_type => invitable,
+                                        attending: true)
+
+      expect(invitable.reload.attending_students).to_not include(invitation_to_banned_student)
     end
   end
 end


### PR DESCRIPTION
This is my work so far for issue [#1259](
https://github.com/codebar/planner/issues/1259) - I thought I'd keep you in the loop as it was high priority.

This work removes banned members at the scope level. Proving a negative is hard so for all cases I had a test that allowed a banned member and did another test with the minimum change to reject the banned member.

I was surprised that `in_group` filtered out the banned members rather than call it `allowed_in_group` or an `allowed` scope but I thought, well, I can't think of any reason to allow any banned member appearing in invitations so the above changes had the intention of making it impossible to get a banned member in an invitation scope.

- ea60cfa  - test to confirm `in_group` removes banned members
- 72763d3 - test to confirm `attending_meeting` removes banned members
- 48a8240 - invitable concern was missing any testing - this tested the current code with the shared_example
- b0924be - Changes invitable concern to remove banned members plus testing

These changes will remove all banned members from InvitationManager's lists (because they end up calling the above banned cleared scopes). The exception is `retrieve_and_notify_waitlisted(role:)` which I will look at if the work so far is OK.

When `retrieve_and_notify_waitlised` is complete then there can be no banned members getting an invitation. However, the issue expressly wanted tests for each of the methods in the WorshopInvitationManagerConcern and that would be the next step of the work.
 
 
