### PR TITLE
[Issue/1272] display workshop timezone

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,9 @@
 module ApplicationHelper
-  def humanize_date(date, with_time: false, with_year: false)
-    human_date = "#{I18n.l(date, format: :day_in_words)}, "
-    human_date << "#{ActiveSupport::Inflector.ordinalize(date.day)} "
-    human_date << I18n.l(date, format: :month)
-    human_date << " #{I18n.l(date, format: :year)}" if with_year
-    human_date << " at #{I18n.l(date.time, format: :time)}" if with_time
-    human_date
+  def humanize_date(datetime, end_time = nil, with_time: false, with_year: false)
+    return I18n.l(datetime, format: :humanised_with_year) if with_year
+    return humanize_date_with_time(datetime, end_time) if with_time
+
+    I18n.l(datetime, format: :humanised)
   end
 
   def title(title = nil)
@@ -60,5 +58,14 @@ module ApplicationHelper
   def number_to_currency(number, options = {})
     options[:locale] = 'en'
     super(number, options)
+  end
+
+  private
+
+  def humanize_date_with_time(datetime, end_time)
+    formatted_datetime = I18n.l(datetime, format: :humanised_with_time)
+    formatted_datetime << " - #{I18n.l(end_time, format: :time)}" if end_time
+    formatted_datetime << " #{I18n.l(datetime, format: :time_zone)}"
+    formatted_datetime
   end
 end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -110,6 +110,12 @@ class Workshop < ActiveRecord::Base
     super.in_time_zone(time_zone)
   end
 
+  def ends_at
+    return nil unless super
+
+    super.in_time_zone(time_zone)
+  end
+
   private
 
   def set_opens_at

--- a/app/presenters/course_presenter.rb
+++ b/app/presenters/course_presenter.rb
@@ -10,4 +10,8 @@ class CoursePresenter < EventPresenter
   def admin_path
     '#'
   end
+
+  def time
+    I18n.l(model.date_and_time, format: :time_with_zone)
+  end
 end

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -35,7 +35,17 @@ class EventPresenter < BasePresenter
   end
 
   def time
+    formatted_time = start_time
+    formatted_time << " - #{end_time}" if model.ends_at
+    formatted_time << " #{I18n.l(model.date_and_time, format: :time_zone)}"
+  end
+
+  def start_time
     I18n.l(model.date_and_time, format: :time)
+  end
+
+  def end_time
+    I18n.l(model.ends_at, format: :time)
   end
 
   def path

--- a/app/presenters/meeting_presenter.rb
+++ b/app/presenters/meeting_presenter.rb
@@ -28,4 +28,8 @@ class MeetingPresenter < EventPresenter
   def sponsors
     []
   end
+
+  def time
+    I18n.l(model.date_and_time, format: :time_with_zone)
+  end
 end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -45,20 +45,6 @@ class WorkshopPresenter < EventPresenter
           .pluck(:email).join(', ')
   end
 
-  def time
-    I18n.l(model.time, format: :time)
-  end
-
-  def end_time
-    I18n.l(model.ends_at, format: :time)
-  end
-
-  def start_and_end_time
-    start_and_end_time = time
-    start_and_end_time << " - #{end_time}" if model.ends_at.present?
-    start_and_end_time
-  end
-
   def path
     Rails.application.routes.url_helpers.workshop_path(model)
   end

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -31,7 +31,7 @@
       .medium-12.columns
         %h2= @event.to_s
         %h3
-          %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time) }
+          %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
 
     .row
       - if @event.venue.present?

--- a/app/views/admin/meetings/show.html.haml
+++ b/app/views/admin/meetings/show.html.haml
@@ -19,7 +19,7 @@
         %h2
           =@meeting.name
         %h3
-          %small #{l(@meeting.date_and_time)}
+          %small #{humanize_date(@meeting.date_and_time, nil, with_time: true)}
 
     .row
       .medium-2.columns

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -40,7 +40,7 @@
           = link_to [:admin, @workshop.chapter] do
             %small=@workshop.chapter.name
         %h3
-          %small #{l(@workshop.date_and_time, format: :dashboard)} #{@workshop.start_and_end_time}
+          %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
         - if @workshop.rsvp_opens_at
           RSVPs will open at
           = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')

--- a/app/views/event_invitation_mailer/attending.html.haml
+++ b/app/views/event_invitation_mailer/attending.html.haml
@@ -26,7 +26,7 @@
               %td
                 %h4
                   #{@event.name}
-                  %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time)}
+                  %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
                 = link_to 'Update your attendance', full_url_for(event_invitation_url(@event.id, @invitation.token)), class: 'btn'
 
         .content

--- a/app/views/event_invitation_mailer/invite_coach.html.haml
+++ b/app/views/event_invitation_mailer/invite_coach.html.haml
@@ -24,7 +24,7 @@
               %td
                 %h4
                   #{@event.name}
-                  %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time)}
+                  %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
                 = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
 
         .content

--- a/app/views/event_invitation_mailer/invite_student.html.haml
+++ b/app/views/event_invitation_mailer/invite_student.html.haml
@@ -24,7 +24,7 @@
               %td
                 %h4
                   #{@event.name}
-                  %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time)}
+                  %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
                 = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
 
         .content

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -7,14 +7,15 @@
           at
           = link_to event.venue.name, event.venue.website
     .event__details
+      .date
+        %i.material-icons
+          calendar_today
+        = event.date
       .time
         %i.material-icons
           access_time
         = event.time
-      .date 
-        %i.material-icons
-          calendar_today
-        = event.date
+
       - if event.organisers.any?
         .event__organisers
           .event__organisers-list

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,11 +1,16 @@
 .stripe.reverse
   .row
     .large-12.columns
-      %h2= @event.name
-      %h3
-        %small #{l(@event.date_and_time)} to #{l(@event.ends_at, format: :time) }
-      %p.lead= @event.description.html_safe
+      %h2
+        = @event.name
+        %br
+        %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
 
+  %section#banner
+    .row
+      .medium-12.columns
+        %p.lead
+          = @event.description.html_safe
   .row
     .large-10.columns
       = render partial: 'event_actions'

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'shared/title', locals: { title: t('feedback_form.title'), date:  humanize_date(@workshop.date_and_time, with_time: true) }
+= render partial: 'shared/title', locals: { title: t('feedback_form.title'), date: humanize_date(@workshop.date_and_time, with_time: true) }
 %section#banner
   .row
     .large-12.columns

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -6,7 +6,7 @@
       %h2
         = @workshop.title
         %br
-        %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
+        %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning= t('messages.already_taken_place')
 .alert-box.info

--- a/app/views/meetings/_meeting.html.haml
+++ b/app/views/meetings/_meeting.html.haml
@@ -7,12 +7,14 @@
           at
           = link_to meeting.venue.name, meeting.venue.website
     .event__details
-      .time
-        Time:
-        = meeting.time
-      .date 
-        Date: 
+      .date
+        %i.material-icons
+          calendar_today
         = meeting.date
+      .time
+        %i.material-icons
+          access_time
+        = meeting.time
       - if meeting.organisers.any?
         .event__organisers
           .event__organisers-list

--- a/app/views/virtual_workshop_invitation_mailer/attending.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending.html.haml
@@ -30,8 +30,7 @@
             %tr
               %td
                 %h4
-                  Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
@@ -26,8 +26,7 @@
             %tr
               %td
                 %h4
-                  Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  Invites for our next virtual workshop are now open and we are looking for coaches. The workshop will take place on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  Invites for our next virtual workshop are now open and we are looking for coaches.
 
                 %p At the workshop you will be helping students remotely as they work their way through one of our tutorials or a personal project they need help on. Don't worry we'll only match you with someone who you'll be able to help.
 
@@ -34,7 +34,7 @@
                   =@workshop.to_s
                   %br
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?

--- a/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
@@ -26,9 +26,7 @@
             %tr
               %td{ width: '60%', style: 'vertical-align: top; padding-right: 20px;' }
                 %h4
-                  = @workshop.to_s
-                  %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -14,7 +14,7 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you're on the waiting list for the virtual workshop on #{humanize_date(@workshop.date_and_time, with_time: true)}.
+                  This is a quick email to remind you that you're on the waiting list for the virtual workshop on #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}.
                 %p
                   If an attendee drops out, the next person on the waiting list will automatically get their place. We'll email you if this happens.
                   %strong Attendees often drop out at short notice,
@@ -29,8 +29,7 @@
             %tr
               %td
                 %h4
-                  Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -8,11 +8,7 @@
       %h2
         = t('workshops.virtual.title', chapter: @workshop.chapter.name)
         %br
-        %small #{humanize_date(@workshop.date_and_time)} #{@workshop.distance_of_time}
-        #workshop-time.time
-          %i.material-icons
-            access_time
-          = @workshop.start_and_end_time
+        %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning= t('messages.already_taken_place')
 

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -32,7 +32,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -19,7 +19,8 @@
                   If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.
                   <a href='https://codebar.io/student-guide#attendance'>We have a three-strikes attendance policy for no-shows.</a>
                 %p
-                  <strong>Please do not turn up before #{(@workshop.date_and_time).strftime('%H:%M')}.</strong> If you are early, please wait in a nearby cafe.
+                  %strong Please do not turn up before #{(@workshop.date_and_time).strftime('%H:%M')}.
+                  If you are early, please wait in a nearby cafe.
 
         .content
           %table{ bgcolor: '#FFFFFF' }
@@ -27,7 +28,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -33,7 +33,7 @@
                 %h4
                   Workshop
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -28,7 +28,7 @@
                 %h4
                   Workshop
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -22,7 +22,7 @@
               %td
                 %h4
                   Workshop
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -31,7 +31,7 @@
                 %h4
                   Workshop
                   %br
-                  %small #{humanize_date(@workshop.date_and_time, with_time: true)}#{@workshop.ends_at.present? ? " - " + @workshop.ends_at.strftime('%H:%M') : ""}
+                  %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
                 = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -8,11 +8,7 @@
       %h2
         = t('workshops.title', host: @workshop.host.name)
         %br
-        %small #{humanize_date(@workshop.date_and_time)} #{@workshop.distance_of_time}
-        #workshop-time.time
-          %i.material-icons
-            access_time
-          = @workshop.start_and_end_time
+        %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %label.label.warning= t('messages.already_taken_place')
   %section#banner

--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -1,0 +1,16 @@
+{
+  en: {
+    date: {
+      formats: {
+        humanised: lambda { |time, _| "%a, #{time.day.ordinalize} %B" },
+      }
+    },
+    time: {
+      formats: {
+        humanised: lambda { |time, _| "%a, #{time.day.ordinalize} %B" },
+        humanised_with_time: lambda { |time, _| "%a, #{time.day.ordinalize} %B | %H:%M" },
+        humanised_with_year: lambda { |time, _| "%a, #{time.day.ordinalize} %B %Y | %H:%M" }
+      }
+    }
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
       year: "%Y"
       meeting_format: "%a %d %B %H:%M"
       time: "%H:%M"
+      time_with_zone: "%H:%M %Z (GMT%:z)"
+      time_zone: "%Z (GMT%:z)"
       year_month: "%Y-%B"
       log: "at %H:%M on the %d/%m/%Y"
       workshop: "%A, %e %B %Y at %R"

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Event creation', type: :feature do
         expect(page).to have_content('Event successfully created')
 
         expect(page).to have_content('A test event')
-        expect(page).to have_content("#{I18n.l(date, format: :date)} 16:00 to 18:00")
+        expect(page).to have_content("#{I18n.l(date, format: :humanised)} | 16:00 - 18:00 BST (GMT+01:00)")
         expect(page).to have_content('A test event description')
         expect(page).to have_content('25 student spots, 19 coach spots')
         expect(find('#schedule', visible: false).text).to eq('9:00 Sign up & breakfast 9:30 kick off')

--- a/spec/presenters/course_presenter_spec.rb
+++ b/spec/presenters/course_presenter_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe CoursePresenter do
   it '#admin_path' do
     expect(event.admin_path).to eq('#')
   end
+
+  it '#time' do
+    expect(course).to receive(:date_and_time).and_return(Time.zone.now)
+
+    event.time
+  end
 end

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -30,10 +30,21 @@ RSpec.describe EventPresenter do
     expect(event.month).to eq('SEPTEMBER')
   end
 
-  it '#time' do
-    expect(workshop).to receive(:date_and_time).and_return(Time.zone.now)
+  context '#time' do
+    it 'when no end_time is set it only returns the start_time' do
+      event =  double(:event, date_and_time: Time.zone.now, start_time: Time.zone.now, ends_at: nil)
+      presenter = EventPresenter.new(event)
 
-    event.time
+      expect(presenter.time).to eq(I18n.l(event.date_and_time, format: :time_with_zone))
+    end
+
+    it 'when a start and an end_time are set it returns a formatted start and end_time' do
+      event =  double(:event, date_and_time: Time.zone.now, start_time: Time.zone.now, ends_at: 1.hour.from_now)
+      presenter = EventPresenter.new(event)
+
+      expect(presenter.time)
+        .to eq("#{presenter.start_time} - #{presenter.end_time} #{I18n.l(event.date_and_time, format: :time_zone)}")
+    end
   end
 
   it '#path' do

--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe MeetingPresenter do
     expect(event.attendees_emails).to eq(attendees.map(&:member).map(&:email).join(', '))
   end
 
+  it '#time' do
+    expect(meeting).to receive(:date_and_time).and_return(Time.zone.now)
+
+    event.time
+  end
+
   it '#to_s' do
     expect(event.to_s).to eq(meeting.name)
   end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -70,34 +70,16 @@ RSpec.describe WorkshopPresenter do
   end
 
   context 'time formatting' do
-    let(:workshop) { double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now) }
+    let(:workshop) { double(:workshop, date_and_time: Time.zone.now, ends_at: 1.hour.from_now) }
 
-    it '#time' do
-      start_time = workshop.time
-
-      expect(presenter.time).to eq(I18n.l(start_time, format: :time))
+    it '#start_time' do
+      expect(presenter.start_time).to eq(I18n.l(workshop.date_and_time, format: :time))
     end
 
     it '#end_time' do
       expect(presenter.end_time).to eq(I18n.l(workshop.ends_at, format: :time))
     end
 
-    context '#start_and_end_time' do
-      it 'when no end_time is set it only returns the start_time' do
-        workshop =  double(:workshop, time: Time.zone.now, ends_at: nil)
-        presenter = WorkshopPresenter.new(workshop)
-
-        expect(presenter.start_and_end_time).to eq(I18n.l(workshop.time, format: :time))
-      end
-
-      it 'when a start and an end_time are set it returns a formatted start and end_time' do
-        workshop =  double(:workshop, time: Time.zone.now, ends_at: 1.hour.from_now)
-        presenter = WorkshopPresenter.new(workshop)
-
-        expect(presenter.start_and_end_time)
-          .to eq("#{I18n.l(workshop.time, format: :time)} - #{I18n.l(workshop.ends_at, format: :time)}")
-      end
-    end
   end
 
   context '#attendees_csv' do


### PR DESCRIPTION
**Summary of changes**

- [x] Landing page 'upcoming events'
- [x] Events page 'Upcoming and past events'
- [x] Workshop page
- [x] Workshop invitation page
- [x] Workshop and virtual workshop emails 
    - [x] invitation
    - [x] attendance
    - [x] attendance reminder
    - [x]  waiting list emails
- [x] Admin workshop page
- [x] Meeting page
- [x] Admin Meeting page
- [x] Meeting emails  - no changes required
- [x] Event page
- [x] Event admin page
- [x] Event invitation emails
    - [x] invitation emails
    - [x] attending

- [x] Timezone WorkshopCalendar - screenshots at bottom of PR

I have also verified all of the above mentioned emails manually and made small amendments. 
Some screenshot of app page changes.


<img width="435" alt="landing-page" src="https://user-images.githubusercontent.com/159200/81940589-a79c9280-95ef-11ea-8210-0c8b0d50612a.png">
<img width="775" alt="admin-workshop-page" src="https://user-images.githubusercontent.com/159200/81940609-ae2b0a00-95ef-11ea-97a0-41348428a4e4.png">
<img width="845" alt="admin-meeting-page" src="https://user-images.githubusercontent.com/159200/81940779-dadf2180-95ef-11ea-87ef-34a1a53f54a9.png">



Included additional but relevant changes to the `WorkshopCalendar` so it respects the chapter's timezone
<img width="962" alt="website-view" src="https://user-images.githubusercontent.com/159200/81967629-1dfebc00-9613-11ea-89aa-e5ac3c0eb915.png">
<img width="278" alt="calendar-entry" src="https://user-images.githubusercontent.com/159200/81967633-1e975280-9613-11ea-9a21-9593c7430341.png">




Closes #1272 and #875 