### PR TITLE
Share the message that the event has taken place

### DIFF
--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -4,7 +4,7 @@
     %label Edit
 
   - if !@event.date_and_time.future?
-    = link_to '#', class: 'item disabled', title: 'The event has already taken place' do
+    = link_to '#', class: 'item disabled', title: t('messages.already_taken_place') do
       %i.fa.fa-send-o
       %label Invite
   - elsif @event.venue and @event.invitable?

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -3,7 +3,7 @@
     %i.fa.fa-pencil
     %label Edit
   - if !@workshop.date_and_time.future?
-    = link_to '#', class: 'item disabled', title: 'The event has already taken place' do
+    = link_to '#', class: 'item disabled', title: t('messages.already_taken_place') do
       %i.fa.fa-send-o
       %label Invite
   - elsif (@workshop.has_valid_host? || @workshop.virtual?) and @workshop.invitable?

--- a/app/views/course/invitation/show.html.haml
+++ b/app/views/course/invitation/show.html.haml
@@ -33,7 +33,7 @@
     .large-4.columns
       .panel
         - if @course.date_and_time < Time.zone.now
-          %em This workshop has already taken place!
+          %em= t('messages.already_taken_place')
         - else
           = link_to "Get your ticket", @invitation.course.ticket_url, class: "expand button round center"
       - if !@next_workshop.nil? or !@meeting.nil?

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -6,7 +6,7 @@
         %br
         %small #{humanize_date(@course.date_and_time, with_time: true)}
       - if @course.date_and_time.past?
-        %label.label.warning This event has already taken place.
+        %label.label.warning= t('messages.already_taken_place')
 
 .stripe.reverse
   .row

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -8,7 +8,7 @@
         %br
         %small #{humanize_date(@workshop.date_and_time, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
-        %label.label.warning= t('workshops.already_taken_place')
+        %label.label.warning= t('messages.already_taken_place')
 .alert-box.info
   .row
     .large-12.columns

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -14,7 +14,7 @@
             access_time
           = @workshop.start_and_end_time
       - if @workshop.date_and_time.past?
-        %label.label.warning= t('workshops.already_taken_place')
+        %label.label.warning= t('messages.already_taken_place')
 
   %section#banner
     .row

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -14,7 +14,7 @@
             access_time
           = @workshop.start_and_end_time
       - if @workshop.date_and_time.past?
-        %label.label.warning This event has already taken place.
+        %label.label.warning= t('messages.already_taken_place')
   %section#banner
     .row
       .medium-12.columns

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
   messages:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'
+    already_taken_place: 'This event has already taken place'
     error_blank_note: 'You must select a note'
     rejected_invitation: "We are so sad you can't make it, but thanks for letting us know %{name}."
     already_rsvped: "You have already confirmed you attendance!"
@@ -212,7 +213,6 @@ en:
     no_spaces_available: 'There are no available spots left for this workshop but you can always join the waiting list.'
     already_attending: 'You are attending this event'
     on_waiting_list: You are on the waiting list.
-    already_taken_place: This workshop has already taken place.
     virtual:
       title: 'Virtual workshop for %{chapter}'
       lead: 'Participate in our workshops to learn programming in a supportive and collaborative online environment at your own pace, or share your knowledge and coach our students.'


### PR DESCRIPTION
Event already taken place is a common message throughout all the events. (I am going to try and put "cancel" warnings in the same place as "event taken place warnings). So I i18n'd them. 

Some of the messages are more specific and say "workshop" I'm not sure if that's important? I think it's clear that the event is over. However, if it is considered important then I could try to find the model and insert it into the message so: 

```
This %{model} has already taken place
# giving: 
This course has already taken place
This workshop has already taken place
this meeting has already taken place
```