### PR TITLE
travis cache bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 language: ruby
+cache: bundler
 bundler_args: --without development
 rvm:
   - 2.4.2


### PR DESCRIPTION
Half of the build time is installing gems and this tells Travis to cache them.
What you should see is that the first build takes around 5min+ as normal but after that it takes approx 2.50. 

We can also save 10s if we use Ruby 2.4.5 (which is installed on Travis by default).