### PR TITLE
Rails 5 upgrade prep

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -14,7 +14,7 @@ class DashboardController < ApplicationController
       hash
     end
 
-    @testimonials = Testimonial.order('RANDOM() ').limit(5).includes(:member)
+    @testimonials = Testimonial.order(Arel.sql('RANDOM()')).limit(5).includes(:member)
   end
 
   def dashboard
@@ -56,7 +56,7 @@ class DashboardController < ApplicationController
     WorkshopInvitation.to_coaches
                       .attended
                       .group(:member_id)
-                      .order('COUNT(member_id) DESC')
+                      .order(Arel.sql('COUNT(member_id) DESC'))
                       .select(:member_id)
   end
 

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -1,7 +1,8 @@
 class WaitingList < ActiveRecord::Base
+  belongs_to :invitation, class_name: 'WorkshopInvitation'
+
   has_one :workshop, through: :invitation
   has_one :member, through: :invitation
-  belongs_to :invitation, class_name: 'WorkshopInvitation'
 
   scope :by_workshop, ->(workshop) { joins(:invitation).where('workshop_invitations.workshop_id = ?', workshop.id) }
   scope :where_role, ->(role) { where('workshop_invitations.role = ?', role) }

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -20,7 +20,7 @@
           %em Sponsored #{sponsor.workshop_sponsors.count} workshops
 
       .large-4.columns
-        = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+        = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
       .large-3.columns
         %p= SponsorPresenter.new(sponsor).contact_info
 

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -16,7 +16,7 @@
 
     .medium-6.large-3.columns
       %h4 Logo
-      = image_tag(@sponsor.avatar, alt: @sponsor.name)
+      = image_tag(@sponsor.avatar.url, alt: @sponsor.name)
 
     .medium-6.large-3.columns
       %h4 Contacts

--- a/app/views/course_invitation_mailer/invite_student.html.haml
+++ b/app/views/course_invitation_mailer/invite_student.html.haml
@@ -35,7 +35,7 @@
           %table{ bgcolor: "#FFFFFF" }
             %tr
               %td.small{ width: "30%", style: "vertical-align: top; padding-right:10px;"}
-                =image_tag(@course.venue.avatar, alt: @course.venue.name)
+                =image_tag(@course.venue.avatar.url, alt: @course.venue.name)
               %td
                 %h4
                   Workshop

--- a/app/views/event_invitation_mailer/invite_coach.html.haml
+++ b/app/views/event_invitation_mailer/invite_coach.html.haml
@@ -38,7 +38,7 @@
                 %h4 Sponsors
                 - @event.sponsors.each do |sponsor|
                   = link_to sponsor.website do
-                    = image_tag(sponsor.avatar, style: 'max-height: 100px;', alt: sponsor.name)
+                    = image_tag(sponsor.avatar.url, style: 'max-height: 100px;', alt: sponsor.name)
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/event_invitation_mailer/invite_student.html.haml
+++ b/app/views/event_invitation_mailer/invite_student.html.haml
@@ -38,7 +38,7 @@
                 %h4 Sponsors
                 - @event.sponsors.each do |sponsor|
                   = link_to sponsor.website do
-                    = image_tag(sponsor.avatar, style: 'max-height: 100px;', alt: sponsor.name)
+                    = image_tag(sponsor.avatar.url, style: 'max-height: 100px;', alt: sponsor.name)
 
         .content
           = render partial: 'shared_mailers/social'

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -59,7 +59,7 @@
             %li
               .row
                 .large-2.columns
-                  = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+                  = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
                 .large-10.columns
                   =link_to sponsor.name, sponsor.website
                   %p

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -103,7 +103,7 @@
         %ul.row.no-bullet
           - @workshop.sponsors.each do |sponsor|
             %li.small-4.columns
-              = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+              = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
               %p
                 = link_to sponsor.name, sponsor.website
 

--- a/app/views/invitations/show.html.haml
+++ b/app/views/invitations/show.html.haml
@@ -78,7 +78,7 @@
         %p
           = @host_address.to_html
       .medium-4.columns
-        = image_tag(@event.venue.avatar, class: 'sponsor-logo-image', alt: @event.venue.name)
+        = image_tag(@event.venue.avatar.url, class: 'sponsor-logo-image', alt: @event.venue.name)
     .row
       .large-12.columns
         %iframe{ width: '100%', height: '250', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }

--- a/app/views/shared_mailers/_venue.html.haml
+++ b/app/views/shared_mailers/_venue.html.haml
@@ -19,4 +19,4 @@
         #{host.accessibility_info}
 
   %td{ width: '30%', style: 'vertical-align: top;' }
-    = image_tag(host.avatar, alt: host.name)
+    = image_tag(host.avatar.url, alt: host.name)

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -40,7 +40,7 @@
                 - if @workshop.sponsors.any?
                   %h4 Sponsored by
                   - @workshop.sponsors.each do |sponsor|
-                    = image_tag(sponsor.avatar, alt: sponsor.name)
+                    = image_tag(sponsor.avatar.url, alt: sponsor.name)
                     %br
 
         .content

--- a/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
@@ -32,7 +32,7 @@
                 - if @workshop.sponsors.any?
                   %h4 Sponsored by
                   - @workshop.sponsors.each do |sponsor|
-                    = image_tag(sponsor.avatar, alt: sponsor.name)
+                    = image_tag(sponsor.avatar.url, alt: sponsor.name)
                     %br
 
         .content

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -34,7 +34,7 @@
           %ul.row.no-bullet
             - @workshop.sponsors.each do |sponsor|
               %li.small-4.columns
-                = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+                = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
                 %p
                   = link_to sponsor.name, sponsor.website
 

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -40,7 +40,7 @@
                   Venue
                   %br
                   %small= @workshop.host.name
-                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
+                = image_tag(@workshop.host.avatar.url, alt: @workshop.host.name)
 
         .content
           = render partial: 'shared_mailers/social', locals: { workshop: @workshop }

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -35,7 +35,7 @@
                   Venue
                   %br
                   %small= @workshop.host.name
-                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
+                = image_tag(@workshop.host.avatar.url, alt: @workshop.host.name)
 
         .content
           = render partial: 'shared_mailers/social', locals: { workshop: @workshop }

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -38,7 +38,7 @@
                   Venue
                   %br
                   %small= @workshop.host.name
-                = image_tag(@workshop.host.avatar, alt: @workshop.host.name)
+                = image_tag(@workshop.host.avatar.url, alt: @workshop.host.name)
 
         .content
           = render partial: 'shared_mailers/social', locals: { workshop: @workshop }

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -32,7 +32,7 @@
         %ul.row.no-bullet
           - @workshop.sponsors.each do |sponsor|
             %li.small-4.columns
-              = image_tag(sponsor.avatar, class: 'sponsor', alt: sponsor.name)
+              = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
               %p
                 = link_to sponsor.name, sponsor.website
 


### PR DESCRIPTION
Upgrading to Rails 5 is a massive task, so I thought to approach it by first resolving non breaking issues that we can integrate in our codebase now. This brings down the failures from **227** to **~123** when running rspec against **rails v5.2.4.2** 


1. Update references to images
**Why**: Rails 5.2 changed the `image_tag` behaviour which now only accepts a url. Up to Rails 5.1 is was possible to pass the uploader object and rails could guess.
2. Wrap SQL in Arel
**Why**: To remove future depreciation warning due to non-attribute arguments not allowed in Rails 6. Known-safe values can be passed by wrapping them in Arel.sql().
3. Ensure belongs_to association is specified before utilising it in :through association as not doing so causes a failure