### PR TITLE
Remove gem rspec-its

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-remote'
   gem 'rspec-collection_matchers'
-  gem 'rspec-its'
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.80.1', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,9 +291,6 @@ GEM
     rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-its (1.3.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -440,7 +437,6 @@ DEPENDENCIES
   rolify
   rollbar
   rspec-collection_matchers
-  rspec-its
   rspec-rails
   rubocop (~> 0.80.1)
   rubocop-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ end
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
-require 'rspec/its'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
["its" left the core of rspec a while a go.](https://gist.github.com/myronmarston/4503509) I think I possibly even removed some of them but the gem had been left in being loaded up each time the tests are run for no good reason.