### PR TITLE
(Fix) Remove order dependency on comparison

### DIFF
--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Sponsor, type: :model  do
       members = Fabricate.times(2, :member)
       members.each { |m| Fabricate(:member_contact, sponsor: sponsor, contact: m) }
 
-      expect(sponsor.contacts).to eq(members)
+      expect(sponsor.contacts).to include(*members)
     end
   end
 end


### PR DESCRIPTION
 - ActiveRecord uses SQL. SQL does not guarantee the order that a
   set of objects are returned to you.
 - Change matcher from eq, expects an order, to include which does
   not care about the order
   - another fix is match_array but the word "match" is confusing
     to me as I would think it was an exact matcher (when it is
     in fact not order dependent)

[Example of Travis failing on this issue](https://travis-ci.org/github/codebar/planner/builds/688356108)

