### PR TITLE
Test workshop validations

### DIFF
--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -24,8 +24,8 @@ class Workshop < ActiveRecord::Base
 
   validates :slack_channel, presence: true, if: :virtual?
   validates :slack_channel_link, presence: true, if: :virtual?
-  validates :student_spaces, numericality: { greater_than: 0 }, if: :virtual
-  validates :coach_spaces, numericality: { greater_than: 0 }, if: :virtual
+  validates :student_spaces, numericality: { greater_than: 0 }, if: :virtual?
+  validates :coach_spaces, numericality: { greater_than: 0 }, if: :virtual?
 
   before_validation :set_date_and_time, if: proc { |model| model.chapter_id.present? }
   before_validation :set_opens_at

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -1,8 +1,36 @@
 require 'spec_helper'
 
-RSpec.describe Workshop, type: :model  do
+RSpec.describe Workshop, type: :model do
   subject(:workshop) { Fabricate(:workshop) }
   include_examples "Invitable", :workshop_invitation, :workshop
+
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:chapter_id) }
+
+    context "date_and_time" do
+      it 'does not validate if chapter_id blank' do
+        workshop.chapter_id = nil
+        workshop.date_and_time = nil
+        workshop.valid?
+        expect(workshop.errors[:date_and_time]).to be_empty
+      end
+
+      it 'validate if chapter_id present' do
+        workshop.chapter_id = 1
+        workshop.date_and_time = nil
+        workshop.valid?
+        expect(workshop.errors[:date_and_time]).to include("can't be blank")
+      end
+    end
+
+    context 'if virtual' do
+      before { allow(subject).to receive(:virtual?).and_return(true) }
+      it { is_expected.to validate_presence_of(:slack_channel)}
+      it { is_expected.to validate_presence_of(:slack_channel_link)}
+      it { is_expected.to validate_numericality_of(:student_spaces).is_greater_than(0) }
+      it { is_expected.to validate_numericality_of(:coach_spaces).is_greater_than(0) }
+    end
+  end
 
   context 'time zone fields' do
     let(:workshop) { Fabricate.build(:workshop, chapter: Fabricate(:chapter, time_zone: 'Pacific Time (US & Canada)')) }


### PR DESCRIPTION
In regards to refactoring the Workshop fabricators.

I wanted to first nail down what was required for validation (the only code change were two `if` changing from `:virtual` to `:virtual?` which doesn't change anything but makes the testing easier. I think it was worthwhile now that workshop is complicated by the `virtual` state.

The next step (as yet undone) is give the workshop fabricators the minimum attributes to be valid and use this minimum as the base for the other types used in the testing (using the `from` keyword).

Note: The shoulda did not handle conditional validation very well and required the longer test for `chapter_id`. 
