### PR TITLE
Workshop#ends_at required when it shouldn't be

### DIFF
--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -1,6 +1,6 @@
 Fabricator(:workshop) do
   date_and_time Time.zone.now + 2.days
-  ends_at Time.zone.now + 2.days + 2.hours
+  # ends_at Time.zone.now + 2.days + 2.hours
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter


### PR DESCRIPTION
@despo - Nothing to do with the work you are doing today. This bug was introduced a few weeks back in WorkshopCalendar. I didn't know how to fix it but wanted to demo it to you (if there was a better way let me know). 

When I remove `ends_at` from the fabricator the system breaks because workshop_calendar is using `workshop.ends_at` without any protection. When I protect the line it all goes away.

```ruby
# spec/fabricators/workshop_fabricator.rb
Fabricator(:workshop) do
  date_and_time Time.zone.now + 2.days
  # ends_at Time.zone.now + 2.days + 2.hours   (line 3)
  title Faker::Lorem.sentence
  description Faker::Lorem.sentence
  ...
end
```
Should be around 18 errors caused by this line 

```ruby
  # app/models/workshop_calendar.rb 
  def end_datetime(workshop)                                        #line 74
    date = workshop.date_and_time.strftime('%Y%m%d')
    end_time = workshop.ends_at.strftime('%H%M')
     #            boom ===/\                                      #line 75 
    "#{date}#{end_time}"
  end
```

---

There is a similar issue when I comment out Workhop Fabricator's sponsor but I I haven't pinned down issue - It doesn't feel like it's one place in this case.

```ruby
Fabricator(:workshop) do
  date_and_time Time.zone.now + 2.days
  ends_at Time.zone.now + 2.days + 2.hours
  title Faker::Lorem.sentence
  description Faker::Lorem.sentence
  chapter
  # after_build do |workshop|
  #  Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: true)
  # end
end
```

❌ 