### PR TITLE
Workshop validates ends_at

### DIFF
--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -20,7 +20,7 @@ class Workshop < ActiveRecord::Base
   scope :coaches, -> { joins(:invitations).where(invitations: { name: 'Coach', attended: true }) }
 
   validates :chapter_id, presence: true
-  validates :date_and_time, presence: true, if: proc { |model| model.chapter_id.present? }
+  validates :date_and_time, :ends_at, presence: true, if: proc { |model| model.chapter_id.present? }
 
   validates :slack_channel, presence: true, if: :virtual?
   validates :slack_channel_link, presence: true, if: :virtual?

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -72,6 +72,7 @@ end
 
 Fabricator(:workshop_no_coaches, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
+  ends_at Time.zone.now + 2.days + 2.hours
   title Faker::Lorem.sentence
   description Faker::Lorem.sentence
   chapter

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -150,6 +150,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
         select chapter.name
         fill_in 'Date', with: Date.current
         fill_in 'Begins at', with: '11:30'
+        fill_in 'Ends at', with: '14:30'
 
         click_on 'Save'
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Workshop, type: :model do
   context 'validates' do
     it { is_expected.to validate_presence_of(:chapter_id) }
 
-    context "date_and_time" do
+    context "#date_and_time" do
       it 'does not validate if chapter_id blank' do
         workshop.chapter_id = nil
         workshop.date_and_time = nil
@@ -16,10 +16,26 @@ RSpec.describe Workshop, type: :model do
       end
 
       it 'validate if chapter_id present' do
-        workshop.chapter_id = 1
+        workshop.chapter = Fabricate(:chapter)
         workshop.date_and_time = nil
         workshop.valid?
         expect(workshop.errors[:date_and_time]).to include("can't be blank")
+      end
+    end
+
+    context '#end_at' do
+      it 'does not validate if chapter_id blank' do
+        workshop.chapter_id = nil
+        workshop.ends_at = nil
+        workshop.valid?
+        expect(workshop.errors[:ends_at]).to be_empty
+      end
+
+      it 'validate if chapter_id present' do
+        workshop.chapter = Fabricate(:chapter)
+        workshop.ends_at = nil
+        workshop.valid?
+        expect(workshop.errors[:ends_at]).to include("can't be blank")
       end
     end
 


### PR DESCRIPTION
 - Chapter required (instead of chapter_id) because timezone method
   requires chapter.time_zone

---
There _might_ be issues with VirtualWorkshops and date_and_time as the :if, callbacks, super, and concerns make this non-trivial. It's a basic pass through.  