### PR TITLE
(Fix) Warning after removing descriptions from factory attributes

### DIFF
--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
     end
 
     context 'virtual workshop' do
-      let(:workshop) { Fabricate(:virtual_workshop_sponsored) }
+      let(:workshop) { Fabricate(:virtual_workshop_sponsored, description: Faker::Lorem.sentence) }
 
       describe '#details' do
         scenario 'workshop and page title' do


### PR DESCRIPTION
Yes, I introduced this to the build - this removes it.

`Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.`