### PR TITLE
(Fix) Use listable's `upcoming` scope to retrieve Events

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -85,7 +85,7 @@ class DashboardController < ApplicationController
   def all_events(workshops)
     course = Course.includes(:sponsor).next
     meeting = Meeting.includes(:venue).next
-    events = Event.includes(:venue, :sponsors).future(DEFAULT_UPCOMING_EVENTS)
+    events = Event.includes(:venue, :sponsors).upcoming.take(DEFAULT_UPCOMING_EVENTS)
 
     [*workshops, course, *events, meeting].uniq.compact
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,8 +22,6 @@ class Event < ActiveRecord::Base
   validates :coach_spaces, :student_spaces, numericality: true
   attr_accessor :publish_day, :publish_time
 
-  scope :future, ->(n) { order('date_and_time').where('date_and_time > ?', Date.current).take(n) }
-
   before_save do
     begins_at = Time.parse(self.begins_at)
     self.date_and_time = self.date_and_time.change(hour: begins_at.hour, min: begins_at.min)

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.feature 'when visiting the homepage', type: :feature do
   let!(:next_workshop) { Fabricate(:workshop) }
   let!(:next_course) { Fabricate(:course) }
-  let!(:event) { Fabricate(:event) }
+  let!(:events) { Fabricate.times(8, :event) }
 
   before(:each) do
     visit root_path
@@ -21,8 +21,8 @@ RSpec.feature 'when visiting the homepage', type: :feature do
     expect(page).to have_content next_course.title
   end
 
-  scenario 'i can view upcoming events' do
-    expect(page).to have_content event.name
+  scenario 'i can view the next 5 upcoming events' do
+    events.take(5).each { |event| expect(page).to have_content "#{event.name} at #{event.venue.name}" }
   end
 
   scenario 'i can access the code of conduct' do


### PR DESCRIPTION
Remove untested `future` scope from Event and substitute with Listable’s `upcoming`

**Issue:** `future` was retrieving events based on `Date.current`, thus rendering Events after they have taken place and without taking into account the timezone, instead of `Time.zone.now` (screenshot attached). Since the functionality it attempts to recreate is already in place it’s best to reuse what is already there.


<img width="552" alt="Screen_Shot_2020-05-19_at_22_49_05_1" src="https://user-images.githubusercontent.com/159200/82386049-74149a80-9a2b-11ea-9d3a-4a30bf2e4e69.png">
