### PR TITLE
Fix for issue/743 - Workshop email reminder arriving on the the day of the event says "tomorrow"

### DIFF
--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -55,7 +55,7 @@ class VirtualWorkshopInvitationMailer < ActionMailer::Base
   private
 
   def setup(workshop, invitation, member)
-    @workshop = workshop
+    @workshop = WorkshopPresenter.new(workshop)
     @member = member
     @invitation = invitation
   end

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -88,6 +88,10 @@ class EventPresenter < BasePresenter
     generate_csv_from_array(attendee_array)
   end
 
+  def day_temporal_pronoun
+    model.date_and_time.today? ? 'today' : 'tomorrow'
+  end
+
   private
 
   def generate_csv_from_array(attendees)

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -92,6 +92,10 @@ class EventPresenter < BasePresenter
     model.date_and_time.today? ? 'today' : 'tomorrow'
   end
 
+  def rsvp_closing_date_and_time
+    model.date_and_time - 3.5.hours
+  end
+
   private
 
   def generate_csv_from_array(attendees)

--- a/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
@@ -14,10 +14,10 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you have signed up for tomorrow's workshop.
+                  This is a quick email to remind you that you have signed up for #{@workshop.day_temporal_pronoun}'s workshop.
                 %p
-                  If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.
-                  <a href='https://codebar.io/student-guide#attendance'>We have a three-strikes attendance policy for no-shows.</a>
+                  If you can no longer make it make sure you cancel your invitation before #{@workshop.day_temporal_pronoun} <strong>#{I18n.l(@workshop.rsvp_closing_date_and_time, format: :email_title)}</strong> so we can reallocate your spot to someone else.
+                  Remember that we have a <a href='https://codebar.io/student-guide#attendance'>three-strikes attendance policy</a> for no-shows.
 
                 = render partial: 'how_to_join_info'
 

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -14,13 +14,12 @@
               %td
                 %h3 Hi #{@member.name},
                 %p.lead
-                  This is a quick email to remind you that you have signed up for tomorrow's workshop.
+                  This is a quick email to remind you that you have signed up for #{@workshop.day_temporal_pronoun}'s workshop.
                 %p
-                  If you can no longer make it, please cancel your invitation <strong>before 15:00</strong> on the day of the event.
-                  <a href='https://codebar.io/student-guide#attendance'>We have a three-strikes attendance policy for no-shows.</a>
+                  If you can no longer make it make sure you cancel your invitation before #{@workshop.day_temporal_pronoun} <strong>#{I18n.l(@workshop.rsvp_closing_date_and_time, format: :email_title)}</strong> so we can reallocate your spot to someone else.
+                  Remember that we have a <a href='https://codebar.io/student-guide#attendance'>three-strikes attendance policy</a> for no-shows.
                 %p
-                  %strong Please do not turn up before #{(@workshop.date_and_time).strftime('%H:%M')}.
-                  If you are early, please wait in a nearby cafe.
+                  As most of our hosts are busy before the workshops begin, do not turn up before #{(@workshop.date_and_time).strftime('%H:%M')} as you may not be allowed in. If you are early, we suggest waiting at a nearby cafe.
 
         .content
           %table{ bgcolor: '#FFFFFF' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ en:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/spec/mailers/course_invitation_mailer_spec.rb
+++ b/spec/mailers/course_invitation_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CourseInvitationMailer, type: :mailer  do
     course = Fabricate(:course, title: 'HTTP Fundamentals', date_and_time: Time.zone.local(2013, 10, 30, 18, 30))
     invitation_token = 'token'
 
-    email_subject = "Course :: #{course.title} by codebar - Wednesday, 30 Oct at 18:30"
+    email_subject = "Course :: #{course.title} by codebar - Wednesday, 30 Oct at 18:30 GMT"
     CourseInvitationMailer.invite_student(course, member, invitation_token).deliver_now
 
     expect(email.subject).to eq(email_subject)

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -68,4 +68,12 @@ RSpec.describe EventPresenter do
       expect(event.day_temporal_pronoun). to eq('tomorrow')
     end
   end
+
+  context 'rsvp_closing_date_and_time' do
+    it 'returns the calculated RSVP closing time for an event' do
+      workshop.date_and_time = Time.zone.local(2040, 10, 10, 16, 30)
+
+      expect(event.rsvp_closing_date_and_time). to eq(Time.zone.local(2040, 10, 10, 13, 00))
+    end
+  end
 end

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -54,4 +54,18 @@ RSpec.describe EventPresenter do
   it '#class_string' do
     expect(event.class_string).to eq('workshop')
   end
+
+  context '#day_temporal_pronoun' do
+    it 'returns today if the date_and_time set set to today' do
+      workshop.date_and_time = Time.zone.now
+
+      expect(event.day_temporal_pronoun). to eq('today')
+    end
+
+    it 'returns yesteday if the date_and_time is not set to today' do
+      workshop.date_and_time = Time.zone.now+1.day
+
+      expect(event.day_temporal_pronoun). to eq('tomorrow')
+    end
+  end
 end


### PR DESCRIPTION
Closes #743 and includes additional improvements to workshop (and virtual workshop) attendance reminder emails:



### Workshop attendance reminder - tomorrow
<img width="706" alt="workshop-attendance-reminder" src="https://user-images.githubusercontent.com/159200/82455983-88987780-9aab-11ea-83ee-1d678f6d535d.png">


### Virtual workshop attendance reminder
#### Today
<img width="669" alt="workshop-today-attendance-reminder" src="https://user-images.githubusercontent.com/159200/82455668-1aec4b80-9aab-11ea-8e2f-6496e260b59b.png">

#### Tomorrow
<img width="709" alt="v-workshop-attendance-reminder" src="https://user-images.githubusercontent.com/159200/82454339-8a613b80-9aa9-11ea-82bf-5f3a8d98829e.png">


