### PR TITLE
Changes around testing Ban

### DIFF
--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -6,7 +6,7 @@ class Ban < ActiveRecord::Base
 
   validate :valid_expiry_date?
 
-  scope :active, -> { where('expires_at > ?', Date.current) }
+  scope :active, -> { where('expires_at > ?', Time.zone.now) }
   scope :permanent, -> { where(permanent: true) }
 
   def active?

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -2,7 +2,7 @@ class Ban < ActiveRecord::Base
   belongs_to :member
   belongs_to :added_by, class_name: 'Member'
 
-  validates :reason, :note, :added_by, presence: true
+  validates :expires_at, :reason, :note, :added_by, presence: true
 
   validate :valid_expiry_date?
 

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -16,6 +16,6 @@ class Ban < ActiveRecord::Base
   private
 
   def valid_expiry_date?
-    errors.add(:expires_at, 'must be in the future') unless expires_at.try(:future?)
+    errors.add(:expires_at, 'must be in the future') unless expires_at&.future?
   end
 end

--- a/spec/models/ban_spec.rb
+++ b/spec/models/ban_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe Ban, type: :model do
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:reason) }
+    it { is_expected.to validate_presence_of(:note) }
+    it { is_expected.to validate_presence_of(:added_by) }
+   end
+  end
+  context '#active?' do
+    it 'is active in the future' do
+      expect(Fabricate.build(:ban, expires_at: Time.zone.now + 1.minute)).to be_active
+    end
+
+    it 'is inactive in the past' do
+      expect(Fabricate.build(:ban, expires_at: Time.zone.now - 1.minute)).to_not be_active
+    end
+  end
+end

--- a/spec/models/ban_spec.rb
+++ b/spec/models/ban_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Ban, type: :model do
   context 'validates' do
+    it { is_expected.to validate_presence_of(:expires_at) }
     it { is_expected.to validate_presence_of(:reason) }
     it { is_expected.to validate_presence_of(:note) }
     it { is_expected.to validate_presence_of(:added_by) }

--- a/spec/models/ban_spec.rb
+++ b/spec/models/ban_spec.rb
@@ -6,8 +6,22 @@ RSpec.describe Ban, type: :model do
     it { is_expected.to validate_presence_of(:reason) }
     it { is_expected.to validate_presence_of(:note) }
     it { is_expected.to validate_presence_of(:added_by) }
-   end
+
+    context '#expires_at' do
+      it 'valid in the future' do
+        ban = Fabricate.build(:ban, expires_at: Time.zone.now + 1.minute)
+        ban.valid?
+        expect(ban.errors[:expires_at]).to be_empty
+      end
+
+      it 'invalid in the past' do
+        ban = Fabricate.build(:ban, expires_at: Time.zone.now - 1.minute)
+        ban.valid?
+        expect(ban.errors[:expires_at]).to include('must be in the future')
+      end
+    end
   end
+
   context '#active?' do
     it 'is active in the future' do
       expect(Fabricate.build(:ban, expires_at: Time.zone.now + 1.minute)).to be_active

--- a/spec/models/ban_spec.rb
+++ b/spec/models/ban_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Ban, type: :model do
     end
   end
 
+  context 'scope' do
+    context 'active' do
+      it 'includes bans expiring in the future' do
+        ban = Fabricate(:ban, expires_at: Time.zone.now + 1.minute)
+        expect(Ban.active).to include(ban)
+      end
+
+      it 'excludes expired bans' do
+        ban = Fabricate(:ban, expires_at: Time.zone.now + 1.minute)
+        travel 5.minutes do
+          expect(Ban.active).to_not include(ban)
+        end
+      end
+    end
+  end
+
   context '#active?' do
     it 'is active in the future' do
       expect(Fabricate.build(:ban, expires_at: Time.zone.now + 1.minute)).to be_active

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   config.include ApplicationHelper
   config.include LoginHelpers
   config.include JobrefHelpers
+  config.include ActiveSupport::Testing::TimeHelpers
   config.use_transactional_fixtures = false
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'


### PR DESCRIPTION
Using Ban and wanted to understand it better so I've added tests.

I made 4 changes to the actual code

| Comment  | Sha |  Note |
| ------------- | ------------- | ------------ |
| 1. Added ActiveSupport TimeHelpers  | 84f0dd3  | it's a way of testing time without 3rd party libraries. |
| 2.  Ban#expired_at required  | 0334f05  |[bans/new - expires_at is required](https://github.com/codebar/planner/blob/master/app/views/admin/bans/new.html.haml#L15) |
|  3. Custom validation refactored to use Ruby safe navigation  |  0ff139a   |  -  |
|  4. Prefer Time.zone.now over Date.current |  46b23fc   |  Not sure if it's important for Time.zone aware code on banning?  |



  
  

