### PR TITLE
Replace Timecop with ActiveSupport::Testing::TimeHelpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.80.1', require: false
   gem 'rubocop-rails', require: false
-  gem 'timecop'
   gem 'bullet'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.1)
     tins (1.20.2)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -444,7 +443,6 @@ DEPENDENCIES
   shoulda-matchers (~> 4.3)
   simple_form
   stripe
-  timecop
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -33,20 +33,20 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
           new_current_time = 1.day + Admin::WorkshopsController::
                                      WORKSHOP_DELETION_TIME_FRAME_SINCE_CREATION
 
-          Timecop.travel(new_current_time)
-          expect do
-            delete :destroy, id: workshop.id
-          end.not_to change { Workshop.count }
-          Timecop.return
+          travel new_current_time do
+            expect do
+              delete :destroy, id: workshop.id
+            end.not_to change { Workshop.count }
+          end
         end
 
         it "should display workshop can't be deleted related flash message" do
           new_current_time = 1.day + Admin::WorkshopsController::
                                      WORKSHOP_DELETION_TIME_FRAME_SINCE_CREATION
 
-          Timecop.travel(new_current_time)
-          delete :destroy, id: workshop.id
-          Timecop.return
+          travel new_current_time do
+            delete :destroy, id: workshop.id
+          end
 
           expect(flash[:notice]).to eq(I18n.t('admin.workshop.destroy.failure'))
         end
@@ -73,20 +73,20 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
           new_current_time = 1.day + Admin::WorkshopsController::
                                      WORKSHOP_DELETION_TIME_FRAME_SINCE_CREATION
 
-          Timecop.travel(new_current_time)
-          expect do
-            delete :destroy, id: workshop.id
-          end.not_to change { Workshop.count }
-          Timecop.return
+          travel new_current_time do
+            expect do
+              delete :destroy, id: workshop.id
+            end.not_to change { Workshop.count }
+          end
         end
 
         it "should display workshop can't be deleted related flash message" do
           new_current_time = 1.day + Admin::WorkshopsController::
                                      WORKSHOP_DELETION_TIME_FRAME_SINCE_CREATION
 
-          Timecop.travel(new_current_time)
-          delete :destroy, id: workshop.id
-          Timecop.return
+          travel new_current_time do
+            delete :destroy, id: workshop.id
+          end
 
           expect(flash[:notice]).to eq(I18n.t('admin.workshop.destroy.failure'))
         end


### PR DESCRIPTION
Controller tests will need to be looked at during upgrade but for an example ...