### PR TITLE
Remove ApplicationController#upcoming_workshops  

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -159,12 +159,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :jobs_pending_approval, :chapters
 
-  def upcoming_workshops
-    Workshop.upcoming
-  end
-
-  helper_method :upcoming_workshops
-
   def redirect_back(fallback_location:, **args)
     if referer = request.headers["Referer"]
       redirect_to referer, **args


### PR DESCRIPTION
 - available to all views but not used
 - similar but not the same:
   - @upcoming_workshops used in
       - chapter_controller and show view
       - dashboard_controller and show view
   - ChapterPresenter an upcoming_workshops

---
Also it's private method - but I don't remember if Ruby enforces that 🤔 