### PR TITLE
Refactor sponsor validations

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -17,7 +17,7 @@ class Sponsor < ActiveRecord::Base
   has_many :contacts, through: :member_contacts, class_name: 'Member', foreign_key: 'member_id'
 
   validates :level, inclusion: { in: Sponsor.levels.keys }
-  validates :name, :address, :avatar, :website, :seats, presence: true
+  validates :name, :address, :avatar, :website, :seats, :level, presence: true
   validate :website_is_url
 
   default_scope -> { order('updated_at desc') }

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -16,6 +16,7 @@ class Sponsor < ActiveRecord::Base
   has_many :member_contacts
   has_many :contacts, through: :member_contacts, class_name: 'Member', foreign_key: 'member_id'
 
+  validates :level, inclusion: { in: Sponsor.levels.keys }
   validates :name, :address, :avatar, :website, :seats, presence: true
   validate :website_is_url
 
@@ -49,7 +50,7 @@ class Sponsor < ActiveRecord::Base
   def website_is_url
     begin
       uri = URI.parse(website)
-      valid = uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)
+      valid = uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
     rescue URI::InvalidURIError
       valid = false
     end

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Managing sponsors', type: :feature do
         fill_in 'Website', with: 'https://www.sponsorname.com/'
         attach_file('Avatar', Rails.root + 'spec/support/codebar-logo.png')
         fill_in 'Student Spots', with: 20
+        select "Bronze", from: "Level"
 
         click_on 'Create sponsor'
 

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Sponsor, type: :model do
     it { is_expected.to validate_presence_of(:avatar) }
     it { is_expected.to validate_presence_of(:website) }
     it { is_expected.to validate_presence_of(:seats) }
+    it { is_expected.to validate_presence_of(:level) }
 
     context '#website_is_url format' do
       it 'allows full URLs' do

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,80 +1,44 @@
 require 'spec_helper'
 
-RSpec.describe Sponsor, type: :model  do
+RSpec.describe Sponsor, type: :model do
   subject(:sponsor) { Fabricate.build(:sponsor) }
 
-  it { should respond_to(:name) }
-  it { should respond_to(:website) }
-  it { should respond_to(:address) }
-  it { should respond_to(:workshops) }
-  it { should respond_to(:workshop_sponsors) }
-  it { should respond_to(:avatar) }
-  it { should respond_to(:seats) }
-  it { should respond_to(:email) }
-  it { should respond_to(:contact_first_name) }
-  it { should respond_to(:contact_surname) }
-  it { should respond_to(:accessibility_info) }
-  it { should be_valid }
-
   context 'validations' do
-    context 'presence' do
-      describe '#name' do
-        before { sponsor.name = nil }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:address) }
+    it { is_expected.to validate_presence_of(:avatar) }
+    it { is_expected.to validate_presence_of(:website) }
+    it { is_expected.to validate_presence_of(:seats) }
 
-        it { should_not be_valid }
-        it { should have(1).error_on(:name) }
+    context '#website_is_url format' do
+      it 'allows full URLs' do
+        sponsor.website = 'http://google.com'
+
+        sponsor.valid?
+
+        expect(sponsor.errors[:website]).to_not include('must be a full, valid URL')
       end
 
-      describe '#website' do
-        before { sponsor.website = nil }
+      it 'does not allow nonsense' do
+        sponsor.website = 'lkjdlkfgjj'
 
-        it { should_not be_valid }
-        it { should have(2).errors_on(:website) }
+        sponsor.valid?
+
+        expect(sponsor.errors[:website]).to include('must be a full, valid URL')
       end
 
-      describe '#address' do
-        before { sponsor.address = nil }
+      it 'must have a protocol' do
+        sponsor.website = 'www.google.com'
 
-        it { should_not be_valid }
-        it { should have(1).error_on(:address) }
-      end
+        sponsor.valid?
 
-      describe '#avatar' do
-        subject(:sponsor) { Fabricate.build(:sponsor, avatar: nil) }
-
-        it { should_not be_valid }
-        it { should have(1).error_on(:avatar) }
-      end
-
-      describe '#seats' do
-        before { sponsor.seats = nil }
-
-        it { should have(1).error_on(:seats) }
+        expect(sponsor.errors[:website]).to include('must be a full, valid URL')
       end
     end
 
-    context 'format' do
-      describe '#website' do
-        describe 'nonsense is not valid.' do
-          before { sponsor.website = 'lkjdlkfgjj' }
-
-          it { should_not be_valid }
-          it { should have(1).error_on(:website) }
-        end
-
-        describe 'websites without a protocol are not valid' do
-          before { sponsor.website = 'www.google.com' }
-
-          it { should_not be_valid }
-          it { should have(1).error_on(:website) }
-        end
-
-        describe 'full URLs are valid' do
-          before { sponsor.website = 'http://google.com' }
-
-          it { should be_valid }
-        end
-      end
+    it 'defines enum level' do
+      is_expected.to define_enum_for(:level)
+        .with_values(%i[hidden standard bronze silver gold])
     end
   end
 


### PR DESCRIPTION
### (refactor) Sponsor validations using shoulda  a4180ec 

 - added validation for enum level
 - kind_of? => is_a? - no change in the code as they are
   synonymous. Change because Rubocop has annointed is_a?
 - remove respond_to because it's an incomplete way of finding
   the attributes of a class - they get out of date and it's
   just easier to use the schema.
 - prefer the more expressive and compact shoulda matchers over
   the hand written validations where possible
 - remove rspec-collection_matchers that are no longer part of
   rspec core

--- 

### (feature) Sponsor validate presence of level 4bbf8d3 

I've added a separate more speculative commit 4bbf8d3 as I wasn't sure what the effect of making the level required. If you press create by default you get standard level. I imagine there aren't many that don't have a level? I assume, if you tried to edit one without a level it would then ask you for a level.

---

#### Unknown
Address is required in the model but the system doesn't care if it's blank. Not sure if that's important or not.
