### PR TITLE
Update node from version 8 to version 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4.2
 
 # Default node version on apt is old. This makes sure a recent version is installed
 # This step also runs apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y build-essential libpq-dev nodejs
 
 # Install latest chrome dev package


### PR DESCRIPTION
Node 8 is no longer actively supported and will not receive any updates.

<details>

<summary>When running locally you'll get this deprecation warning</summary>

```

================================================================================
================================================================================

                              DEPRECATION WARNING

  Node.js 8.x LTS Carbon is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_10.x — Node.js 10 LTS "Dubnium" (recommended)
   * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"

  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions

================================================================================
================================================================================

Continuing in 20 seconds ...

```

</details>

I'm also not really sure why `node` is required. The [rails 4.2 guide](https://guides.rubyonrails.org/v4.2/getting_started.html) doesn't mention installing `node` where it mentions it in the [rails 6.0 guide](https://guides.rubyonrails.org/getting_started.html#installing-node-js-and-yarn) so I'm not sure why it's needed. 