### PR TITLE
Remove cleanup trap in bin/drails script

### DIFF
--- a/bin/drails
+++ b/bin/drails
@@ -2,18 +2,4 @@
 
 set -e
 
-function cleanup {
-  # capture exit code
-  code=$?
-  echo "cleaning up"
-
-  # ignore errors
-  set +e
-  docker-compose down
-
-  exit $code
-}
-
-trap cleanup EXIT
-
-docker-compose run --rm web rails $@
+docker-compose run --rm web rails "$@"


### PR DESCRIPTION
I regularly want to drop into the rails console when I'm working on a rails app to verify commands. But when I run `bin/drails console` and then exit out of it the cleanup trap runs and shuts down the server running in my other terminal 😬 

You can try this by running `bin/dstart` in one terminal window and `bin/drails console` in another. When you exit out of the rails console the rails server also exists in the first window.

I don't think this is the intended behavior. I didn't check the other `bin/d*` scripts to see if they need cleanups but I think `bin/drails` doesn't need it.