### PR TITLE
(refactor) Feedback model validations

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -7,14 +7,6 @@ class Feedback < ActiveRecord::Base
 
   validates :rating, inclusion: { in: 1..5, message: "can't be blank" }
   validates :tutorial, presence: true
-  validate :coach_field_has_a_coach_role?
-
-  def coach_field_has_a_coach_role?
-    return false unless coach_id
-    return if Member.find(coach_id).groups.coaches.any?
-
-    errors.add(:coach, "Coach member doesn't have 'coach' role.")
-  end
 
   def self.submit_feedback(params, token)
     return false unless feedback_request = FeedbackRequest.find_by(token: token)

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,103 +1,39 @@
 require 'spec_helper'
 
-RSpec.describe Feedback, type: :model  do
+RSpec.describe Feedback, type: :model do
   subject(:feedback) { Fabricate.build(:feedback) }
-
-  let(:valid_feedback_token) { 'valid_feedback_token' }
-  let(:invalid_feedback_token) { 'invalid_feedback_token' }
-  let(:chapter) { Fabriate(:chapter) }
-
-  it { should respond_to(:request) }
-  it { should respond_to(:rating) }
-  it { should respond_to(:suggestions) }
-  it { should respond_to(:coach) }
-  it { should respond_to(:tutorial) }
 
   context 'validations' do
     context '#rating' do
-      it 'should not be blank' do
-        feedback = Fabricate.build(:feedback, rating: nil)
-
-        expect(feedback).to_not be_valid
-        expect(feedback).to have(1).error_on(:rating)
-      end
-
-      it 'should accept numbers from 1 to 5' do
-        (1..5).each do |rating|
-          feedback = Fabricate.build(:feedback, rating: rating)
-
-          expect(feedback).to be_valid
-        end
-      end
-
-      it 'should be invalid with number higher than 5' do
-        feedback = Fabricate.build(:feedback, rating: 6)
-
-        expect(feedback).to_not be_valid
-        expect(feedback).to have(1).error_on(:rating)
-      end
-
-      it 'should be invalid with number lower than 1' do
-        feedback = Fabricate.build(:feedback, rating: 0)
-
-        expect(feedback).to_not be_valid
-        expect(feedback).to have(1).error_on(:rating)
-      end
-
-      it 'should be numerical' do
-        feedback = Fabricate.build(:feedback, rating: 'alpha')
-
-        expect(feedback).to_not be_valid
-        expect(feedback).to have(1).error_on(:rating)
-      end
+      it { is_expected.to validate_presence_of(:rating) }
+      it { is_expected.to validate_inclusion_of(:rating).in_range(1..5).with_message(/can't be blank/) }
     end
 
-    context '#coach' do
-      it "accepts member with 'coach' role" do
-        feedback = Fabricate.build(:feedback, coach: Fabricate(:coach))
-
-        expect(feedback).to be_valid
-      end
-
-      it "is invalid with member with 'student' role" do
-        feedback = Fabricate.build(:feedback, coach: Fabricate(:student))
-
-        expect(feedback).to_not be_valid
-        expect(feedback).to have(1).error_on(:coach)
-      end
-
-      it "should display correct error message when member with 'student' role given" do
-        feedback = Fabricate.build(:feedback, coach: Fabricate(:student))
-
-        feedback.valid?
-
-        expect(feedback.errors.messages[:coach]).to include("Coach member doesn't have 'coach' role.")
-      end
-    end
+    it { is_expected.to validate_presence_of(:tutorial) }
   end
 
   context '#submit_feedback' do
     let(:feedback_request) { Fabricate(:feedback_request) }
 
-    let (:params) do
+    let(:params) do
       { rating: 4, coach: Fabricate(:coach), tutorial: Fabricate(:tutorial) }
     end
 
     context 'with valid token' do
-      it 'is submited valid params' do
+      it 'is  submitted valid params' do
         expect do
           Feedback.submit_feedback(params, feedback_request.token)
         end.to change { Feedback.count }.by(1)
       end
 
-      it 'is not submited invalid params' do
+      it 'is not submitted invalid params' do
         expect do
           Feedback.submit_feedback(params.except(:rating), feedback_request.token)
         end.to_not change { Feedback.count }
       end
     end
 
-    it 'is not submited with invalid token' do
+    it 'is not submitted with invalid token' do
       expect do
         Feedback.submit_feedback(params, 'invalid_token')
       end.to_not change { Feedback.count }


### PR DESCRIPTION
 - prefer the more expressive and compact shoulda matchers
   over the hand written validations where possible
 - removes rspec-collection_matchers that have been removed
   from rspec core
 - remove respond_to because it's an incomplete way of finding
   the attributes of a class - they get out of date and it's
   just easier to use the schema.
---
My stack was blown by method name with coach in twice. I've suggested a different name for the method.
