### PR TITLE
Fix for #1314

### DIFF
--- a/app/controllers/concerns/invitation_controller_concerns.rb
+++ b/app/controllers/concerns/invitation_controller_concerns.rb
@@ -2,8 +2,7 @@ module InvitationControllerConcerns
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_invitation
-
+    include WorkshopInvitationConcerns
     include InstanceMethods
   end
 
@@ -62,10 +61,6 @@ module InvitationControllerConcerns
     end
 
     private
-
-    def back_with_message(message)
-      redirect_back(fallback_location: invitation_path(@invitation), notice: message)
-    end
 
     def attending_or_waitlisted?(workshop, user)
       workshop.attendee?(user) || workshop.waitlisted?(user)

--- a/app/controllers/concerns/workshop_invitation_concerns.rb
+++ b/app/controllers/concerns/workshop_invitation_concerns.rb
@@ -1,0 +1,25 @@
+module WorkshopInvitationConcerns
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_invitation
+
+    include InstanceMethods
+  end
+
+  module InstanceMethods
+    private
+
+    def invitation_params
+      params[:workshop_invitation].present? ? params.require(:workshop_invitation).permit(:tutorial, :note) : {}
+    end
+
+    def back_with_message(message)
+      redirect_back(fallback_location: invitation_path(@invitation), notice: message)
+    end
+
+    def set_invitation
+      @invitation = WorkshopInvitation.find_by(token: token)
+    end
+  end
+end

--- a/app/controllers/invitation_controller.rb
+++ b/app/controllers/invitation_controller.rb
@@ -10,39 +10,27 @@ class InvitationController < ApplicationController
     render text: @workshop.attendees_csv if request.format.csv?
   end
 
-  def update_note
+  def update
     @invitation = WorkshopInvitation.find_by(token: params[:id])
-    new_note = params[:note]
 
-    if new_note.blank?
+    if @invitation.role.eql?('Student') && new_note.blank?
       redirect_to :back, notice: t('messages.error_blank_note')
     else
-      @invitation.update_attribute(:note, params[:note])
+      @invitation.update(note: new_note)
       redirect_to :back, notice: t('messages.updated_note')
     end
   end
 
-  def accept_with_note
-    @invitation.update(note: params[:workshop_invitation][:note], rsvp_time: Time.zone.now)
-    @workshop = WorkshopPresenter.decorate(@invitation.workshop)
+  private
 
-    if @workshop.student_spaces?
-      if @workshop.attendee?(current_user) || @workshop.waitlisted?(current_user)
-        return redirect_to :back, notice: t('messages.already_invited')
-      end
-
-      @invitation.update_attribute(:attending, true)
-      @workshop.send_attending_email(@invitation)
-
-      redirect_to :back, notice: t('messages.accepted_invitation',
-                                   name: @invitation.member.name)
-
-    else
-      redirect_to :back, notice: t('messages.no_available_seats')
-    end
+  def new_note
+    @invitation.role.eql?('Student') ? params[:note] : params[:workshop_invitation][:note]
   end
 
-  private
+  def available_spaces?(workshop, invitation)
+    (invitation.role.eql?('Student') && workshop.student_spaces?) ||
+      (invitation.role.eql?('Coach') && workshop.coach_spaces?)
+  end
 
   def set_invitation
     @invitation = WorkshopInvitation.find_by(token: params[:id])

--- a/app/controllers/invitation_controller.rb
+++ b/app/controllers/invitation_controller.rb
@@ -21,7 +21,7 @@ class InvitationController < ApplicationController
   private
 
   def invitation_params
-    params[:workshop_invitation].present? ?  params.require(:workshop_invitation).permit(:tutorial, :note) : {}
+    params[:workshop_invitation].present? ? params.require(:workshop_invitation).permit(:tutorial, :note) : {}
   end
 
   def available_spaces?(workshop, invitation)

--- a/app/controllers/invitation_controller.rb
+++ b/app/controllers/invitation_controller.rb
@@ -11,20 +11,17 @@ class InvitationController < ApplicationController
   end
 
   def update
-    @invitation = WorkshopInvitation.find_by(token: params[:id])
+    @invitation.assign_attributes(invitation_params.merge!(attending: true, rsvp_time: Time.zone.now))
+    return back_with_message(@invitation.errors.full_messages) unless @invitation.valid?
 
-    if @invitation.role.eql?('Student') && new_note.blank?
-      redirect_to :back, notice: t('messages.error_blank_note')
-    else
-      @invitation.update(note: new_note)
-      redirect_to :back, notice: t('messages.updated_note')
-    end
+    @invitation.update(invitation_params)
+    back_with_message(t('messages.invitations.updated_details'))
   end
 
   private
 
-  def new_note
-    @invitation.role.eql?('Student') ? params[:note] : params[:workshop_invitation][:note]
+  def invitation_params
+    params[:workshop_invitation].present? ?  params.require(:workshop_invitation).permit(:tutorial, :note) : {}
   end
 
   def available_spaces?(workshop, invitation)

--- a/app/controllers/invitation_controller.rb
+++ b/app/controllers/invitation_controller.rb
@@ -29,7 +29,7 @@ class InvitationController < ApplicationController
       (invitation.role.eql?('Coach') && workshop.coach_spaces?)
   end
 
-  def set_invitation
-    @invitation = WorkshopInvitation.find_by(token: params[:id])
+  def token
+    params[:id]
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -43,7 +43,7 @@ class InvitationsController < ApplicationController
       redirect_to :back, notice: notice
     else
       email = event.chapters.present? ? event.chapters.first.email : 'hello@codebar.io'
-      redirect_to :back, notice: t('messages.no_available_seats', email: email)
+      redirect_to :back, notice: t('messages.invitations.event.no_available_seats', email: email)
     end
   end
 

--- a/app/controllers/waiting_lists_controller.rb
+++ b/app/controllers/waiting_lists_controller.rb
@@ -1,33 +1,29 @@
 class WaitingListsController < ApplicationController
+  include WorkshopInvitationConcerns
+
   def create
-    invitation.update_attribute(:note, note) if note.present?
-    WaitingList.add(invitation, auto_rsvp)
+    @invitation.assign_attributes(invitation_params)
+    return back_with_message(@invitatiaon.errors.full_messages) unless @invitation.valid?
+
+    @invitation.save && WaitingList.add(@invitation, auto_rsvp)
     message = auto_rsvp ? 'You have been added to the waiting list' :
-                          'We will send you an email if any spots become available'
-    redirect_to invitation_path(invitation), notice: message
+      'We will send you an email if any spots become available'
+    back_with_message(message)
   end
 
   def destroy
-    WaitingList.find_by(invitation_id: invitation.id).destroy
+    WaitingList.find_by(invitation_id: @invitation.id).destroy
 
-    redirect_to invitation_path(invitation), notice: 'You have been removed from the waiting list'
+    redirect_to invitation_path(@invitation), notice: 'You have been removed from the waiting list'
   end
 
   private
 
-  def invitation_token
+  def token
     params.permit(:invitation_id)[:invitation_id]
   end
 
   def auto_rsvp
     true
-  end
-
-  def note
-    params.key?(:invitation) ? params[:invitation][:note] : params[:note]
-  end
-
-  def invitation
-    @invitation ||= WorkshopInvitation.find_by(token: invitation_token)
   end
 end

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -7,6 +7,7 @@ class WorkshopInvitation < ActiveRecord::Base
   validates :workshop, :member, presence: true
   validates :member_id, uniqueness: { scope: %i[workshop_id role] }
   validates :role, inclusion: { in: %w[Student Coach], allow_nil: true }
+  validates :tutorial, presence: true, if: :student_rsvp?
 
   scope :year, ->(year) { joins(:workshop).where('EXTRACT(year FROM workshops.date_and_time) = ?', year) }
   scope :accepted, -> { where(attending: true) }
@@ -30,5 +31,9 @@ class WorkshopInvitation < ActiveRecord::Base
 
   def parent
     workshop
+  end
+
+  def student_rsvp?
+    for_student? && rsvp_time.present?
   end
 end

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -7,7 +7,7 @@ class WorkshopInvitation < ActiveRecord::Base
   validates :workshop, :member, presence: true
   validates :member_id, uniqueness: { scope: %i[workshop_id role] }
   validates :role, inclusion: { in: %w[Student Coach], allow_nil: true }
-  validates :tutorial, presence: true, if: :student_rsvp?
+  validates :tutorial, presence: true, if: :student_attending?
 
   scope :year, ->(year) { joins(:workshop).where('EXTRACT(year FROM workshops.date_and_time) = ?', year) }
   scope :accepted, -> { where(attending: true) }
@@ -33,7 +33,7 @@ class WorkshopInvitation < ActiveRecord::Base
     workshop
   end
 
-  def student_rsvp?
-    for_student? && rsvp_time.present?
+  def student_attending?
+    for_student? && attending.present?
   end
 end

--- a/app/presenters/member_presenter.rb
+++ b/app/presenters/member_presenter.rb
@@ -19,17 +19,17 @@ class MemberPresenter < BasePresenter
     opt_in_newsletter_at.present?
   end
 
-  def pairing_details_array(role, note)
-    role.eql?('Coach') ? coach_pairing_details : student_pairing_details(note)
+  def pairing_details_array(role, tutorial, note)
+    role.eql?('Coach') ? coach_pairing_details(note) : student_pairing_details(tutorial, note)
   end
 
   private
 
-  def coach_pairing_details
-    [newbie?, full_name, 'Coach', 'N/A', skill_list.to_s]
+  def coach_pairing_details(note)
+    [newbie?, full_name, 'Coach', 'N/A', note, skill_list.to_s]
   end
 
-  def student_pairing_details(note)
-    [newbie?, full_name, 'Student', note, 'N/A']
+  def student_pairing_details(tutorial, note)
+    [newbie?, full_name, 'Student', tutorial, note, 'N/A']
   end
 end

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -3,7 +3,7 @@ class WorkshopPresenter < EventPresenter
   include ActionView::Context
   include ActionView::Helpers::DateHelper
 
-  PAIRING_HEADINGS = ['New attendee', 'Name', 'Role', 'Study note', 'Skills'].freeze
+  PAIRING_HEADINGS = ['New attendee', 'Name', 'Role', 'Tutorial', 'Note', 'Skills'].freeze
 
   def self.decorate(workshop)
     return VirtualWorkshopPresenter.new(workshop) if workshop.virtual?
@@ -74,7 +74,7 @@ class WorkshopPresenter < EventPresenter
   def pairing_csv
     pairing_details = model.attendances.inject([PAIRING_HEADINGS]) do |content, invitation|
       member = MemberPresenter.new(invitation.member)
-      content << member.pairing_details_array(invitation.role, invitation.note)
+      content << member.pairing_details_array(invitation.role, invitation.tutorial, invitation.note)
     end
     generate_csv_from_array(pairing_details)
   end

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -27,6 +27,9 @@
               - else
                 = invitation.member.full_name
           %td.small-6.columns
+            -if invitation.tutorial?
+              %small Tutorial: #{invitation.tutorial}
+              %br
             -if invitation.note?
               %small=invitation.note
               %br

--- a/app/views/invitation/_waiting_list.html.haml
+++ b/app/views/invitation/_waiting_list.html.haml
@@ -2,20 +2,22 @@
   %p
     %label.warning.label The workshop is full.
   - if @invitation.for_student?
-    = simple_form_for :invitation, url: invitation_waiting_list_path(@invitation), method: :post do |f|
-      = f.input :note, label: "What do you plan to work on?", collection: @tutorial_titles, required: true, include_blank: true
-      %br
+    = simple_form_for @invitation, url: invitation_waiting_list_path(@invitation), method: :post do |f|
+      = f.input :tutorial, collection: @tutorial_titles, include_blank: true
+      = f.input :note, required: false, input_html: { rows: 3, maxlength: 100 }, hint: 'Anything else we should know?', placeholder: 'e.g. I need help understanding selectors'
       = f.button :submit, "Join the waiting list",  class: "button expand round"
   - else
-    =link_to "Join the waiting list", invitation_waiting_list_path(invitation), method: :post, class: 'button round expand', "data-confirm" => "If any spots become available you will automatically be allocated one."
-
+    = simple_form_for @invitation, url: invitation_waiting_list_path(@invitation), method: :post do |f|
+      = f.input :note, required: false, input_html: { rows: 3, maxlength: 100 }
+      = f.button :submit, "Join the waiting list",  class: "button expand round"
 - else
   .text-center Waiting List position: <strong>#{invitation.waiting_list_position}</strong>/#{@workshop.waiting_list_count_for(invitation.role)}
   %br
   - if @invitation.for_student?
-    - if @invitation.note.present?
-      %small You will be working on...
-      %p #{@invitation.note}
+    %small You will be working on...
+    %p #{@invitation.tutorial}
+  %p
+    #{@invitation.note}
 
   = link_to "Remove from the waiting list", invitation_waiting_list_path(invitation), method: :delete, class: 'button expand round alert', "data-confirm" => "Are you sure you want to let go of your spot? You cannot undo this."
 

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -31,12 +31,10 @@
         - else
           - if @invitation.attending.eql?(true)
             - if @invitation.for_student?
-              %p
-                %small You will be working on...
-                = form_tag invitation_path(@invitation), method: :put do
-                  = select_tag :note, options_for_select(@tutorial_titles, @invitation.note)
-                  %br
-                  = submit_tag 'Update note', class: "expand button small"
+              = simple_form_for @invitation, url: :invitation, method: :put do |f|
+                = f.input :tutorial, collection: @tutorial_titles, include_blank: true
+                = f.input :note, required: false, input_html: { rows: 3, maxlength: 100 }, hint: 'Anything else we should know?', placeholder: 'e.g. I need help understanding selectors'
+                = f.button :submit, "Update",  class: "button expand round"
             - if @invitation.for_coach?
               %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true', title: I18n.t('workshop_invitation.coach_skills_tooltip') }
                 %i.fa.fa-info
@@ -77,8 +75,8 @@
             - else
               - if @workshop.student_spaces?
                 = simple_form_for @invitation, url: :accept_invitation, method: :post do |f|
-                  = f.input :note, label: "What do you plan to work on?", collection: @tutorial_titles, required: true, include_blank: true
-                  %br
+                  = f.input :tutorial, collection: @tutorial_titles, include_blank: true
+                  = f.input :note, required: false, input_html: { rows: 3, maxlength: 100 }, hint: 'Anything else we should know?', placeholder: 'e.g. I need help understanding selectors'
                   = f.button :submit, "Attend",  class: "button expand round"
               - else
                 = render partial: 'invitation/waiting_list', locals: { invitation: @invitation }

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -33,10 +33,18 @@
             - if @invitation.for_student?
               %p
                 %small You will be working on...
-                = form_tag update_note_invitation_path(@invitation) do
+                = form_tag invitation_path(@invitation), method: :put do
                   = select_tag :note, options_for_select(@tutorial_titles, @invitation.note)
                   %br
                   = submit_tag 'Update note', class: "expand button small"
+            - if @invitation.for_coach?
+              %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true', title: I18n.t('workshop_invitation.coach_skills_tooltip') }
+                %i.fa.fa-info
+              =link_to 'Keep your skills up-to-date!', edit_member_path
+              %hr
+              = simple_form_for @invitation, url: :invitation, method: :put do |f|
+                = f.input :note, required: false, input_html: { rows: 3, maxlength: 100 }
+                = f.button :submit, "Update note",  class: "button expand round"
             - if @workshop.rsvp_available?
               = link_to "I can no longer attend", reject_invitation_url(@invitation), class: "expand button small alert"
             - else
@@ -56,12 +64,19 @@
           - else
             - if @invitation.for_coach?
               - if @workshop.coach_spaces?
-                = link_to "Attend", accept_invitation_url(@invitation), class: "expand button round center"
+                %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true', title: I18n.t('workshop_invitation.coach_skills_tooltip') }
+                  %i.fa.fa-info
+                =link_to 'Keep your skills up-to-date!', edit_member_path
+                %hr
+                = simple_form_for @invitation, url: :accept_invitation, method: :post do |f|
+                  = f.input :note, required: false, input_html: { rows: 3, maxlength: 100 }
+                  %br
+                  = f.button :submit, "Attend",  class: "button expand round"
               - else
                 = render partial: 'invitation/waiting_list', locals: { invitation: @invitation }
             - else
               - if @workshop.student_spaces?
-                = simple_form_for @invitation, url: :accept_with_note_invitation, method: :post do |f|
+                = simple_form_for @invitation, url: :accept_invitation, method: :post do |f|
                   = f.input :note, label: "What do you plan to work on?", collection: @tutorial_titles, required: true, include_blank: true
                   %br
                   = f.button :submit, "Attend",  class: "button expand round"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,8 @@ en:
       student_intro_2: 'In case you are unable to attend after you RSVP, please make sure you come back and update your attendance. We have limited space and do a coaches request depending on the number of attending students.'
       student_intro_3_html: 'Please make sure you <b>bring your laptop</b> with you.'
       shared_intro_4_html: 'PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us an email at %{email_link}.'
+  workshop_invitation:
+    coach_skills_tooltip: 'Keeping your skills up-to-date enables Organisers to plan ahead and makes running workshops easier.'
   meeting:
     title: "%{name} - %{date}"
   messages:
@@ -611,9 +613,13 @@ en:
         slack_channel: 'e.g. virtual-london-2022-12-03'
         slack_channel_link: 'e.g. https://codebar.slack.com/archives/CGLQD917T'
         description: 'Any details you would like to add about the workshop. This will be visible on both the public workshop and invitation pages'
+      workshop_invitation:
+        note: 'e.g. I am a Junior and would prefer to not be paired on advanced projects'
     hints:
       member:
         email: 'This is needed so we can email you invitations to our events'
+      workshop_invitation:
+        note: 'Pairing preferences or anything else you think we should know.'
       job:
         remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
@@ -631,6 +637,8 @@ en:
       workshop:
         description: Additional description
         virtual: Virtual workshop
+      workshop_invitation:
+        note: 'Note'
   activerecord:
     attributes:
       job:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,7 +145,7 @@ en:
     rejected_invitation: "We are so sad you can't make it, but thanks for letting us know %{name}."
     already_rsvped: "You have already confirmed you attendance!"
     not_attending_already: "You have already confirmed you can't make it!"
-    no_available_seats: "Unfortunately there are no more spaces left :(. If you would like to join our waiting list send us an email at %{email}"
+    no_available_seats: "There are no more spots left for this event, but you can join the waiting list."
     feedback_saved: "Thank you for taking the time to give us feedback!"
     feedback_not_found: "You have already submitted feedback for this event."
     updated_note: "Successfully updated note."
@@ -153,6 +153,8 @@ en:
       meeting:
         cancel: "Thanks for letting us know you can't make it."
         rsvp: "Your RSVP was successful. We look forward to seeing you at the Monthly!"
+      event:
+        no_available_seats: "No spaces left. If you would like to join our waiting list send us an email at %{email}"
       rsvped_to_other_workshop: "You have already RSVP'd to another workshop on this date. If you would prefer to attend this workshop, please cancel your other RSVP first."
       select_a_member_to_rsvp: "Select a member to RSVP"
       spot_confirmed: "Your spot has been confirmed for %{event}! We look forward to seeing you there."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,14 +141,12 @@ en:
     accepted_invitation: "Thanks for getting back to us %{name}. See you at the workshop!"
     already_invited: 'You have already RSVPd or joined the waitlist for this workshop.'
     already_taken_place: 'This event has already taken place'
-    error_blank_note: 'You must select a note'
     rejected_invitation: "We are so sad you can't make it, but thanks for letting us know %{name}."
     already_rsvped: "You have already confirmed you attendance!"
     not_attending_already: "You have already confirmed you can't make it!"
     no_available_seats: "There are no more spots left for this event, but you can join the waiting list."
     feedback_saved: "Thank you for taking the time to give us feedback!"
     feedback_not_found: "You have already submitted feedback for this event."
-    updated_note: "Successfully updated note."
     invitations:
       meeting:
         cancel: "Thanks for letting us know you can't make it."
@@ -159,6 +157,7 @@ en:
       select_a_member_to_rsvp: "Select a member to RSVP"
       spot_confirmed: "Your spot has been confirmed for %{event}! We look forward to seeing you there."
       spot_not_confirmed: 'Your spot has not yet been confirmed. We will verify your attendance after you complete the questionnaire.'
+      updated_details: "Invitation details successfully updated."
     invalid_format: "The requested format is invalid: %{invalid_format}"
   notifications:
     provider_already_connected: 'You are already signed in!'
@@ -658,6 +657,11 @@ en:
         newsletter: 'If you do not want to receive the codebar newsletter uncheck this box'
         pronouns: 'What pronouns do you use?'
     errors:
+      models:
+        workshop_invitation:
+          attributes:
+            tutorial:
+              blank: 'must be selected'
       messages:
         all_invitation_details_required: 'Fill in all invitations details to make the event invitable'
         already_sponsoring: 'already a sponsor'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,10 +42,9 @@ Planner::Application.routes.draw do
 
   get 'unsubscribe/:token' => 'members#unsubscribe', as: :unsubscribe
 
-  resources :invitation, only: [:show] do
+  resources :invitation, only: [:show, :update] do
     member do
-      post 'accept_with_note', as: :accept_with_note
-      post 'update_note'
+      post 'accept'
       get 'accept'
       get 'reject'
     end

--- a/db/migrate/20200521151343_add_tutorial_to_workshop_invitation.rb
+++ b/db/migrate/20200521151343_add_tutorial_to_workshop_invitation.rb
@@ -1,0 +1,5 @@
+class AddTutorialToWorkshopInvitation < ActiveRecord::Migration
+  def change
+    add_column :workshop_invitations, :tutorial, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -536,6 +536,7 @@ ActiveRecord::Schema.define(version: 20200522142646) do
     t.datetime "reminded_at"
     t.datetime "rsvp_time"
     t.boolean  "automated_rsvp"
+    t.text     "tutorial"
   end
 
   add_index "workshop_invitations", ["member_id"], name: "index_workshop_invitations_on_member_id", using: :btree

--- a/spec/fabricators/workshop_invitation_fabricator.rb
+++ b/spec/fabricators/workshop_invitation_fabricator.rb
@@ -9,10 +9,11 @@ end
 
 Fabricator(:attending_workshop_invitation, from: :workshop_invitation) do
   attending true
+  note { Faker::Lorem.word }
   reminded_at nil
 end
 
-Fabricator(:attended_workshop_invitation, from: :workshop_invitation) do
+Fabricator(:attended_workshop_invitation, from: :attending_workshop_invitation) do
   attended true
 end
 

--- a/spec/fabricators/workshop_invitation_fabricator.rb
+++ b/spec/fabricators/workshop_invitation_fabricator.rb
@@ -2,7 +2,7 @@ Fabricator(:workshop_invitation) do
   member
   attending nil
   attended nil
-  note { Faker::Lorem.word }
+  tutorial { Faker::Lorem.word }
   workshop
   role 'Student'
 end

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -18,24 +18,24 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
 
     context 'amend invitation details' do
       context 'a student' do
-        scenario 'logged in user with accepted invitation can edit the note' do
+        scenario 'logged in user with accepted invitation can edit the tutorial' do
           tutorial = Tutorial.create(title: 'Lesson 1 - Introducing HTML')
           invitation.update_attribute(:attending, true)
           visit invitation_route
 
-          select tutorial.title, from: 'note'
-          click_on 'Update note'
+          select tutorial.title, from: :workshop_invitation_tutorial
+          click_on 'Update'
 
-          expect(page).to have_content('Successfully updated note.')
+          expect(page).to have_content('Invitation details successfully updated.')
         end
 
-        scenario 'logged in user with accepted invitation errors without note' do
-          invitation.update_attribute(:attending, true)
+        scenario 'logged in user with accepted invitation errors without a tutorial' do
+          invitation.update(attending: true, tutorial: nil)
           visit invitation_route
 
-          click_on 'Update note'
+          click_on 'Update'
 
-          expect(page).to have_content('You must select a note')
+          expect(page).to have_content('Tutorial must be selected')
         end
       end
 
@@ -73,7 +73,7 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
           click_on 'Update note'
 
           expect(page).to have_field('workshop_invitation_note', with: note)
-          expect(page).to have_content("Successfully updated note.")
+          expect(page).to have_content("Invitation details successfully updated.")
         end
       end
     end

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -17,24 +17,64 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
     it_behaves_like 'invitation route'
 
     context 'amend invitation details' do
-      scenario 'logged in user with accepted invitation can edit the note' do
-        tutorial = Tutorial.create(title: 'Lesson 1 - Introducing HTML')
-        invitation.update_attribute(:attending, true)
-        visit invitation_route
+      context 'a student' do
+        scenario 'logged in user with accepted invitation can edit the note' do
+          tutorial = Tutorial.create(title: 'Lesson 1 - Introducing HTML')
+          invitation.update_attribute(:attending, true)
+          visit invitation_route
 
-        select tutorial.title, from: 'note'
-        click_on 'Update note'
+          select tutorial.title, from: 'note'
+          click_on 'Update note'
 
-        expect(page).to have_content('Successfully updated note.')
+          expect(page).to have_content('Successfully updated note.')
+        end
+
+        scenario 'logged in user with accepted invitation errors without note' do
+          invitation.update_attribute(:attending, true)
+          visit invitation_route
+
+          click_on 'Update note'
+
+          expect(page).to have_content('You must select a note')
+        end
       end
 
-      scenario 'logged in user with accepted invitation errors without note' do
-        invitation.update_attribute(:attending, true)
-        visit invitation_route
+      context 'a coach' do
+        let(:invitation) { Fabricate(:coach_workshop_invitation, member: member) }
+        let(:note) { 'I am most comfortable with being paired in JavaScript' }
 
-        click_on 'Update note'
+        scenario 'can accept their invitation without a note' do
+          visit invitation_route
 
-        expect(page).to have_content('You must select a note')
+          click_on 'Attend'
+
+          expect(page).to have_content("Thanks for getting back to us #{member.name}. See you at the workshop!")
+          expect(page).to have_field('workshop_invitation_note', with: '')
+        end
+
+        scenario 'can accept their invitation with a note' do
+          visit invitation_route
+
+          fill_in 'Note', with: note
+          click_on 'Attend'
+
+          expect(page).to have_content("Thanks for getting back to us #{member.name}. See you at the workshop!")
+          expect(page).to have_field('workshop_invitation_note', with: note)
+        end
+
+        scenario 'can update the note on their invitation' do
+          note = 'I am most comfortable with being paired in JavaScript'
+          invitation.update_attributes(note: 'A note', attending: true)
+          visit invitation_route
+
+          expect(page).to have_field('workshop_invitation_note', with: 'A note')
+
+          fill_in 'Note', with: note
+          click_on 'Update note'
+
+          expect(page).to have_field('workshop_invitation_note', with: note)
+          expect(page).to have_content("Successfully updated note.")
+        end
       end
     end
   end

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -7,19 +7,23 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
     let(:invitation_route) { invitation_path(invitation) }
     let(:accept_invitation_route) { accept_invitation_path(invitation) }
     let(:reject_invitation_route) { reject_invitation_path(invitation) }
-
     let(:set_no_available_slots) { invitation.workshop.host.update_attribute(:seats, 0) }
-
-    before(:each) do
-      login(member)
-    end
+    let!(:tutorial) { Fabricate(:tutorial) }
 
     it_behaves_like 'invitation route'
 
     context 'amend invitation details' do
       context 'a student' do
-        scenario 'logged in user with accepted invitation can edit the tutorial' do
-          tutorial = Tutorial.create(title: 'Lesson 1 - Introducing HTML')
+        scenario 'cannot accept an invitation  without a tutorial' do
+          invitation.update_attributes(attending: nil, tutorial: nil)
+          visit invitation_route
+
+          click_on 'Attend'
+
+          expect(page).to have_content('Tutorial must be selected')
+        end
+
+        scenario 'with an accepted invitation can edit the tutorial' do
           invitation.update_attribute(:attending, true)
           visit invitation_route
 
@@ -27,15 +31,6 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
           click_on 'Update'
 
           expect(page).to have_content('Invitation details successfully updated.')
-        end
-
-        scenario 'logged in user with accepted invitation errors without a tutorial' do
-          invitation.update(attending: true, tutorial: nil)
-          visit invitation_route
-
-          click_on 'Update'
-
-          expect(page).to have_content('Tutorial must be selected')
         end
       end
 

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -60,5 +60,14 @@ RSpec.feature 'managing workshop attendances', type: :feature do
       expect(page).to have_content(I18n.l(other_invitation.reload.rsvp_time))
       expect(page).to have_selector('i.fa-magic')
     end
+
+    scenario 'can view the tutorial and note set by an attendee' do
+      invitation = Fabricate(:attending_workshop_invitation, workshop: workshop)
+      login_as_admin(member)
+
+      visit admin_workshop_path(workshop)
+      expect(page).to have_content(invitation.note)
+      expect(page).to have_content(invitation.tutorial)
+    end
   end
 end

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Managing users', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:student) { Fabricate(:student) }
   let(:admin) { Fabricate(:chapter_organiser) }
-  let!(:invitation) { Fabricate(:attended_workshop_invitation, attending: true, member: member) }
+  let!(:invitation) { Fabricate(:attended_workshop_invitation, member: member) }
   let!(:attending_invitation) { Fabricate(:attending_workshop_invitation, member: member) }
 
   before do

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
         end
       end
 
-      scenario 'displays the correc timezone for the workshop' do
+      scenario 'displays the correct timezone for the workshop' do
         chapter = Fabricate(:chapter, time_zone: 'Berlin')
         visit new_admin_workshop_path
 

--- a/spec/features/managing_course_invitation_spec.rb
+++ b/spec/features/managing_course_invitation_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Managing a course invitation', type: :feature do
       visit accepting_invitation_path
 
       expect(current_url).to eq(root_url)
-      expect(page).to have_content('Unfortunately there are no more spaces left :(.')
+      expect(page).to have_content('There are no more spots left for this event, but you can join the waiting list')
     end
   end
 

--- a/spec/presenters/member_presenter_spec.rb
+++ b/spec/presenters/member_presenter_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe MemberPresenter do
 
   context '#pairing_details_array' do
     it 'returns student pairing information' do
-      expect(member_presenter.pairing_details_array('Student', 'Study note'))
-        .to eq([member_presenter.newbie?, member.full_name, 'Student', 'Study note', 'N/A'])
+      expect(member_presenter.pairing_details_array('Student', 'Tutorial', 'Note'))
+        .to eq([member_presenter.newbie?, member.full_name, 'Student', 'Tutorial', 'Note', 'N/A'])
     end
 
     it 'returns coach pairing information' do
-      expect(member_presenter.pairing_details_array('Coach', nil))
-        .to eq([member_presenter.newbie?, member.full_name, 'Coach', 'N/A', 'java, ruby'])
+      expect(member_presenter.pairing_details_array('Coach', nil, 'A note'))
+        .to eq([member_presenter.newbie?, member.full_name, 'Coach', 'N/A', 'A note', 'java, ruby'])
     end
   end
 end

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -105,10 +105,10 @@ RSpec.describe WorkshopPresenter do
   context '#pairing_csv' do
     let(:workshop) { double(:workshop, attendances: [invitation]) }
     let(:student) { Fabricate(:student) }
-    let(:invitation) { Fabricate(:workshop_invitation, member: student) }
+    let(:invitation) { Fabricate(:workshop_invitation, member: student, note: 'Note') }
 
     it 'returns a csv with all the details required to enable organisers to pair the participants' do
-      student_pairing_array = [true, student.full_name, 'Student', invitation.note, 'N/A']
+      student_pairing_array = [true, student.full_name, 'Student', invitation.tutorial, invitation.note, 'N/A']
       student_presenter = MemberPresenter.new(student)
 
       expect(presenter.pairing_csv)

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -9,8 +9,11 @@ RSpec.shared_examples 'invitation route' do
 
   context 'accept an invitation' do
     scenario 'when there are available spots' do
-      Tutorial.create(title: 'title')
+      tutorial = Fabricate(:tutorial)
       visit invitation_route
+
+      select tutorial.title, from: :workshop_invitation_tutorial if invitation.for_student?
+
       click_on 'Attend'
 
       expect(page).to have_link 'I can no longer attend'

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -9,7 +9,6 @@ RSpec.shared_examples 'invitation route' do
 
   context 'accept an invitation' do
     scenario 'when there are available spots' do
-      tutorial = Fabricate(:tutorial)
       visit invitation_route
 
       select tutorial.title, from: :workshop_invitation_tutorial if invitation.for_student?
@@ -30,13 +29,24 @@ RSpec.shared_examples 'invitation route' do
       end
     end
 
-    scenario 'they can RSVP directly through the invitation' do
-      Tutorial.create(title: 'title')
-      visit accept_invitation_route
+    context 'RSVPing directly through the invitation' do
+      scenario 'a Student must first select a tutorial' do
+        puts invitation.inspect
+        invitation.update_attributes(role: 'Student', attending: nil, tutorial: nil)
+        visit accept_invitation_route
 
-      expect(page).to have_link 'I can no longer attend'
-      expect(page.current_path).to eq(invitation_route)
-      expect(page).to have_content(I18n.t('messages.accepted_invitation', name: member.name))
+        expect(page).to_not have_link 'I can no longer attend'
+        expect(page).to have_content('Tutorial must be selected')
+      end
+
+      scenario 'a Coach must can RSVP diredctly' do
+        invitation.update_attributes(role: 'Coach', attending: nil, tutorial: nil)
+        visit accept_invitation_route
+
+        expect(page).to have_link 'I can no longer attend'
+        expect(page.current_path).to eq(invitation_route)
+        expect(page).to have_content(I18n.t('messages.accepted_invitation', name: member.name))
+      end
     end
 
     scenario 'when they have already RSVPed and are attempting to re-accept through the invitation link' do
@@ -113,9 +123,9 @@ RSpec.shared_examples 'invitation route' do
     end
 
     scenario 'when already RSVPd to another event on same evening' do
-      invitation.update(attending: true, member_id: member.id)
+      invitation.update(attending: true, member: member)
 
-      invitation2 = Fabricate(:coach_workshop_invitation)
+      invitation2 = Fabricate(:coach_workshop_invitation, member: member)
       invitation2_route = invitation_path(invitation2)
 
       visit invitation2_route
@@ -126,9 +136,9 @@ RSpec.shared_examples 'invitation route' do
     end
 
     scenario 'when already RSVPd to another event on same evening and attempting to RSVP directly through the link' do
-      invitation.update(attending: true, member_id: member.id)
+      invitation.update(attending: true, member: member)
 
-      invitation2 = Fabricate(:coach_workshop_invitation)
+      invitation2 = Fabricate(:coach_workshop_invitation, member: member)
       invitation2_route = invitation_path(invitation2)
 
       visit accept_invitation_path(invitation2)

--- a/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
+++ b/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
@@ -2,6 +2,8 @@ RSpec.shared_examples 'managing workshop attendance' do
   context 'a logged in member' do
     context '#upcoming workshop' do
       context 'via the workshop page' do
+        let!(:tutorial) { Fabricate(:tutorial) }
+
         context 'with only student subscriptions' do
           before do
             login(student)
@@ -10,6 +12,8 @@ RSpec.shared_examples 'managing workshop attendance' do
 
           it 'can only RSVP as a student' do
             click_on 'Attend as a student'
+
+            select tutorial.title, from: :workshop_invitation_tutorial
             click_on 'Attend'
 
             expect(page).to have_content('See you at the workshop')
@@ -55,6 +59,8 @@ RSpec.shared_examples 'managing workshop attendance' do
 
           it 'can get to the RSVP as a student page' do
             click_on 'Attend as a student'
+
+            select tutorial.title, from: :workshop_invitation_tutorial
             click_on 'Attend'
 
             expect(page).to have_content('See you at the workshop')


### PR DESCRIPTION
Resolves #1314 

- Enables student and coach to set a note when accepting an invitation
- Adds new `tutorial` field on `WorkshopInvitation` and updates functionality so that tutorial is now stored there instead of note
- Updates admin/workshop view to render both note and tutorial
- Updates WorkshopPresenter to include note and tutorial in generate Paring CSV
- Updates waiting list functionality to include tutorial for students and note for coaches
- Extract reusable functionality in `WorkshopInvitationConcerns`
- Updates to improve invitation tests

### student invitation
<img width="697" alt="student-invitation" src="https://user-images.githubusercontent.com/159200/82615811-44989600-9bc3-11ea-8fe4-71aaf8505b72.png">

### waiting list / student

<img width="490" alt="waiting_list_student" src="https://user-images.githubusercontent.com/159200/82729814-778d7780-9cf2-11ea-966c-0872aed3b57d.png">

### coach invitation
<img width="598" alt="coach-invitation-pre-rsvp" src="https://user-images.githubusercontent.com/159200/82615838-55e1a280-9bc3-11ea-867f-4e95195e1eb2.png">

### waiting list / coach
<img width="511" alt="waiting_list_coach" src="https://user-images.githubusercontent.com/159200/82729817-7b20fe80-9cf2-11ea-8043-292dff5c1ece.png">


### admin workshop / coach view
<img width="724" alt="admin-view-coach-note" src="https://user-images.githubusercontent.com/159200/82615870-6c87f980-9bc3-11ea-843f-4666a57e3798.png">

### admin workshop / student view
<img width="644" alt="admin-view-student-tutorial-and-note" src="https://user-images.githubusercontent.com/159200/82615883-77428e80-9bc3-11ea-89c0-51882e9b2714.png">
