### PR TITLE
Resolves production build error caused by removing coffee script

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Planner::Application.configure do
   config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
```
       Uglifier::Error: Unexpected token: punc ()). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).

       --

        42000 _gs('GSN-171446-A');

        42001 // Expand/collapse toggling for coach/student group subscriptions.

        42002 // Used in the new user signup flow, to stop too many options being

        42003 // presented.

        42004 

        42005 /* global $ */

        42006 

        42007 

           => $(() =>

        42009   $(".subscriptions .toggle").click(function (e) {

        42010     const $section = $(e.target).closest(".subscriptions");

        42011     const $container = $(".group-container", $section);

        42012     const $icon = $(".toggle i", $section);

        42013     $container.slideToggle(400, () => $container.toggleClass("collapsed"));

        42014     $icon.toggleClass("fa-chevron-right fa-chevron-down");

        42015   })

        42016 );

       ==

       /tmp/build_8504ef483f907aa8cd48398d2
```