### PR TITLE
Refactor workshop invitation

### DIFF
--- a/app/models/concerns/invitation_concerns.rb
+++ b/app/models/concerns/invitation_concerns.rb
@@ -9,7 +9,6 @@ module InvitationConcerns
     validates :token, uniqueness: true
 
     scope :accepted, -> { where(attending: true) }
-    scope :accepted_or_attended, -> { where('attending=? or attended=?', true, true) }
     scope :not_accepted, -> { where('attending is NULL or attending = false') }
 
     before_create :set_token

--- a/app/models/concerns/invitation_concerns.rb
+++ b/app/models/concerns/invitation_concerns.rb
@@ -6,13 +6,13 @@ module InvitationConcerns
 
     belongs_to :member
 
-    before_create :set_token
-
     validates :token, uniqueness: true
 
     scope :accepted, -> { where(attending: true) }
     scope :accepted_or_attended, -> { where('attending=? or attended=?', true, true) }
     scope :not_accepted, -> { where('attending is NULL or attending = false') }
+
+    before_create :set_token
   end
 
   module InstanceMethods

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,13 +1,13 @@
 class Invitation < ActiveRecord::Base
   include InvitationConcerns
 
-  validates :event, :member, presence: true
-  validates :member_id, uniqueness: { scope: %i[event_id role] }
-  validates :role, inclusion: { in: %w[Student Coach] }
-
   belongs_to :event
   belongs_to :member
   belongs_to :verified_by, class_name: 'Member'
+
+  validates :event, :member, presence: true
+  validates :member_id, uniqueness: { scope: %i[event_id role] }
+  validates :role, inclusion: { in: %w[Student Coach] }
 
   scope :students, -> { where(role: 'Student') }
   scope :coaches, -> { where(role: 'Coach') }

--- a/app/models/meeting_invitation.rb
+++ b/app/models/meeting_invitation.rb
@@ -1,11 +1,11 @@
 class MeetingInvitation < ActiveRecord::Base
   include InvitationConcerns
 
-  validates :meeting, :member, presence: true
-  validates :member_id, uniqueness: { scope: [:meeting_id] }
-
   belongs_to :meeting
   belongs_to :member
+
+  validates :meeting, :member, presence: true
+  validates :member_id, uniqueness: { scope: [:meeting_id] }
 
   scope :accepted, -> { where(attending: true) }
   scope :attended, -> { where(attended: true) }

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -11,6 +11,7 @@ class WorkshopInvitation < ActiveRecord::Base
   scope :year, ->(year) { joins(:workshop).where('EXTRACT(year FROM workshops.date_and_time) = ?', year) }
   scope :accepted, -> { where(attending: true) }
   scope :attended, -> { where(attended: true) }
+  scope :accepted_or_attended, -> { where('attending=? or attended=?', true, true) }
   scope :to_students, -> { where(role: 'Student') }
   scope :to_coaches, -> { where(role: 'Coach') }
   scope :order_by_latest, -> { joins(:workshop).order('workshops.date_and_time desc') }

--- a/spec/models/course_invitation_spec.rb
+++ b/spec/models/course_invitation_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe CourseInvitation, type: :model  do
   let(:invitation) { Fabricate(:course_invitation) }
   it_behaves_like InvitationConcerns, :course_invitation
 
+  context 'defaults' do
+    it { is_expected.to have_attributes(attending: nil) }
+    it { is_expected.to have_attributes(attended: nil) }
+  end
+
   context 'validates' do
     it { is_expected.to validate_presence_of(:course) }
     it { is_expected.to validate_presence_of(:member) }

--- a/spec/models/course_invitation_spec.rb
+++ b/spec/models/course_invitation_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 RSpec.describe CourseInvitation, type: :model  do
   let(:invitation) { Fabricate(:course_invitation) }
-  let!(:accepted_invitation) { 2.times { Fabricate(:course_invitation, attending: true) } }
-
-  it_behaves_like InvitationConcerns
+  it_behaves_like InvitationConcerns, :course_invitation
 
   context '#role' do
     it 'sets the role to Student' do

--- a/spec/models/course_invitation_spec.rb
+++ b/spec/models/course_invitation_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe CourseInvitation, type: :model  do
   let(:invitation) { Fabricate(:course_invitation) }
   it_behaves_like InvitationConcerns, :course_invitation
 
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:course) }
+    it { is_expected.to validate_presence_of(:member) }
+  end
+
   context '#role' do
     it 'sets the role to Student' do
       expect(invitation.role).to eq('Student')

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -4,15 +4,10 @@ RSpec.describe Invitation, type: :model  do
   it_behaves_like InvitationConcerns, :invitation
 
   context 'validations' do
-    subject { Invitation.new }
-
-    it '#event' do
-      should have(1).error_on(:event)
-    end
-
-    it '#role' do
-      should have(1).error_on(:role)
-    end
+    it { is_expected.to validate_presence_of(:event) }
+    it { is_expected.to validate_presence_of(:member) }
+    it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:event_id, :role) }
+    it { is_expected.to validate_inclusion_of(:role).in_array(['Student', 'Coach']) }
   end
 
   context '#student_spaces?' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 RSpec.describe Invitation, type: :model  do
   it_behaves_like InvitationConcerns, :invitation
 
+  context 'defaults' do
+    it { is_expected.to have_attributes(attending: nil) }
+  end
+
   context 'validations' do
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:member) }

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Invitation, type: :model  do
+  it_behaves_like InvitationConcerns, :invitation
+
   context 'validations' do
     subject { Invitation.new }
 

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe MeetingInvitation, type: :model  do
+  it_behaves_like InvitationConcerns, :meeting_invitation
+end

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -2,4 +2,10 @@ require 'spec_helper'
 
 RSpec.describe MeetingInvitation, type: :model  do
   it_behaves_like InvitationConcerns, :meeting_invitation
+
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:meeting) }
+    it { is_expected.to validate_presence_of(:member) }
+    it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:meeting_id) }
+  end
 end

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 RSpec.describe MeetingInvitation, type: :model  do
   it_behaves_like InvitationConcerns, :meeting_invitation
 
+  context 'defaults' do
+    it { is_expected.to have_attributes(attending: nil) }
+    it { is_expected.to have_attributes(attended: false) }
+  end
+
   context 'validates' do
     it { is_expected.to validate_presence_of(:meeting) }
     it { is_expected.to validate_presence_of(:member) }

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -12,6 +12,38 @@ RSpec.describe WorkshopInvitation, type: :model  do
       expect(WorkshopInvitation.attended.count).to eq(4)
     end
 
+    context '#accepted_or_attended' do
+      it 'ignores when attending nil and attended nil' do
+        Fabricate(:workshop_invitation, attending: nil, attended: nil)
+
+        expect(WorkshopInvitation.accepted_or_attended).to eq []
+      end
+
+      it 'ignores when attending false and attended false' do
+        Fabricate(:workshop_invitation, attending: false, attended: false)
+
+        expect(WorkshopInvitation.accepted_or_attended).to eq []
+      end
+
+      it 'selects when attending false and attended true' do
+        invitation = Fabricate(:workshop_invitation, attending: false, attended: true)
+
+        expect(WorkshopInvitation.accepted_or_attended).to include(invitation)
+      end
+
+      it 'selects when attending true and attended false' do
+        invitation = Fabricate(:workshop_invitation, attending: true, attended: false)
+
+        expect(WorkshopInvitation.accepted_or_attended).to include(invitation)
+      end
+
+      it 'selects when attending true and attended true' do
+        invitation = Fabricate(:workshop_invitation, attending: true, attended: true)
+
+        expect(WorkshopInvitation.accepted_or_attended).to include(invitation)
+      end
+    end
+
     it '#not_accepted' do
       4.times { Fabricate(:workshop_invitation, attending: nil) }
       4.times { Fabricate(:workshop_invitation, attending: false) }

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,15 +1,33 @@
 require 'spec_helper'
 
 RSpec.describe WorkshopInvitation, type: :model  do
-  context 'methods' do
-    it_behaves_like InvitationConcerns, :workshop_invitation
+  it_behaves_like InvitationConcerns, :workshop_invitation
+
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:workshop) }
+    it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:workshop_id, :role) }
+    it { is_expected.to validate_inclusion_of(:role).in_array(['Student', 'Coach']) }
   end
 
   context 'scopes' do
-    it '#attended' do
-      4.times { Fabricate(:attended_workshop_invitation) }
+    context '#attended' do
+      it 'ignores when attended nil' do
+        Fabricate(:workshop_invitation, attended: nil)
 
-      expect(WorkshopInvitation.attended.count).to eq(4)
+        expect(WorkshopInvitation.attended).to eq []
+      end
+
+      it 'ignores when attended false' do
+        Fabricate(:workshop_invitation, attended: false)
+
+        expect(WorkshopInvitation.attended).to eq []
+      end
+
+      it 'selects when attended true' do
+        invitation = Fabricate(:workshop_invitation, attended: true)
+
+        expect(WorkshopInvitation.attended).to include(invitation)
+      end
     end
 
     context '#accepted_or_attended' do
@@ -42,25 +60,6 @@ RSpec.describe WorkshopInvitation, type: :model  do
 
         expect(WorkshopInvitation.accepted_or_attended).to include(invitation)
       end
-    end
-
-    it '#not_accepted' do
-      4.times { Fabricate(:workshop_invitation, attending: nil) }
-      4.times { Fabricate(:workshop_invitation, attending: false) }
-
-      expect(WorkshopInvitation.not_accepted.count).to eq(8)
-    end
-
-    it '#to_coaches' do
-      6.times { Fabricate(:coach_workshop_invitation) }
-
-      expect(WorkshopInvitation.to_coaches.count).to eq(6)
-    end
-
-    it '#to_student' do
-      4.times { Fabricate(:student_workshop_invitation) }
-
-      expect(WorkshopInvitation.to_students.count).to eq(4)
     end
 
     it '#year' do

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 RSpec.describe WorkshopInvitation, type: :model  do
   it_behaves_like InvitationConcerns, :workshop_invitation
 
+  context 'defaults' do
+    it { is_expected.to have_attributes(attending: nil) }
+    it { is_expected.to have_attributes(attended: nil) }
+  end
+
   context 'validates' do
     it { is_expected.to validate_presence_of(:workshop) }
     it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:workshop_id, :role) }

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -2,10 +2,7 @@ require 'spec_helper'
 
 RSpec.describe WorkshopInvitation, type: :model  do
   context 'methods' do
-    let(:invitation) { Fabricate(:student_workshop_invitation) }
-    let!(:accepted_invitation) { 2.times { Fabricate(:workshop_invitation, attending: true) } }
-
-    it_behaves_like InvitationConcerns
+    it_behaves_like InvitationConcerns, :workshop_invitation
   end
 
   context 'scopes' do

--- a/spec/support/shared_examples/behaves_like_an_invitation.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation.rb
@@ -1,11 +1,49 @@
-RSpec.shared_examples InvitationConcerns do
+RSpec.shared_examples InvitationConcerns do |invitation_type|
+  let(:invitation_constant) { invitation_type.to_s.camelize.constantize }
+  let(:invitation) { Fabricate(invitation_type) }
   it 'has a token set on creation' do
     expect(invitation.token).to_not be(nil)
   end
 
   context '#scopes' do
-    it '#accepted' do
-      expect(invitation.class.accepted.length).to eq(2)
+    context '#accepted' do
+      it 'ignores when attending nil' do
+        Fabricate(invitation_type, attending: nil)
+
+        expect(invitation_constant.accepted).to eq []
+      end
+
+      it 'ignores when attending false' do
+        Fabricate(invitation_type, attending: false)
+
+        expect(invitation_constant.accepted).to eq []
+      end
+
+      it 'selects when attending true' do
+        invitation = Fabricate(invitation_type, attending: true)
+
+        expect(invitation_constant.accepted).to include(invitation)
+      end
+    end
+
+    context '#not_accepted' do
+      it 'selects when attended nil' do
+        Fabricate(invitation_type, attending: nil)
+
+        expect(invitation_constant.not_accepted).to include(invitation)
+      end
+
+      it 'selects when attended false' do
+        Fabricate(invitation_type, attending: false)
+
+        expect(invitation_constant.not_accepted).to include(invitation)
+      end
+
+      it 'ignores when attended true' do
+        invitation = Fabricate(invitation_type, attending: true)
+
+        expect(invitation_constant.not_accepted).to eq []
+      end
     end
   end
 end


### PR DESCRIPTION
I'm working through Invitation modules with the aim of changing the boolean default nils to true or false as appropriate. This is the setup work so that I can look at what's involved in updating the migration.

- 8873de2 - ordering modules code blocks  so [include => assocation => validates => scope => methods ](https://stackoverflow.com/a/16967431/1511504)
- 42b7ded - testing of the concern 
- 272327b - moved accepted_or_attended from concern because it can't work with Invitation as it doesn't have `accepted`. It is only used by `WorkshopInvitation`
- 1abec50 - testing WorkshopInvitation 
- 7581dce - validation of Invitation / MeetingInvitation / CourseInvitation 
- 520ca95 - test to show where we are with the nils ...