### PR TITLE
Fix relative RSVP date text

### DIFF
--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -42,7 +42,10 @@
         %h3
           %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
         - if @workshop.rsvp_opens_at
-          RSVPs will open at
+          - if @workshop.open_for_rsvp?
+            RSVPs opened at
+          - else
+            RSVPs will open at
           = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')
           %br
           %br

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -42,13 +42,12 @@
         %h3
           %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
         - if @workshop.rsvp_opens_at
-          - if @workshop.open_for_rsvp?
-            RSVPs opened at
-          - else
-            RSVPs will open at
-          = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')
-          %br
-          %br
+          %div{style: "margin-bottom: 2em"}
+            - if @workshop.open_for_rsvp?
+              RSVPs opened at
+            - else
+              RSVPs will open at
+            = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')
         - if @workshop.venue.present? || @workshop.virtual?
           %strong.label.round.primary #{@workshop.student_spaces} student spots, #{@workshop.coach_spaces} coach spots
           - unless @workshop.spaces?

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -42,7 +42,7 @@
         %h3
           %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
         - if @workshop.rsvp_opens_at
-          %div{style: "margin-bottom: 2em"}
+          %div.mb2
             - if @workshop.open_for_rsvp?
               RSVPs opened at
             - else


### PR DESCRIPTION
Half of #1278. Just makes sure that we say `RSVPs opened at [date]` when the date was in the past and `RSVPs will open at [date]` when the date is in the future.

I had trouble with the rest of the issue. Finding where `invitable?` is defined is not apparent to me but I might just not understand how this codebase is structured. I've also never seen HAML before and I got to admit that I think I prefer plain old HTML or ERB instead of it 😅 