### PR TITLE
[WIP] (Fix) Allow original exception to be seen outside of production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   rescue_from Exception do |ex|
     Rollbar.error(ex)
     Rails.logger.fatal(ex)
+    raise unless Rails.env.production?
+
     respond_to do |format|
       format.html { render 'errors/error', layout: false, status: :internal_server_error }
       format.all  { render nothing: true, status: :internal_server_error }


### PR DESCRIPTION
Note: Changes creates an error in development on my local machine. I need to find out why ...
---
 - currently the exception block is giving the error page in every
   environment. This is bad because during development and testing
   it is helpful to see the stack trace.
 - fix allows you to see the stack trace in not production.
 - Note: if you have a staging environment so:
   Rails.env.staging?
   => true
   You would want to change this code. The alternative form is
   raise if Rails.env.production? || Rails.env.test?

### Before / Bad 👎 

```ruby
  1) viewing a course i can view a course's information
     Failure/Error: expect(page).to have_content course.title
       expected to find text "Et amet soluta repudiandae." in "Something went wrong\nIf the problem persists please get in touch with us on Slack.\nIn the meantime why don't you join our community on Slack?"
     # ./spec/features/viewing_a_course_spec.rb:10:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:80:in `block (2 levels) in <top (required)>'
```

### After / Good  👍 
```ruby
  1) viewing a course i can view a course's information
     Failure/Error: - if @course.past?
     
     ActionView::Template::Error:
       undefined method `past?' for #<CoursePresenter:0x00007fd162477b98>
     # ./app/views/courses/show.html.haml:8:in `_app_views_courses_show_html_haml__615509449984628271_70268647366560'
     # ./spec/features/viewing_a_course_spec.rb:8:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:80:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # NoMethodError:
     #   undefined method `past?' for #<CoursePresenter:0x00007fd162477b98>
     #   ./app/views/courses/show.html.haml:8:in `_app_views_courses_show_html_haml__615509449984628271_70268647366560'
```
