### PR TITLE
DateTimeConcerns Review

### DIFF
--- a/app/models/concerns/date_time_concerns.rb
+++ b/app/models/concerns/date_time_concerns.rb
@@ -23,7 +23,7 @@ module DateTimeConcerns
     end
 
     def time
-      date_and_time.try(:time)
+      date_and_time&.time
     end
 
     def date_and_time

--- a/app/models/concerns/date_time_concerns.rb
+++ b/app/models/concerns/date_time_concerns.rb
@@ -38,16 +38,18 @@ module DateTimeConcerns
       super.in_time_zone(time_zone)
     end
 
+    def past?
+      date_and_time < Time.zone.today
+    end
+
+    private
+
     def datetime_from_fields(date_string, time_string)
       return nil if date_string.blank? || time_string.blank? || !time_zone
 
       date = Date.parse(date_string)
       time = Time.zone.parse(time_string)
       ActiveSupport::TimeZone[time_zone].local(date.year, date.month, date.day, time.hour, time.min)
-    end
-
-    def past?
-      date_and_time < Time.zone.today
     end
   end
 end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Meeting, type: :model  do
   include_examples "Invitable", :meeting_invitation, :meeting
+  include_examples DateTimeConcerns, :meeting
 
   context 'validations' do
     subject { Meeting.new }

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -41,14 +41,6 @@ RSpec.describe Meeting, type: :model  do
     end
   end
 
-  context '#date' do
-    it 'returns the date of the meeting in :dashboard format' do
-      meeting = Fabricate(:meeting, date_and_time: Time.zone.local(2018, 8, 22, 18, 30))
-
-      expect(meeting.date).to eq('Wednesday, Aug 22')
-    end
-  end
-
   context '#not_full' do
     it 'returns true if meeting is not full' do
       meeting = Fabricate(:meeting)
@@ -62,14 +54,6 @@ RSpec.describe Meeting, type: :model  do
       Fabricate.times(21, :attending_meeting_invitation, meeting: meeting)
 
       expect(meeting.not_full).to eq(false)
-    end
-  end
-
-  context '#past?' do
-    it 'checks whether the meeting already happened' do
-      meeting = Fabricate(:meeting, date_and_time: Time.zone.local(2018, 8, 20, 18, 30))
-
-      expect(meeting.past?).to eq(true)
     end
   end
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe Workshop, type: :model do
   subject(:workshop) { Fabricate(:workshop) }
   include_examples "Invitable", :workshop_invitation, :workshop
+  include_examples DateTimeConcerns, :workshop
 
   context 'validates' do
     it { is_expected.to validate_presence_of(:chapter_id) }

--- a/spec/support/shared_examples/behaves_like_date_time_concerns.rb
+++ b/spec/support/shared_examples/behaves_like_date_time_concerns.rb
@@ -16,10 +16,19 @@ RSpec.shared_examples DateTimeConcerns do |date_time_type|
     expect(date_time_able.date).to eq('Wednesday, Aug 22')
   end
 
-  it '#time returns Time object' do
-    travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
-      date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.now)
-      expect(date_time_able.time).to eq Time.zone.local(2010, 12, 31, 23, 59, 42)
+  context '#time' do
+    it 'returns nil if not available' do
+      travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+        date_time_able = Fabricate.build(date_time_type, date_and_time: nil)
+        expect(date_time_able.time).to be_nil
+      end
+    end
+
+    it 'returns Time object' do
+      travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+        date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.now)
+        expect(date_time_able.time).to eq Time.zone.local(2010, 12, 31, 23, 59, 42)
+      end
     end
   end
 

--- a/spec/support/shared_examples/behaves_like_date_time_concerns.rb
+++ b/spec/support/shared_examples/behaves_like_date_time_concerns.rb
@@ -1,0 +1,50 @@
+RSpec.shared_examples DateTimeConcerns do |date_time_type|
+  let(:date_time_able_type) { date_time_type.to_s.camelize.constantize }
+
+  it { is_expected.to respond_to(:future?) }
+
+  it '#date returns formatted date' do
+    travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+      date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.now)
+      expect(date_time_able.date).to eq 'Friday, Dec 31'
+    end
+  end
+
+  it '#date returns the date in dashboard format' do
+    date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.local(2018, 8, 22, 18, 30))
+
+    expect(date_time_able.date).to eq('Wednesday, Aug 22')
+  end
+
+  it '#time returns Time object' do
+    travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+      date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.now)
+      expect(date_time_able.time).to eq Time.zone.local(2010, 12, 31, 23, 59, 42)
+    end
+  end
+
+  it '#date_and_time returns TimeWithZone' do
+    travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+      date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.now)
+      expect(date_time_able.date_and_time).to eq Time.zone.local(2010, 12, 31, 23, 59, 42)
+    end
+  end
+
+  context '#past?' do
+    it 'returns true for object with datetime before today' do
+      travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+        date_time_able = Fabricate(date_time_type,
+                                   date_and_time: Time.zone.local(2010, 12, 30, 23, 59, 59))
+        expect(date_time_able.past?).to be true
+      end
+    end
+
+    it 'returns false for object with datetime from today' do
+      travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
+        date_time_able = Fabricate(date_time_type,
+                                   date_and_time: Time.zone.local(2010, 12, 31, 0, 0, 0))
+        expect(date_time_able.past?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
- (Refactor) DateTimeConcern move code to private
  - improve readability
- DateTimeConcerns tested
   - main work
    - I use `travel_to` because it's easier to follow. If I use `Time.zone.now` the tests are constantly changing.
- (refactor) Prefer safe navigation operator over try