### PR TITLE
Some small fixes for the new job page

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -200,10 +200,6 @@ form .hint {
   margin-bottom: 0.5rem;
 }
 
-.breadcrumbs {
-  background-color: none;
-}
-
 .chosen-dropwdown {
   margin-bottom: 1.14286rem;
 }

--- a/app/views/member/jobs/new.html.haml
+++ b/app/views/member/jobs/new.html.haml
@@ -4,7 +4,8 @@
       .large-12.columns
         %br
         %ul.breadcrumbs
-          %li=link_to  t('member.jobs.title'), member_jobs_path
+          %li
+            %span=link_to t('member.jobs.title'), member_jobs_path
           %li.current
             %span=t('member.jobs.new.title')
 

--- a/app/views/member/jobs/new.html.haml
+++ b/app/views/member/jobs/new.html.haml
@@ -31,7 +31,7 @@
               %label{for: 'short'}= t('member.jobs.new.short')
             %li
               %input#donation{type: 'checkbox'}
-              %label{for: 'donation'}= t('member.jobs.new.pay', link: link_to(t('member.jobs.new.donation'), new_donation_path)).html_safe
+              %label{for: 'donation'}= t('member.jobs.new.pay.html', link: new_donation_path)
 
     %br
     .row

--- a/app/views/member/jobs/new.html.haml
+++ b/app/views/member/jobs/new.html.haml
@@ -30,8 +30,8 @@
               %input#short{type: 'checkbox'}
               %label{for: 'short'}= t('member.jobs.new.short')
             %li
-              %input#short{type: 'checkbox'}
-              %label{for: 'pay'}= t('member.jobs.new.pay', link: link_to(t('member.jobs.new.donation'), new_donation_path)).html_safe
+              %input#donation{type: 'checkbox'}
+              %label{for: 'donation'}= t('member.jobs.new.pay', link: link_to(t('member.jobs.new.donation'), new_donation_path)).html_safe
 
     %br
     .row

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -366,8 +366,8 @@ de:
         salary: der Job ein angemessenes Gehalt bietet
         short: "der Eintrag kurz und auf den Punkt ist"
         approval_info: "*Nach dem Abschicken wird der Job sichtbar sobald er geprüft und bestätigt wurde."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -455,8 +455,8 @@ en:
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
         optional_details_message: "The information below is only required if you want this job post to be shared with Google Search UK."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -366,8 +366,8 @@ en-AU:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -366,8 +366,8 @@ en-GB:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -364,8 +364,8 @@ en-US:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -366,8 +366,8 @@ es:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -366,8 +366,8 @@ fi:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -366,8 +366,8 @@ fr:
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -366,8 +366,8 @@
         salary: The job pays an appropriate salary
         short: "It's short and to the point"
         approval_info: "*Once submitted, a job will be visible once it has been reviewed and approved."
-        pay: You have made the required payment of £50 through %{link}
-        donation: a donation
+        pay: 
+          html: You have made the required payment of £50 through <a href="%{link}">a donation</a>.
         button:
           pay: Make a payment
       edit:


### PR DESCRIPTION
Some small fixes to issues I've noticed on the `/jobs/new` page.

#### e381c44

Fixes an issue where you'd click the label of one checkbox and the wrong checkbox would be toggled.

![Screen Recording 2020-05-26 at 19 57 48](https://user-images.githubusercontent.com/318208/82939724-a4a88700-9f8b-11ea-99a0-bb8ab23cbe84.gif)

#### efdf2da

Keys named `html` are marked as [HTML safe](https://guides.rubyonrails.org/v4.2/i18n.html#using-safe-html-translations). This change pushes the HTML rendering into the i18n translation files and merges the two i18n values into one.

#### 4dc5f7d

Remove CSS rule that doesn't do anything because it's invalid.

####  2009fbd

##### Before

![image](https://user-images.githubusercontent.com/318208/82939635-89d61280-9f8b-11ea-9dd0-b292d64a1e08.png)

##### After

![image](https://user-images.githubusercontent.com/318208/82939659-90648a00-9f8b-11ea-8932-e7e1043f055e.png)