### PR TITLE
DateTimeConcern#past? renamed to before_today?

### DIFF
--- a/app/models/concerns/date_time_concerns.rb
+++ b/app/models/concerns/date_time_concerns.rb
@@ -38,7 +38,7 @@ module DateTimeConcerns
       super.in_time_zone(time_zone)
     end
 
-    def past?
+    def before_today?
       date_and_time < Time.zone.today
     end
 

--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -54,7 +54,7 @@ class WorkshopPresenter < EventPresenter
   end
 
   def distance_of_time
-    return "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" if past?
+    return "(#{distance_of_time_in_words_to_now(date_and_time)} ago)" if before_today?
 
     "(in #{distance_of_time_in_words_to_now(date_and_time)})"
   end

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -25,5 +25,5 @@
               - workshop.sponsors.each do |sponsor|
                 = link_to sponsor.name, sponsor.website
             %td
-              - if workshop.date_and_time.future?
+              - if workshop.future?
                 %label.label upcoming

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -2,7 +2,7 @@
   = link_to edit_admin_workshop_path(@workshop), class: 'item' do
     %i.fa.fa-pencil
     %label Edit
-  - if !@workshop.date_and_time.future?
+  - if !@workshop.future?
     = link_to '#', class: 'item disabled', title: t('messages.already_taken_place') do
       %i.fa.fa-send-o
       %label Invite

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -7,7 +7,7 @@
         = @workshop.title
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
-      - if @workshop.date_and_time.past?
+      - if @workshop.past?
         %label.label.warning= t('messages.already_taken_place')
 .alert-box.info
   .row

--- a/app/views/invitation/show.html.haml
+++ b/app/views/invitation/show.html.haml
@@ -7,7 +7,7 @@
         = @workshop.title
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
-      - if @workshop.past?
+      - if @workshop.before_today?
         %label.label.warning= t('messages.already_taken_place')
 .alert-box.info
   .row
@@ -26,7 +26,7 @@
 
     .medium-5.large-4.columns
       .panel
-        - if @workshop.past?
+        - if @workshop.before_today?
           %em= t('workshops.already_taken_place')
         - else
           - if @invitation.attending.eql?(true)

--- a/app/views/meetings/_meeting_actions.html.haml
+++ b/app/views/meetings/_meeting_actions.html.haml
@@ -16,7 +16,7 @@
   %h4 RSVP
 
   - if logged_in?
-    - if @meeting.past?
+    - if @meeting.before_today?
       %p This event has already occurred.
 
     - elsif current_user.banned?

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -9,7 +9,7 @@
         = t('workshops.virtual.title', chapter: @workshop.chapter.name)
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
-      - if @workshop.date_and_time.past?
+      - if @workshop.past?
         %label.label.warning= t('messages.already_taken_place')
 
   %section#banner

--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -9,7 +9,7 @@
         = t('workshops.virtual.title', chapter: @workshop.chapter.name)
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
-      - if @workshop.past?
+      - if @workshop.before_today?
         %label.label.warning= t('messages.already_taken_place')
 
   %section#banner

--- a/app/views/workshops/_actions.html.haml
+++ b/app/views/workshops/_actions.html.haml
@@ -2,7 +2,7 @@
   %p
     %label.label.info= t('workshops.not_open_for_rsvp')
 - else
-  - if @workshop.past? and !logged_in?
+  - if @workshop.before_today? and !logged_in?
     %p= t('workshops.sign_up_to_be_invited')
   - else
     - if logged_in?

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -9,7 +9,7 @@
         = t('workshops.title', host: @workshop.host.name)
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
-      - if @workshop.past?
+      - if @workshop.before_today?
         %label.label.warning= t('messages.already_taken_place')
   %section#banner
     .row

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -9,7 +9,7 @@
         = t('workshops.title', host: @workshop.host.name)
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
-      - if @workshop.date_and_time.past?
+      - if @workshop.past?
         %label.label.warning= t('messages.already_taken_place')
   %section#banner
     .row

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe Meeting, type: :model  do
     end
   end
 
+  context '#before_today?' do
+    it 'checks whether the meeting already happened' do
+      meeting = Fabricate(:meeting, date_and_time: Time.zone.local(2018, 8, 20, 18, 30))
+
+      expect(meeting.before_today?).to eq(true)
+    end
+  end
+
   context '#attendees_csv' do
     it 'generates a csv of attendees' do
       meeting = Fabricate(:meeting)

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -65,14 +65,6 @@ RSpec.describe Meeting, type: :model  do
     end
   end
 
-  context '#before_today?' do
-    it 'checks whether the meeting already happened' do
-      meeting = Fabricate(:meeting, date_and_time: Time.zone.local(2018, 8, 20, 18, 30))
-
-      expect(meeting.before_today?).to eq(true)
-    end
-  end
-
   context '#attendees_csv' do
     it 'generates a csv of attendees' do
       meeting = Fabricate(:meeting)

--- a/spec/support/shared_examples/behaves_like_date_time_concerns.rb
+++ b/spec/support/shared_examples/behaves_like_date_time_concerns.rb
@@ -39,12 +39,12 @@ RSpec.shared_examples DateTimeConcerns do |date_time_type|
     end
   end
 
-  context '#past?' do
+  context '#before_today?' do
     it 'returns true for object with datetime before today' do
       travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
         date_time_able = Fabricate(date_time_type,
                                    date_and_time: Time.zone.local(2010, 12, 30, 23, 59, 59))
-        expect(date_time_able.past?).to be true
+        expect(date_time_able.before_today?).to be true
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.shared_examples DateTimeConcerns do |date_time_type|
       travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
         date_time_able = Fabricate(date_time_type,
                                    date_and_time: Time.zone.local(2010, 12, 31, 0, 0, 0))
-        expect(date_time_able.past?).to be false
+        expect(date_time_able.before_today?).to be false
       end
     end
   end


### PR DESCRIPTION
With the application we used `Past?` in two ways.

1. When you use `ActiveSupport::TimeWithZone` and ask for `past? ` you get:

[Returns true if the current object's time is in the past.](https://api.rubyonrails.org/v6.0.2.1/classes/ActiveSupport/TimeWithZone.html#method-i-past-3F) So a millisecond "past" the time and we are in the past.

```ruby
Time.zone.now.class
=> ActiveSupport::TimeWithZone

(byebug) workshop.date_and_time.class
ActiveSupport::TimeWithZone
```

[You don't actually create an ActiveSupport::TimeWithZone but they are used by Rails for Timezone aware times.](https://api.rubyonrails.org/v6.0.2.1/classes/ActiveSupport/TimeWithZone.html). I'm not going to claim to have any expertise... it just seems to be what Rails is using.

2. In DateTimeConcern we defined it in a second way. That is "it is something that has happened in the past" and it was arbitrarily decided that the past was "yesterday".

```ruby
def past?
  date_and_time < Time.zone.today
end

(byebug) Time.zone.today
Thu, 28 May 2020      <=== no time component
```

Clearly, this is a bad thing. I've redefined the concern's past? as `before_today?` (name ideas welcome). 

We can then re-introduce `past?` to delegate to date_and_time like it is with forward.

`    delegate :future?, to: :date_and_time`