### PR TITLE
(fix) Flaky test when timezone missing from CourseInvitationMailer

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4,7 +4,7 @@ de:
     formats:
       default: "%d.%m.%Y"
       email: "%a, %d %B um %H:%M"
-      email_title: "%A, %d %b um %H:%M"
+      email_title: "%A, %d %b um %H:%M %Z"
       short: "%d.%m.%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y um %H:%M"
@@ -22,7 +22,7 @@ de:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B um %H:%M"
-      email_title: "%A, %d %b um %H:%M"
+      email_title: "%A, %d %b um %H:%M %Z"
       short: "%d.%m.%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -4,7 +4,7 @@ en-AU:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ en-AU:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -4,7 +4,7 @@ en-GB:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ en-GB:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -4,7 +4,7 @@ en-US:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ en-US:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,7 +4,7 @@ es:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ es:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -4,7 +4,7 @@ fi:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ fi:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,7 +4,7 @@ fr:
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@ fr:
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -4,7 +4,7 @@
     formats:
       default: "%d/%m/%Y"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       website_format: "%a, %d %B %Y at %H:%M"
@@ -22,7 +22,7 @@
     formats:
       default: "%a, %d %b %Y %H:%M"
       email: "%a, %d %B at %H:%M"
-      email_title: "%A, %d %b at %H:%M"
+      email_title: "%A, %d %b at %H:%M %Z"
       short: "%d/%m/%Y %H:%M "
       date: "%d %b %Y"
       full_date: "%d %B %Y"

--- a/spec/features/internationalization_spec.rb
+++ b/spec/features/internationalization_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.feature 'Internationalization', type: :feature do
+  after(:each) do
+    I18n.locale = :en
+  end
+
   context 'a visitor to the website' do
     context 'views the website in English' do
       scenario 'by default' do


### PR DESCRIPTION
### Problem

- course_invitation_mailer_spec#invite_student flaked when it
  missed the timezone component of an expected string - GMT

expected: "Course ... Wednesday, 30 Oct at 18:30 GMT"
actual: "Course ... Wednesday, 30 Oct at 18:30"

[Original Travis link](https://travis-ci.org/github/codebar/planner/builds/692250919)

### Solution in two parts

1) Before the CourseInvitationMailer#invite_student had run it had
   first run an Internationalization spec which changed the locale
   to French but did not change it back.

   visit root_path(locale: 'fr')  <== locale changed

   Part one of the solution is to make sure that the locale is
   returned to en after each time a locale change is made.

2) CourseInvitationMailer#invite_student uses a date format
   :email_title

`   email_title: "%A, %d %b at %H:%M %Z"`

   But the French format was *missing* the TimeZone component

`   email_title: "%A, %d %b at %H:%M"`

   Part two of the solution is to make all locale formats have the
   same TimeZone format `%Z`.



### How to find this flaky test?

Tests are randomized each time they are run. When a flaky test
fails take the random seed number and re-run the tests to see
if they fail again. If they do it's likely a bug caused by the
order of tests running (as in this case).

On the Travis build page we can see:

Randomized with seed 13838

![flaky-localisation-bug](https://user-images.githubusercontent.com/1710795/83253477-f0824880-a1a4-11ea-9132-89a72d497dcf.png)


Then we re-run it:

`rspec spec --seed 13838`

The problem is unlikely to be just the test that has failed but
something that has happened recently as well. So look through the
previous few tests. In this case I commented out the code in
previous tests until it started working again. In this case it
started to work after I removed locale: 'fr' and everything started
to work again. Running the flaky test with a locale of 'fr' broke
it every time. With that it becomes a normal test and you can step
through looking for what went wrong - in this case the
time.email_format was missing %Z on the i18n French yml file.

--- 

Edit: Wonder why it was Wednesday and not Mercredi ?