### PR TITLE
Basic Rubocop over spec

### DIFF
--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.feature 'Accepting Terms and Conditions', type: :feature do
-
   context 'When a user signs up to codebar' do
     before do
       mock_github_auth
@@ -49,7 +48,6 @@ RSpec.feature 'Accepting Terms and Conditions', type: :feature do
   end
 
   context 'When an existing member logs in' do
-
     context 'and they have not yet accepted codebar''s ToCs' do
       scenario 'they have to accept before continuing to the page they want to get' do
         member = Fabricate(:member_without_toc)

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Managing meetings', type: :feature do
 
       expect do
         visit invite_admin_meeting_path(meeting)
-      end.to change { ActionMailer::Base.deliveries.count }.by (chapter.members.count - 4)
+      end.to change { ActionMailer::Base.deliveries.count }.by(chapter.members.count - 4)
     end
   end
 end

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -160,7 +160,6 @@ RSpec.feature 'An admin managing workshops', type: :feature do
     end
   end
 
-
   context '#actions' do
     context 'sending invitations to attendees' do
       scenario 'for a workshop' do

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Member portal', type: :feature do
         presenter = WorkshopPresenter.new(workshop)
         visit dashboard_path
 
-        expect(page).to have_content("#{presenter.to_s} at #{presenter.venue.name}", count: 1)
+        expect(page).to have_content("#{presenter} at #{presenter.venue.name}", count: 1)
       end
 
       it 'can view upcoming workshops for their chapters' do
@@ -40,9 +40,9 @@ RSpec.feature 'Member portal', type: :feature do
 
         visit dashboard_path
 
-        expect(page).to have_content("#{c1_workshop_presenter.to_s} at #{c1_workshop_presenter.venue.name}",
+        expect(page).to have_content("#{c1_workshop_presenter} at #{c1_workshop_presenter.venue.name}",
                                      count: 1)
-        expect(page).to have_content("#{c2_workshop_presenter.to_s} at #{c2_workshop_presenter.venue.name}",
+        expect(page).to have_content("#{c2_workshop_presenter} at #{c2_workshop_presenter.venue.name}",
                                      count: 1)
       end
     end

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature 'viewing a meeting', type: :feature do
     end
 
     scenario "can view a meeting's information" do
-
       expect(page).to have_content meeting.name
       expect(page).to have_content meeting.venue.name
     end

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -96,6 +96,5 @@ RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
     end
 
     include_examples "viewing workshop details"
-
   end
 end

--- a/spec/lib/services/mailing_list_spec.rb
+++ b/spec/lib/services/mailing_list_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe MailingList do
   context '#subscribe' do
     it 'adds a user to the mailing list' do
       expect(members).to receive(:create)
-                     .with(body: { email_address: :email,
-                                   status: "subscribed",
-                                   merge_fields: { FNAME: :first_name, LNAME: :last_name}})
+        .with(body: { email_address: :email,
+                      status: "subscribed",
+                      merge_fields: { FNAME: :first_name, LNAME: :last_name } })
 
       mailing_list.subscribe(:email, :first_name, :last_name)
     end
@@ -33,9 +33,9 @@ RSpec.describe MailingList do
 
       expect(Digest::MD5).to receive(:hexdigest).with(email)
       expect(members).to receive(:upsert)
-                    .with(body: { email_address: email,
-                                  status: "subscribed",
-                                  merge_fields: { FNAME: :first_name, LNAME: :last_name}})
+        .with(body: { email_address: email,
+                      status: "subscribed",
+                      merge_fields: { FNAME: :first_name, LNAME: :last_name } })
 
       mailing_list.subscribe(email, :first_name, :last_name)
     end
@@ -47,9 +47,9 @@ RSpec.describe MailingList do
 
       expect(Digest::MD5).to receive(:hexdigest).with(email)
       expect(members).to receive(:upsert)
-                    .with(body: { email_address: email,
-                                  status: "subscribed",
-                                  merge_fields: { FNAME: :first_name, LNAME: :last_name}})
+        .with(body: { email_address: email,
+                      status: "subscribed",
+                      merge_fields: { FNAME: :first_name, LNAME: :last_name } })
 
       mailing_list.reactivate_subscription(email, :first_name, :last_name)
     end
@@ -61,7 +61,7 @@ RSpec.describe MailingList do
 
       expect(Digest::MD5).to receive(:hexdigest).with(email)
       expect(members).to receive(:update)
-                     .with(body: { status: "unsubscribed" })
+        .with(body: { status: "unsubscribed" })
 
       mailing_list.unsubscribe(email)
     end

--- a/spec/mailers/course_invitation_mailer_spec.rb
+++ b/spec/mailers/course_invitation_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe CourseInvitationMailer, type: :mailer  do
+RSpec.describe CourseInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
 
   it '#invite_student' do

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe EventInvitationMailer, type: :mailer  do
+RSpec.describe EventInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FeedbackRequestMailer, type: :mailer  do
+RSpec.describe FeedbackRequestMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:member) { Fabricate(:member) }
   let(:feedback_request) { Fabricate(:feedback_request, workshop: workshop, member: member) }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-RSpec.describe Address, type: :model  do
+RSpec.describe Address, type: :model do
   subject(:address) { Fabricate.build(:address) }
 end

--- a/spec/models/course_invitation_spec.rb
+++ b/spec/models/course_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe CourseInvitation, type: :model  do
+RSpec.describe CourseInvitation, type: :model do
   let(:invitation) { Fabricate(:course_invitation) }
   it_behaves_like InvitationConcerns, :course_invitation
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Course, type: :model  do
+RSpec.describe Course, type: :model do
   let(:course) { Fabricate(:course) }
 
   context 'validations' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Event, type: :model  do
+RSpec.describe Event, type: :model do
   subject(:event) { Fabricate(:event) }
   include_examples "Invitable", :invitation, :event
 
@@ -53,7 +53,7 @@ RSpec.describe Event, type: :model  do
           event.valid?
 
           expect(event.errors[:invitable])
-                      .to_not include('Fill in all invitations details to make the event invitable')
+            .to_not include('Fill in all invitations details to make the event invitable')
         end
 
         it 'it validates invitable if student spaces or coach spaces missing' do
@@ -64,7 +64,7 @@ RSpec.describe Event, type: :model  do
           event.valid?
 
           expect(event.errors[:invitable])
-                      .to include('Fill in all invitations details to make the event invitable')
+            .to include('Fill in all invitations details to make the event invitable')
         end
 
         it 'validates invitable if both student spaces and coach spaces missing' do
@@ -75,7 +75,7 @@ RSpec.describe Event, type: :model  do
           event.valid?
 
           expect(event.errors[:invitable])
-                      .to include('Fill in all invitations details to make the event invitable')
+            .to include('Fill in all invitations details to make the event invitable')
         end
       end
     end

--- a/spec/models/feedback_request_spec.rb
+++ b/spec/models/feedback_request_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FeedbackRequest, type: :model  do
+RSpec.describe FeedbackRequest, type: :model do
   subject { Fabricate(:feedback_request) }
 
   it { should respond_to(:member) }

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe InvitationManager, type: :model  do
+RSpec.describe InvitationManager, type: :model do
   subject(:manager) { InvitationManager.new }
 
   let(:chapter) { Fabricate(:chapter) }
@@ -136,8 +136,8 @@ RSpec.describe InvitationManager, type: :model  do
       waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Coach')
 
       expect(WorkshopInvitationMailer).to receive(:notify_waiting_list).once
-        .with(waitinglist_invitation)
-        .and_call_original
+                                                                       .with(waitinglist_invitation)
+                                                                       .and_call_original
 
       manager.send_waiting_list_emails(workshop)
     end
@@ -157,8 +157,8 @@ RSpec.describe InvitationManager, type: :model  do
       waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Student')
 
       expect(WorkshopInvitationMailer).to receive(:notify_waiting_list).once
-        .with(waitinglist_invitation)
-        .and_call_original
+                                                                       .with(waitinglist_invitation)
+                                                                       .and_call_original
 
       manager.send_waiting_list_emails(workshop)
     end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Invitation, type: :model  do
+RSpec.describe Invitation, type: :model do
   it_behaves_like InvitationConcerns, :invitation
 
   context 'defaults' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Invitation, type: :model do
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:member) }
     it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:event_id, :role) }
-    it { is_expected.to validate_inclusion_of(:role).in_array(['Student', 'Coach']) }
+    it { is_expected.to validate_inclusion_of(:role).in_array(%w[Student Coach]) }
   end
 
   context '#student_spaces?' do

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe MeetingInvitation, type: :model  do
+RSpec.describe MeetingInvitation, type: :model do
   it_behaves_like InvitationConcerns, :meeting_invitation
 
   context 'defaults' do

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe Meeting, type: :model  do
+RSpec.describe Meeting, type: :model do
   include_examples "Invitable", :meeting_invitation, :meeting
   include_examples DateTimeConcerns, :meeting
 
   context 'validations' do
     subject(:meeting) { Fabricate(:meeting) }
-    it {is_expected.to validate_presence_of(:date_and_time) }
-    it {is_expected.to validate_presence_of(:venue) }
+    it { is_expected.to validate_presence_of(:date_and_time) }
+    it { is_expected.to validate_presence_of(:venue) }
 
     context '#slug' do
       it 'fails when slug not present' do

--- a/spec/models/meeting_talk_spec.rb
+++ b/spec/models/meeting_talk_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe MeetingTalk, type: :model  do
+RSpec.describe MeetingTalk, type: :model do
   context 'validations' do
     subject { MeetingTalk.new }
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Member, type: :model do
     end
 
     context 'properties' do
-      let (:member) { Fabricate(:member) }
+      let(:member) { Fabricate(:member) }
 
       it '#full_name' do
         expect(member.full_name).to eq("#{member.name} #{member.surname} (#{member.pronouns})")

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Member, type: :model  do
+RSpec.describe Member, type: :model do
   context 'mandatory attributes' do
     context 'validation' do
       it { is_expected.to validate_presence_of(:auth_services) }
@@ -14,7 +14,7 @@ RSpec.describe Member, type: :model  do
       end
 
       it { is_expected.to validate_length_of(:about_you).is_at_most(255) }
-      it { is_expected.to validate_uniqueness_of(:email)}
+      it { is_expected.to validate_uniqueness_of(:email) }
     end
 
     context 'properties' do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Role, type: :model  do
+RSpec.describe Role, type: :model do
   context 'scopes' do
     let(:student_role) { Fabricate(:student_role) }
     let(:coach_role) { Fabricate(:coach_role) }

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Tutorial, type: :model  do
+RSpec.describe Tutorial, type: :model do
   subject(:tutorial) { Fabricate.build(:tutorial) }
 
   it { should respond_to(:title) }

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe WorkshopInvitation, type: :model  do
+RSpec.describe WorkshopInvitation, type: :model do
   it_behaves_like InvitationConcerns, :workshop_invitation
 
   context 'defaults' do

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WorkshopInvitation, type: :model do
   context 'validates' do
     it { is_expected.to validate_presence_of(:workshop) }
     it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:workshop_id, :role) }
-    it { is_expected.to validate_inclusion_of(:role).in_array(['Student', 'Coach']) }
+    it { is_expected.to validate_inclusion_of(:role).in_array(%w[Student Coach]) }
   end
 
   context 'scopes' do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Workshop, type: :model do
 
     context 'if virtual' do
       before { allow(subject).to receive(:virtual?).and_return(true) }
-      it { is_expected.to validate_presence_of(:slack_channel)}
-      it { is_expected.to validate_presence_of(:slack_channel_link)}
+      it { is_expected.to validate_presence_of(:slack_channel) }
+      it { is_expected.to validate_presence_of(:slack_channel_link) }
       it { is_expected.to validate_numericality_of(:student_spaces).is_greater_than(0) }
       it { is_expected.to validate_numericality_of(:coach_spaces).is_greater_than(0) }
     end

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe EventPresenter do
 
   context '#time' do
     it 'when no end_time is set it only returns the start_time' do
-      event =  double(:event, date_and_time: Time.zone.now, start_time: Time.zone.now, ends_at: nil)
+      event = double(:event, date_and_time: Time.zone.now, start_time: Time.zone.now, ends_at: nil)
       presenter = EventPresenter.new(event)
 
       expect(presenter.time).to eq(I18n.l(event.date_and_time, format: :time_with_zone))
@@ -63,7 +63,7 @@ RSpec.describe EventPresenter do
     end
 
     it 'returns yesteday if the date_and_time is not set to today' do
-      workshop.date_and_time = Time.zone.now+1.day
+      workshop.date_and_time = Time.zone.now + 1.day
 
       expect(event.day_temporal_pronoun). to eq('tomorrow')
     end

--- a/spec/presenters/job_presenter_spec.rb
+++ b/spec/presenters/job_presenter_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe JobPresenter do
   context '#published_on' do
     let(:job) { Fabricate(:published_job) }
 
-    it'returns the localised published on date if set' do
+    it 'returns the localised published on date if set' do
       published_on = I18n.l(job.published_on, format: :date)
 
       expect(presenter.published_on).to eq(published_on)
     end
 
-    it'returns the localised published on date if set' do
+    it 'returns the localised published on date if set' do
       job.update_attribute(:published_on, nil)
 
       expect(presenter.published_on).to eq('-')
@@ -23,7 +23,7 @@ RSpec.describe JobPresenter do
     let(:published_on) { Time.zone.now }
     let(:job) { Fabricate(:published_job, published_on: published_on) }
 
-    it'returns the published_on datetime converted to ixo8601 format ' do
+    it 'returns the published_on datetime converted to ixo8601 format ' do
       expect(presenter.published_on_time_iso8601).to eq(published_on.to_time.iso8601)
     end
   end

--- a/spec/presenters/sponsor_presenter_spec.rb
+++ b/spec/presenters/sponsor_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SponsorPresenter do
-  let(:sponsor_presenter) { SponsorPresenter.new(sponsor)}
+  let(:sponsor_presenter) { SponsorPresenter.new(sponsor) }
 
   context '#contact_full_name' do
     let(:sponsor) { double(:sponsor, contact_first_name: 'leonardo', contact_surname: 'da Vinci') }

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe WorkshopPresenter do
                       attending_students: double(:attending_students, count: attending_students))
   end
 
-
   context '#decorate' do
     it 'returns a workshop decorated with the WorkshopPresenter' do
       workshop = double(:workshop, virtual?: false)
@@ -34,7 +33,7 @@ RSpec.describe WorkshopPresenter do
   end
 
   context '#attending_and_available_student_spots' do
-  let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 4) }
+    let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 4) }
 
     it 'returns the attending students count over the available workshop spots' do
       expect(presenter.attending_and_available_student_spots).to eq('4/5')
@@ -42,13 +41,12 @@ RSpec.describe WorkshopPresenter do
   end
 
   context '#attending_and_available_coach_spots' do
-  let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 4) }
+    let(:workshop) { double_workshop(attending_coaches: 3, attending_students: 4) }
 
     it 'returns the attending coaches count over the available workshop spots' do
       expect(presenter.attending_and_available_coach_spots).to eq('3/15')
     end
   end
-
 
   context '#title' do
     it 'returns the title of a workshop' do
@@ -79,7 +77,6 @@ RSpec.describe WorkshopPresenter do
     it '#end_time' do
       expect(presenter.end_time).to eq(I18n.l(workshop.ends_at, format: :time))
     end
-
   end
 
   context '#attendees_csv' do
@@ -153,7 +150,6 @@ RSpec.describe WorkshopPresenter do
                         attending_coaches: double(:attending_coaches, length: attending_coaches),
                         attending_students: double(:attending_students, length: attending_students))
     end
-
 
     context 'when the host has more available spots' do
       let(:workshop) { double_workshop(attending_coaches: 2, attending_students: 3) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,9 @@ require 'coveralls'
 require 'shoulda/matchers'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+                                                                 SimpleCov::Formatter::HTMLFormatter,
+                                                                 Coveralls::SimpleCov::Formatter
+                                                               ])
 
 SimpleCov.start 'rails' do
   add_group 'Presenters', 'app/presenters'
@@ -46,6 +46,7 @@ RSpec.configure do |config|
         uncommitted transaction data setup over the spec's database connection.
       MSG
     end
+
     DatabaseCleaner.clean_with(:truncation)
     DatabaseCleaner.strategy = :deletion
   end

--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -35,7 +35,6 @@ module LoginHelpers
         name: Faker::Name.name
       }
     )
-
   end
 
   def accept_toc

--- a/spec/support/shared_examples/behaves_like_invitable.rb
+++ b/spec/support/shared_examples/behaves_like_invitable.rb
@@ -49,12 +49,11 @@ RSpec.shared_examples 'Invitable' do |invitation_type, invitable_type|
 
     it 'rejects banned attending students' do
       invitation_to_banned_student = Fabricate(invitation_type,
-                                        member: Fabricate(:banned_member),
-                                        role: 'Student',
-                                        invitable_type => invitable,
-                                        attending: true)
+                                               member: Fabricate(:banned_member),
+                                               role: 'Student',
+                                               invitable_type => invitable,
+                                               attending: true)
 
-                                        # byebug
       expect(invitable.reload.attending_students).to_not include(invitation_to_banned_student)
     end
   end
@@ -80,10 +79,10 @@ RSpec.shared_examples 'Invitable' do |invitation_type, invitable_type|
 
     it 'rejects banned attending coaches' do
       invitation_to_banned_student = Fabricate(invitation_type,
-                                        member: Fabricate(:banned_member),
-                                        role: 'Student',
-                                        invitable_type => invitable,
-                                        attending: true)
+                                               member: Fabricate(:banned_member),
+                                               role: 'Student',
+                                               invitable_type => invitable,
+                                               attending: true)
 
       expect(invitable.reload.attending_students).to_not include(invitation_to_banned_student)
     end

--- a/spec/support/shared_examples/behaves_like_sending_workshop_emails.rb
+++ b/spec/support/shared_examples/behaves_like_sending_workshop_emails.rb
@@ -1,54 +1,54 @@
 RSpec.shared_examples 'sending workshop emails' do
-    it 'creates an invitation for each student' do
-      student_group = Fabricate(:students, chapter: chapter, members: students)
+  it 'creates an invitation for each student' do
+    student_group = Fabricate(:students, chapter: chapter, members: students)
 
-      students.each do |student|
-        expect(WorkshopInvitation).to receive(:create).with(workshop: workshop, member: student, role: 'Student').and_call_original
-        expect(mailer).to receive(:invite_student).and_call_original
-      end
+    students.each do |student|
+      expect(WorkshopInvitation).to receive(:create).with(workshop: workshop, member: student, role: 'Student').and_call_original
+      expect(mailer).to receive(:invite_student).and_call_original
+    end
 
+    manager.send(send_email, workshop, 'students')
+  end
+
+  it 'creates an invitation for each coach' do
+    coach_group = Fabricate(:coaches, chapter: chapter, members: coaches)
+
+    coaches.each do |coach|
+      expect(WorkshopInvitation).to receive(:create).with(workshop: workshop, member: coach, role: 'Coach').and_call_original
+      expect(mailer).to receive(:invite_coach).and_call_original
+    end
+
+    manager.send(send_email, workshop, 'coaches')
+  end
+
+  it 'does not invite banned coaches' do
+    banned_coach = Fabricate(:banned_member)
+    coach_group = Fabricate(:coaches, chapter: chapter, members: coaches + [banned_coach])
+
+    coaches.each do |coach|
+      expect(WorkshopInvitation).to receive(:create).with(workshop: workshop, member: coach, role: 'Coach').and_call_original
+    end
+    expect(WorkshopInvitation).to_not receive(:create).with(workshop: workshop, member: banned_coach, role: 'Coach')
+
+    manager.send(send_email, workshop, 'coaches')
+  end
+
+  it 'sends emails when a WorkshopInvitation is created' do
+    student_group = Fabricate(:students, chapter: chapter, members: students)
+    coach_group = Fabricate(:coaches, chapter: chapter, members: coaches)
+
+    expect do
+      manager.send(send_email, workshop, 'everyone')
+    end.to change { ActionMailer::Base.deliveries.count }.by(students.count + coaches.count)
+  end
+
+  it "does not send emails when no invitation is created" do
+    student_group = Fabricate(:students, chapter: chapter, members: students)
+
+    expect(WorkshopInvitation).to receive(:create).and_return(WorkshopInvitation.new).exactly(students.count)
+
+    expect do
       manager.send(send_email, workshop, 'students')
-    end
-
-    it 'creates an invitation for each coach' do
-      coach_group = Fabricate(:coaches, chapter: chapter, members: coaches)
-
-      coaches.each do |coach|
-        expect(WorkshopInvitation).to receive(:create).with(workshop: workshop, member: coach, role: 'Coach').and_call_original
-        expect(mailer).to receive(:invite_coach).and_call_original
-      end
-
-      manager.send(send_email, workshop, 'coaches')
-    end
-
-    it 'does not invite banned coaches' do
-      banned_coach = Fabricate(:banned_member)
-      coach_group = Fabricate(:coaches, chapter: chapter, members: coaches + [banned_coach])
-
-      coaches.each do |coach|
-        expect(WorkshopInvitation).to receive(:create).with(workshop: workshop, member: coach, role: 'Coach').and_call_original
-      end
-      expect(WorkshopInvitation).to_not receive(:create).with(workshop: workshop, member: banned_coach, role: 'Coach')
-
-      manager.send(send_email, workshop, 'coaches')
-    end
-
-    it 'sends emails when a WorkshopInvitation is created' do
-      student_group = Fabricate(:students, chapter: chapter, members: students)
-      coach_group = Fabricate(:coaches, chapter: chapter, members: coaches)
-
-      expect do
-        manager.send(send_email, workshop, 'everyone')
-      end.to change { ActionMailer::Base.deliveries.count }.by(students.count + coaches.count)
-    end
-
-    it "does not send emails when no invitation is created" do
-      student_group = Fabricate(:students, chapter: chapter, members: students)
-
-      expect(WorkshopInvitation).to receive(:create).and_return(WorkshopInvitation.new).exactly(students.count)
-
-      expect do
-        manager.send(send_email, workshop, 'students')
-      end.not_to change { ActionMailer::Base.deliveries.count }
-    end
+    end.not_to change { ActionMailer::Base.deliveries.count }
+  end
 end


### PR DESCRIPTION
I would like to treat the spec directory with the same care as the app directory. Currently, there is no linting over the spec directory at all. These are a few Rubocop defaults over the spec directory.

When the basics are fixed my aim would be to apply `rubocop-rspec`.

All this would improve consistency in the testing code.