### PR TITLE
(enhancement) Fabricator ends_at calculated from start time

### DIFF
--- a/spec/fabricators/event_fabricator.rb
+++ b/spec/fabricators/event_fabricator.rb
@@ -2,7 +2,7 @@ Fabricate.sequence(:slug) { |i| "#{Faker::Lorem.word}-#{i}" }
 
 Fabricator(:event) do
   date_and_time Time.zone.now + 2.days
-  ends_at Time.zone.now + 2.days + 8.hours
+  ends_at { |attrs| attrs[:date_and_time] + 8.hours }
   name Faker::Lorem.sentence
   description Faker::Lorem.sentence
   coach_description Faker::Lorem.sentence

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -1,6 +1,6 @@
 Fabricator(:workshop) do
   date_and_time Time.zone.now + 2.days
-  ends_at Time.zone.now + 2.days + 2.hours
+  ends_at { |attrs| attrs[:date_and_time] + 2.hours }
   chapter
   after_build do |workshop, transients|
     Fabricate(:workshop_sponsor,
@@ -17,7 +17,7 @@ end
 
 Fabricator(:workshop_no_sponsor, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
-  ends_at Time.zone.now + 2.days + 2.hours
+  ends_at { |attrs| attrs[:date_and_time] + 2.hours }
   chapter
 end
 
@@ -33,12 +33,11 @@ end
 
 Fabricator(:past_workshop, from: :workshop) do
   date_and_time 3.months.ago
-  ends_at 3.months.ago + 2.hours
 end
 
 Fabricator(:virtual_workshop, class_name: :workshop) do
   date_and_time Time.zone.now + 2.days
-  ends_at Time.zone.now + 2.days + 2.hours
+  ends_at { |attrs| attrs[:date_and_time] + 2.hours }
   chapter
   virtual true
   student_spaces 10

--- a/spec/support/shared_examples/behaves_like_date_time_concerns.rb
+++ b/spec/support/shared_examples/behaves_like_date_time_concerns.rb
@@ -19,7 +19,8 @@ RSpec.shared_examples DateTimeConcerns do |date_time_type|
   context '#time' do
     it 'returns nil if not available' do
       travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
-        date_time_able = Fabricate.build(date_time_type, date_and_time: nil)
+        date_time_able = Fabricate.build(date_time_type)
+        date_time_able.date_and_time = nil
         expect(date_time_able.time).to be_nil
       end
     end


### PR DESCRIPTION
 - date_and_time (the starting time) and ends_at is a time range
 - most of the time you want ends at to be a few hours after
   starts at. Most of the tests are setup without the programmer
   worrying about this. By having the ends_at calculate from the
   start time it will be a consistently sensible default.
 - You can now Fabricate a workshop with a starting time and not
   worry about explicitly setting an ending time.

 - the wrinkle with the code is that Fabricator breaks if
   date_and_time is set to nil. This happened in one test and I
   would prefer to fix that test rather than complicate the
   Fabricator (which are untested) with a nil check