### PR TITLE
Rearrange homepage sections

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -181,7 +181,7 @@ $anchor-font-color-hover: darken($secondary-color, 10%);
 // $hr-margin: rem-calc(20);
 
 // We use these to style lists
- $list-style-position: outside;
+$list-style-position: outside;
 // $list-side-margin: 1.1rem;
 // $list-ordered-side-margin: 1.4rem;
 // $list-side-margin-no-bullet: 0;
@@ -191,11 +191,11 @@ $definition-list-header-weight: 100;
 // $definition-list-margin-bottom: rem-calc(12);
 
 // We use these to style blockquotes
-// $blockquote-font-color: scale-color($header-font-color, $lightness: 35%);
-// $blockquote-padding: rem-calc(9 20 0 19);
+$blockquote-font-color: #666;
+$blockquote-padding: rem-calc(15 20 15 45);
 $blockquote-border: none;
-$blockquote-cite-font-size: rem-calc(13);
-// $blockquote-cite-font-color: scale-color($header-font-color, $lightness: 23%);
+$blockquote-cite-font-size: rem-calc(12);
+$blockquote-cite-font-color: #666;
 // $blockquote-cite-link-color: $blockquote-cite-font-color;
 
 // Acronym styles
@@ -1347,15 +1347,16 @@ table thead tr td {
 
 
 blockquote {
-  display:block;
-  padding: 15px 20px 15px 45px;
-  margin: 0 0 20px;
+  background: $white;
+  border-radius: 5px;
+  display: block;
+  margin-bottom: 0;
   position: relative;
+}
 
-  /*Font*/
-  font-size: 16px;
-  line-height: 1.2;
-  color: #666;
+blockquote cite {
+  line-height: 2.2;
+  margin-left: 5px;
 }
 
 blockquote::before {
@@ -1365,8 +1366,9 @@ blockquote::before {
   font-weight: bold;
   color: #999;
   position: absolute;
+  line-height: 1.4;
   left: 10px;
-  top:5px;
+  top: 5px;
 }
 
 blockquote::after{

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -132,11 +132,6 @@ u {
   background-size: 10px 10px;
 }
 
-#showcase img {
-  max-height: 60px;
-  padding-bottom: 10px;
-}
-
 .stripe:not(.reverse):first-child {
   padding: 80px 0px 40px;
 }
@@ -147,12 +142,12 @@ u {
 }
 
 .stripe.reverse:nth-child(even) {
-  padding: 80px 0;
+  padding: 60px 0;
 }
 
 .stripe.reverse:nth-child(odd) {
   background-color: #f5f6f7;
-  padding: 80px 0;
+  padding: 60px 0;
 }
 
 .stripe.reverse:first-child {

--- a/app/assets/stylesheets/partials/_hero.scss
+++ b/app/assets/stylesheets/partials/_hero.scss
@@ -40,7 +40,7 @@ section.hero {
 
 @media only screen and (max-width: 40em) {
   section.hero {
-    padding: 20px 20px 60px;
+    padding: 20px 0;
     height: 300px;
   }
 }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,22 +1,19 @@
 - title t('homepage.title')
+
 %section.hero.opaque
   .row
     .medium-offset-1.medium-6.columns
       %p.lead
         = raw t('homepage.intro')
 
-%section.testimonials.stripe.reverse
+%section.stripe.reverse
   .row
-    .large-12.columns
+    .medium-offset-1.medium-10.columns
       %p.lead
         = t('homepage.explanation')
-  - if @testimonials.any?
-    .row
-      .large-offset-1.large-11.columns
-        = render partial: 'members/testimonials'
 
 %section.stripe.reverse
-  .row#showcase
+  .row
     .large-4.columns
       .text-center
         %h4
@@ -25,9 +22,9 @@
         = t('homepage.participate.students_explanation_p1')
       %p
         = t('homepage.participate.students_explanation_p2')
-
       .text-center
         = link_to t('homepage.participate.students_button'), new_member_path, class: 'button'
+
     .large-4.columns
       .text-center
         %h4
@@ -36,9 +33,9 @@
         = raw t('homepage.participate.coaches_explanation_p1')
       %p
         = t('homepage.participate.coaches_explanation_p2')
-
       .text-center
         = link_to t('homepage.participate.coaches_button'), new_member_path, class: 'button'
+
     .large-4.columns
       .text-center
         %h4
@@ -68,6 +65,7 @@
           .grouped-events
             %h3.date= date
             = render workshops
+
     .large-4.columns
       %h3
         = t('homepage.chapters.title')
@@ -75,3 +73,9 @@
         - @chapters.each do |chapter|
           %li
             = link_to chapter.name, chapter_path(chapter.slug)
+
+- if @testimonials.any?
+  %section.stripe.reverse
+    .row
+      .medium-offset-1.medium-10.columns
+        = render partial: 'members/testimonials'

--- a/app/views/members/_testimonials.html.haml
+++ b/app/views/members/_testimonials.html.haml
@@ -1,12 +1,9 @@
-%ul{ "data-orbit" => true, "data-options" => " animation:fade;timer_speed:60000;next_on_click:false;bullets:false;slide_number:false;circular:true;navigation_arrows:false;pause_on_hover:false;" }
+%ul{ "data-orbit" => true, "data-options" => " animation:fade;timer_speed:60000;next_on_click:false;bullets:false;slide_number:false;circular:true;navigation_arrows:false;pause_on_hover:false;timer:false;" }
   - @testimonials.each_with_index do |testimonial, index|
     %li{ "data-orbit-slide" => "testimonial-#{index}" }
-      .row
-        .large-11.medium-10.small-10.columns
-          %blockquote
-            %p= testimonial.text
-            %cite.right
-              = testimonial.member.full_name
-        .large-1.medium-2.small-2.columns
-          %br
-          = image_tag(testimonial.member.avatar(40), class: 'th radius', alt: testimonial.member.name)
+      %blockquote
+        %p= testimonial.text
+        %footer.clearfix
+          = image_tag(testimonial.member.avatar(32), class: 'th radius left', alt: testimonial.member.name)
+          %cite.left
+            = testimonial.member.full_name


### PR DESCRIPTION
## Description
This PR rearranges the sections on the homepage to the following order: hero, intro, sign up, how to support codebar, events & chapters and finally testimonials. Also includes a few layout improvements on mobile.

## Status
Ready for Review

## Screenshots
![Screenshot_2020-07-20 codebar](https://user-images.githubusercontent.com/5873816/87975070-f1867680-ca7f-11ea-8bf8-35c4a97d3b81.png)