### PR TITLE
Display more details in attendance warning confirmation dialog #1319

### DIFF
--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -9,9 +9,14 @@
     = link_to admin_member_send_eligibility_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to verify their eligibility for codebar. This cannot be undone. Are you sure?"}, class: 'item' do
       %i.fa.fa-envelope
       %label Eligibility
-  = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?"}, class: 'item' do
-    %i.fa.fa-clock-o
-    %label Attendance
+  - if @member.attendance_warnings.empty?
+    = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?"}, class: 'item' do
+      %i.fa.fa-clock-o
+      %label Attendance
+  - else
+    = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "#{@member.name} has already received a warning about missing too many workshops on #{@member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?"}, class: 'item' do
+      %i.fa.fa-clock-o
+      %label Attendance
 
 %section
   .stripe.reverse

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -62,8 +62,10 @@ RSpec.feature 'Managing users', type: :feature do
 
   scenario 'Warn a user' do
     visit admin_member_path member
+    expect(page).to have_selector("a[data-confirm='Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?']")
     click_on 'Attendance'
-
+    expect(page).to have_selector("a[data-confirm='#{member.name} has already received a warning about missing too many workshops on #{member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?']")
     expect(page).to have_content 'You have sent an attendance warning.'
   end
+
 end


### PR DESCRIPTION
Display more details in attendance warning confirmation dialog #1319
- Display suitable information for attendance email confirm
- Update warn user test

<img width="1122" alt="Screen Shot 2020-07-25 at 16 25 57" src="https://user-images.githubusercontent.com/20545298/88459304-92b46900-ce94-11ea-9d98-616a597863a7.png">
<img width="1122" alt="Screen Shot 2020-07-25 at 16 26 23" src="https://user-images.githubusercontent.com/20545298/88459312-b1b2fb00-ce94-11ea-85a1-e908afe3fccd.png">
