### PR TITLE
Venue no longer required to create events

### DIFF
--- a/app/views/admin/events/_form.html.haml
+++ b/app/views/admin/events/_form.html.haml
@@ -29,7 +29,7 @@
       = f.input :schedule
   .row
     .large-3.columns
-      = f.association :venue, input_html: { data: { placeholder: 'Select sponsors' }}, required: true
+      = f.association :venue, input_html: { data: { placeholder: 'Select host' }}
   .row
     .large-6.columns
       %br

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -16,7 +16,7 @@
       = render partial: 'event_actions'
 
 .stripe.reverse
-  - if event.venue.present?
+  - if @event.venue.present?
     .row
       = render partial: 'shared/venue', locals: { venue: @event.venue, address: @host_address}
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -16,8 +16,9 @@
       = render partial: 'event_actions'
 
 .stripe.reverse
-  .row
-    = render partial: 'shared/venue', locals: { venue: @event.venue, address: @host_address}
+  - if event.venue.present?
+    .row
+      = render partial: 'shared/venue', locals: { venue: @event.venue, address: @host_address}
 
   .row
     .small-12.column


### PR DESCRIPTION
For our `Events` adding a venue is required, however, with the increase of virtual events we don't want this to be the case. I have removed the need for this field to be required.

I noticed at various points in the code we use `@event.venue.present?` so I think this logic is what is then needed to hide the venue row on the event page. I haven't been able to test it correctly as I can't log in locally for some reason, I'll test on staging once merged.
