### PR TITLE
Improve layout of _venue partial if venue has no address 

### DIFF
--- a/app/presenters/address_presenter.rb
+++ b/app/presenters/address_presenter.rb
@@ -1,11 +1,12 @@
 class AddressPresenter < BasePresenter
   def to_html
-    lat = model.latitude.present? ? "Latitude: #{model.latitude}" : nil
-    lng = model.longitude.present? ? "Longitude: #{model.longitude}" : nil
-    postal_code = model.postal_code.present? ? ", #{model.postal_code}" : nil
+    lat = model.latitude.present? ? "Latitude: #{model.latitude}" : ''
+    lng = model.longitude.present? ? "Longitude: #{model.longitude}" : ''
+    city_and_postal_code = [model.city, model.postal_code].delete_if(&:empty?)
+                                                          .join(', ')
 
-    [model.flat, model.street, "#{model.city}#{postal_code}", lat, lng]
-      .compact.delete_if(&:empty?).join('<br/>').html_safe
+    [model.flat, model.street, city_and_postal_code, lat, lng]
+      .delete_if(&:empty?).join('<br/>').html_safe
   end
 
   def for_map

--- a/app/presenters/address_presenter.rb
+++ b/app/presenters/address_presenter.rb
@@ -2,8 +2,9 @@ class AddressPresenter < BasePresenter
   def to_html
     lat = model.latitude.present? ? "Latitude: #{model.latitude}" : nil
     lng = model.longitude.present? ? "Longitude: #{model.longitude}" : nil
+    postal_code = model.postal_code.present? ? ", #{model.postal_code}" : nil
 
-    [model.flat, model.street, "#{model.city}, #{model.postal_code}", lat, lng]
+    [model.flat, model.street, "#{model.city}#{postal_code}", lat, lng]
       .compact.delete_if(&:empty?).join('<br/>').html_safe
   end
 

--- a/app/views/shared/_venue.html.haml
+++ b/app/views/shared/_venue.html.haml
@@ -1,19 +1,21 @@
+- formatted_address = address.to_html
+- section_title = formatted_address.empty? ? "Host" : "Venue"
+
 #venue
-  .small-12.column
-    %h3 Venue
   .medium-6.columns
+    %h3= section_title
     %p
       %strong= venue.name
-      %br
-        #address
-          = address.to_html
+    - unless formatted_address.empty?
+      #address
+        = address.to_html
 
-    - if address.directions
+    - if address.directions.present?
       %p
         %strong Directions:
         = address.directions
 
-    - if venue.accessibility_info
+    - if venue.accessibility_info.present?
       %p
         %strong Accessibility information:
         = venue.accessibility_info


### PR DESCRIPTION
## Description
This PR improves the layout and the content shown in the _venue partial when the workshop's/event's etc. venue has no address (aka all address fields are empty). It also fixes a small bug in the` AddressPresenter` `to_html` method wherein a dangling comma would show for venues with no address.

## Status
Ready for Review

## Screenshots
**With address**
![Screenshot_2020-08-04 codebar(1)](https://user-images.githubusercontent.com/5873816/89363301-b04bb480-d684-11ea-9313-4712e0fe138c.png)

**Without address**
![Screenshot_2020-08-04 codebar](https://user-images.githubusercontent.com/5873816/89363335-c3f71b00-d684-11ea-9715-d7da7d41fb06.png)