### PR TITLE
add levels to sponsorships

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -77,7 +77,8 @@ class Admin::EventsController < Admin::ApplicationController
       :name, :slug, :date_and_time, :begins_at, :ends_at, :description, :info, :schedule, :venue_id, :external_url,
       :coach_spaces, :student_spaces, :email, :announce_only, :tito_url, :invitable, :student_questionnaire,
       :confirmation_required, :surveys_required, :audience,
-      :coach_questionnaire, :show_faq, :display_coaches, :display_students, sponsor_ids: [], chapter_ids: []
+      :coach_questionnaire, :show_faq, :display_coaches, :display_students, bronze_sponsor_ids: [],
+      silver_sponsor_ids: [], gold_sponsor_ids: [], sponsor_ids: [], chapter_ids: []
     )
   end
 

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -77,8 +77,8 @@ class Admin::EventsController < Admin::ApplicationController
       :name, :slug, :date_and_time, :begins_at, :ends_at, :description, :info, :schedule, :venue_id, :external_url,
       :coach_spaces, :student_spaces, :email, :announce_only, :tito_url, :invitable, :student_questionnaire,
       :confirmation_required, :surveys_required, :audience,
-      :coach_questionnaire, :show_faq, :display_coaches, :display_students, bronze_sponsor_ids: [],
-      silver_sponsor_ids: [], gold_sponsor_ids: [], sponsor_ids: [], chapter_ids: []
+      :coach_questionnaire, :show_faq, :display_coaches, :display_students,
+      bronze_sponsor_ids: [], silver_sponsor_ids: [], gold_sponsor_ids: [], sponsor_ids: [], chapter_ids: []
     )
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,7 +25,7 @@ class Event < ActiveRecord::Base
   validate :gold_sponsors_uniqueness
 
   before_save do
-    begins_at = Time.zone.parse(self.begins_at)
+    begins_at = Time.parse(self.begins_at)
     self.date_and_time = date_and_time.change(hour: begins_at.hour, min: begins_at.min)
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,10 @@ class Event < ActiveRecord::Base
 
   belongs_to :venue, class_name: 'Sponsor'
   has_many :sponsorships
-  has_many :sponsors, through: :sponsorships
+  has_many :sponsors, -> { where('sponsorships.level'=> nil) }, through: :sponsorships, source: :sponsor
+  has_many :bronze_sponsors, -> { where('sponsorships.level'=> 'bronze') }, through: :sponsorships, source: :sponsor
+  has_many :silver_sponsors, -> { where('sponsorships.level'=> 'silver') }, through: :sponsorships, source: :sponsor
+  has_many :gold_sponsors, -> { where('sponsorships.level'=> 'gold') }, through: :sponsorships, source: :sponsor
   has_many :organisers, -> { where('permissions.name' => 'organiser') }, through: :permissions, source: :members
   has_and_belongs_to_many :chapters
   has_many :invitations
@@ -16,10 +19,24 @@ class Event < ActiveRecord::Base
   validates :slug, uniqueness: true
   validate :invitability, if: :invitable?
   validates :coach_spaces, :student_spaces, numericality: true
+  validate :sponsors_uniqueness
 
   before_save do
     begins_at = Time.parse(self.begins_at)
     self.date_and_time = date_and_time.change(hour: begins_at.hour, min: begins_at.min)
+  end
+
+  def sponsors_uniqueness
+    ids = sponsorships.reject(&:marked_for_destruction?).map(&:sponsor_id)
+    duplicated = ids.select { |e| ids.count(e) > 1 }
+    standards_ids = sponsors.map(&:id)
+    bronze_ids = bronze_sponsors.map(&:id)
+    silver_ids = silver_sponsors.map(&:id)
+    gold_ids = gold_sponsors.map(&:id)
+    errors.add(:sponsors, :duplicated_sponsor) unless (standards_ids & duplicated).empty?
+    errors.add(:bronze_sponsors, :duplicated_sponsor) unless (bronze_ids & duplicated).empty?
+    errors.add(:silver_sponsors, :duplicated_sponsor) unless (silver_ids & duplicated).empty?
+    errors.add(:gold_sponsors, :duplicated_sponsor) unless (gold_ids & duplicated).empty?
   end
 
   def to_s
@@ -75,5 +92,20 @@ class Event < ActiveRecord::Base
 
   def permitted_audience_values
     %w[Students Coaches]
+  end
+
+  def has_sponsors?(level=nil)
+    case level
+    when :gold
+      gold_sponsors.any?
+    when :silver
+      silver_sponsors.any?
+    when :bronze
+      bronze_sponsors.any?
+    when :standard
+      sponsors.any?
+    else
+      sponsorships.any?
+    end
   end
 end

--- a/app/views/admin/events/_form.html.haml
+++ b/app/views/admin/events/_form.html.haml
@@ -31,9 +31,14 @@
     .large-3.columns
       = f.association :venue, input_html: { data: { placeholder: 'Select sponsors' }}, required: true
   .row
+    .large-12.columns
+      %h3
+        Please add sponsors only to either Standard level OR Gold/Silver/Bronze levels.
+  .row
     .large-3.medium-6.small-12.columns
       %br
       = f.association :sponsors, input_html: { data: { placeholder: 'Select standard sponsors' }}, collection: Sponsor.all
+  .row
     .large-3.medium-6.small-12.columns
       %br
       = f.association :bronze_sponsors, input_html: { data: { placeholder: 'Select bronze sponsors' }}, collection: Sponsor.all

--- a/app/views/admin/events/_form.html.haml
+++ b/app/views/admin/events/_form.html.haml
@@ -31,9 +31,18 @@
     .large-3.columns
       = f.association :venue, input_html: { data: { placeholder: 'Select sponsors' }}, required: true
   .row
-    .large-6.columns
+    .large-3.medium-6.small-12.columns
       %br
-      = f.association :sponsors, input_html: { data: { placeholder: 'Select sponsors' }}
+      = f.association :sponsors, input_html: { data: { placeholder: 'Select standard sponsors' }}, collection: Sponsor.all
+    .large-3.medium-6.small-12.columns
+      %br
+      = f.association :bronze_sponsors, input_html: { data: { placeholder: 'Select bronze sponsors' }}, collection: Sponsor.all
+    .large-3.medium-6.small-12.columns
+      %br
+      = f.association :silver_sponsors, input_html: { data: { placeholder: 'Select silver sponsors' }}, collection: Sponsor.all
+    .large-3.medium-6.small-12.columns
+      %br
+      = f.association :gold_sponsors, input_html: { data: { placeholder: 'Select sponsors' }}, collection: Sponsor.all
   .row
     .large-6.columns
       %br

--- a/app/views/admin/events/edit.html.haml
+++ b/app/views/admin/events/edit.html.haml
@@ -36,9 +36,18 @@
           .large-3.columns
             = f.association :venue, input_html: { data: { placeholder: 'Select sponsors' }}, required: true
         .row
-          .large-6.columns
+          .large-3.medium-6.small-12.columns
             %br
-            = f.association :sponsors, input_html: { data: { placeholder: 'Select sponsors' }}
+            = f.association :sponsors, input_html: { data: { placeholder: 'Select standard sponsors' }}, collection: Sponsor.all
+          .large-3.medium-6.small-12.columns
+            %br
+            = f.association :bronze_sponsors, input_html: { data: { placeholder: 'Select bronze sponsors' }}, collection: Sponsor.all
+          .large-3.medium-6.small-12.columns
+            %br
+            = f.association :silver_sponsors, input_html: { data: { placeholder: 'Select silver sponsors' }}, collection: Sponsor.all
+          .large-3.medium-6.small-12.columns
+            %br
+            = f.association :gold_sponsors, input_html: { data: { placeholder: 'Select sponsors' }}, collection: Sponsor.all
         .row
           .large-6.columns
             %br

--- a/app/views/admin/events/edit.html.haml
+++ b/app/views/admin/events/edit.html.haml
@@ -36,9 +36,14 @@
           .large-3.columns
             = f.association :venue, input_html: { data: { placeholder: 'Select sponsors' }}, required: true
         .row
+          .large-12.columns
+            %h3
+              Please add sponsors only to either Standard level OR Gold/Silver/Bronze levels.
+        .row
           .large-3.medium-6.small-12.columns
             %br
             = f.association :sponsors, input_html: { data: { placeholder: 'Select standard sponsors' }}, collection: Sponsor.all
+        .row
           .large-3.medium-6.small-12.columns
             %br
             = f.association :bronze_sponsors, input_html: { data: { placeholder: 'Select bronze sponsors' }}, collection: Sponsor.all

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -53,13 +53,36 @@
           %small
             = @address.to_html
       .large-3.small-6.columns#sponsors
-        - if @event.sponsors.any?
+        - if @event.has_sponsors?
           %h4 Sponsors
-          %ul.no-bullet
-            - @event.sponsors.each do |sponsor|
-              %li
-                %span
-                  = link_to sponsor.name, [:admin, sponsor]
+          - if @event.has_sponsors?(:standard)
+            %h5 Standard
+            %ul.no-bullet
+              - @event.sponsors.each do |sponsor|
+                %li
+                  %span
+                    = link_to sponsor.name, [:admin, sponsor]
+          - if @event.has_sponsors?(:bronze)
+            %h5 Bronze
+            %ul.no-bullet
+              - @event.bronze_sponsors.each do |sponsor|
+                %li
+                  %span
+                    = link_to sponsor.name, [:admin, sponsor]
+          - if @event.has_sponsors?(:silver)
+            %h5 Silver
+            %ul.no-bullet
+              - @event.silver_sponsors.each do |sponsor|
+                %li
+                  %span
+                    = link_to sponsor.name, [:admin, sponsor]
+          - if @event.has_sponsors?(:gold)
+            %h5 Gold
+            %ul.no-bullet
+              - @event.gold_sponsors.each do |sponsor|
+                %li
+                  %span
+                    = link_to sponsor.name, [:admin, sponsor]
       .large-6.small-12.columns
         %h4 Team
         - @event.organisers.each do |organiser|

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -53,30 +53,30 @@
           %small
             = @address.to_html
       .large-3.small-6.columns#sponsors
-        - if @event.has_sponsors?
+        - if @event.sponsors?
           %h4 Sponsors
-          - if @event.has_sponsors?(:standard)
+          - if @event.sponsors?(:standard)
             %h5 Standard
             %ul.no-bullet
               - @event.sponsors.each do |sponsor|
                 %li
                   %span
                     = link_to sponsor.name, [:admin, sponsor]
-          - if @event.has_sponsors?(:bronze)
+          - if @event.sponsors?(:bronze)
             %h5 Bronze
             %ul.no-bullet
               - @event.bronze_sponsors.each do |sponsor|
                 %li
                   %span
                     = link_to sponsor.name, [:admin, sponsor]
-          - if @event.has_sponsors?(:silver)
+          - if @event.sponsors?(:silver)
             %h5 Silver
             %ul.no-bullet
               - @event.silver_sponsors.each do |sponsor|
                 %li
                   %span
                     = link_to sponsor.name, [:admin, sponsor]
-          - if @event.has_sponsors?(:gold)
+          - if @event.sponsors?(:gold)
             %h5 Gold
             %ul.no-bullet
               - @event.gold_sponsors.each do |sponsor|

--- a/app/views/events/_sponsors.html.haml
+++ b/app/views/events/_sponsors.html.haml
@@ -1,0 +1,10 @@
+- sponsors.each do |sponsor|
+  %li
+    .row
+      .large-2.columns
+        = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
+      .large-10.columns
+        = link_to sponsor.name, sponsor.website
+        %p
+          = sponsor.description
+  %br

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -53,18 +53,18 @@
       %p.text-center
         %i= t('events.thx_to_sponsors')
       %br
-      - if @event.has_sponsors?
+      - if @event.sponsors?
         %ul.no-bullet
-          - if @event.has_sponsors?(:gold)
+          - if @event.sponsors?(:gold)
             %h3.text-center Gold 
             = render partial: "sponsors", object: @event.gold_sponsors
-          - if @event.has_sponsors?(:silver)
+          - if @event.sponsors?(:silver)
             %h3.text-center Silver
             = render partial: "sponsors", object: @event.silver_sponsors
-          - if @event.has_sponsors?(:bronze)
+          - if @event.sponsors?(:bronze)
             %h3.text-center Bronze
             = render partial: "sponsors", object: @event.bronze_sponsors
-          - if @event.has_sponsors?(:standard)
+          - if @event.sponsors?(:standard)
             %h3.text-center Standard
             = render partial: "sponsors", object: @event.sponsors
 - if @event.verified_coaches.any?

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -53,18 +53,20 @@
       %p.text-center
         %i= t('events.thx_to_sponsors')
       %br
-      - if @event.sponsors.any?
+      - if @event.has_sponsors?
         %ul.no-bullet
-          - @event.sponsors.each do |sponsor|
-            %li
-              .row
-                .large-2.columns
-                  = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
-                .large-10.columns
-                  =link_to sponsor.name, sponsor.website
-                  %p
-                    = sponsor.description
-
+          - if @event.has_sponsors?(:gold)
+            %h3.text-center Gold 
+            = render partial: "sponsors", object: @event.gold_sponsors
+          - if @event.has_sponsors?(:silver)
+            %h3.text-center Silver
+            = render partial: "sponsors", object: @event.silver_sponsors
+          - if @event.has_sponsors?(:bronze)
+            %h3.text-center Bronze
+            = render partial: "sponsors", object: @event.bronze_sponsors
+          - if @event.has_sponsors?(:standard)
+            %h3.text-center Standard
+            = render partial: "sponsors", object: @event.sponsors
 - if @event.verified_coaches.any?
   .stripe.reverse
     .row

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -65,7 +65,6 @@
             %h3.text-center Bronze
             = render partial: "sponsors", object: @event.bronze_sponsors
           - if @event.sponsors?(:standard)
-            %h3.text-center Standard
             = render partial: "sponsors", object: @event.sponsors
 - if @event.verified_coaches.any?
   .stripe.reverse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -658,6 +658,16 @@ en:
         pronouns: 'What pronouns do you use?'
     errors:
       models:
+        event:
+          attributes:
+            bronze_sponsors:
+              duplicated_sponsor: "Bronze level contains a duplicated sponsor"
+            sponsors:
+              duplicated_sponsor: "Standard level contains a duplicated sponsor"
+            silver_sponsors:
+              duplicated_sponsor: "Silver level contains a duplicated sponsor"
+            gold_sponsors:
+              duplicated_sponsor: "Gold level contains a duplicated sponsor"
         workshop_invitation:
           attributes:
             tutorial:

--- a/db/migrate/20200805104520_add_level_to_sponsorship.rb
+++ b/db/migrate/20200805104520_add_level_to_sponsorship.rb
@@ -1,0 +1,5 @@
+class AddLevelToSponsorship < ActiveRecord::Migration
+  def change
+    add_column :sponsorships, :level, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200522142646) do
+ActiveRecord::Schema.define(version: 20200805104520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -392,6 +392,7 @@ ActiveRecord::Schema.define(version: 20200522142646) do
     t.string   "about_you"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "unsubscribed"
     t.boolean  "can_log_in",                     default: false, null: false
     t.string   "mobile"
     t.boolean  "received_coach_welcome_email",   default: false
@@ -399,7 +400,6 @@ ActiveRecord::Schema.define(version: 20200522142646) do
     t.string   "pronouns"
     t.datetime "accepted_toc_at"
     t.datetime "opt_in_newsletter_at"
-    t.boolean  "unsubscribed"
   end
 
   add_index "members", ["email"], name: "index_members_on_email", unique: true, using: :btree
@@ -459,6 +459,7 @@ ActiveRecord::Schema.define(version: 20200522142646) do
     t.integer  "sponsor_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "level"
   end
 
   add_index "sponsorships", ["event_id"], name: "index_sponsorships_on_event_id", using: :btree


### PR DESCRIPTION
This PR is adding the possibility to have four levels of sponsors for an event `standard` (similar to the old level), `bronze`, `silver` and `gold`.

To accomplish that I added a column in the `sponsorship` table called used to connect events and sponsors and it's used to assign the level of the sponsor based on the content [see](https://github.com/jabawack81/planner/blob/9b2a235b49bb9634a3193b15dce2d6a8b86babe7/app/models/event.rb#L10), and I edited four views to edit and display this new feature:
add the fields in the new and edit form:
![edit/new event](https://user-images.githubusercontent.com/432450/89482493-f478ab00-d791-11ea-892a-42b9f3af5347.png)
add the new levels in the show event page in the admin section:
![show page in admin section](https://user-images.githubusercontent.com/432450/89482496-f5114180-d791-11ea-82b1-15b71253a871.png)
and the show event page for the user
![show event page for the user](https://user-images.githubusercontent.com/432450/89482497-f5114180-d791-11ea-8d99-dcb5145c5667.png)

I added a new validation to the event model to prevent having a sponsor as more than one level with this [sponsors_uniqueness](https://github.com/jabawack81/planner/blob/9b2a235b49bb9634a3193b15dce2d6a8b86babe7/app/models/event.rb#L29), first, it detects any duplicated sponsors and then checks if any of the four levels include it and add an error to the level that does, I realise this implementation is quite intensive but considering that it will be invoked only on the creation or edit of events, that I would imagine will happen once or twice a week but is giving a level of details for the error.