### PR TITLE
Added POSTGRES_PASSWORD for docker setup

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ development: &default
   database: planner_development
   pool: 5
   username: <%= ENV['DB_USER'] || ''  %>
-  password:
+  password: <%= ENV['POSTGRES_PASSWORD'] || '' %>
   host: <%= (ENV['DB_HOST'] || 'localhost').to_json %>
 
 test:

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,2 +1,3 @@
 DB_HOST=db
 DB_USER=postgres
+POSTGRES_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres
     volumes:
       - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
   web:
     env_file:
       - docker-compose.env


### PR DESCRIPTION
Fix for #1380 

Newer docker images of postgres require the env variable POSGRES_PASSWORD to be set.