### PR TITLE
Improve the content of the member jobs page: add copy about reach & fees + a testimonial

### DIFF
--- a/app/controllers/member/jobs_controller.rb
+++ b/app/controllers/member/jobs_controller.rb
@@ -6,6 +6,11 @@ class Member::JobsController < ApplicationController
     @jobs = current_user.jobs
                         .owner_order
                         .paginate(page: page)
+    @students_count = Member.joins(subscriptions: { group: :chapter })
+                            .where(groups: { name: 'Students' },
+                                   chapters: { active: true })
+                            .distinct
+                            .count
   end
 
   def new

--- a/app/views/member/jobs/index.html.haml
+++ b/app/views/member/jobs/index.html.haml
@@ -1,32 +1,40 @@
 .job
-  .stripe
+  .row
+    .large-12.columns
+      %br
+      %ul.breadcrumbs
+        %li.current=link_to t('member.jobs.title'), "#"
+
+  - if @jobs.any?
     .row
-      .large-12.columns
-        %br
-        %ul.breadcrumbs
-          %li.current=link_to  t('member.jobs.title'), "#"
+      %table.large-12.columns
+        %thead
+          %tr
+            %th Job title
+            %th Company
+            %th Location
+            %th Published on
+            %th Expires on
+            %th Status
+            %th
+        %tbody
+          - @jobs.each do |job|
+            = render partial: 'member/jobs/job', locals: { job: job }
+    .row
+      .medium-6.columns.text-left
+        = page_entries_info(@jobs, model: 'job')
+      .medium-6.columns.text-right
+        = will_paginate(@jobs)
 
-    - if @jobs.any?
-      .row
-        %table.large-12.columns
-          %thead
-            %tr
-              %th Job title
-              %th Company
-              %th Location
-              %th Published on
-              %th Expires on
-              %th Status
-              %th
-          %tbody
-            - @jobs.each do |job|
-              = render partial: 'member/jobs/job', locals: { job: job }
-      .row
-        .medium-6.columns.text-left
-          = page_entries_info(@jobs, model: 'job')
-        .medium-6.columns.text-right
-          = will_paginate(@jobs)
+  - else
+    .row
+      .small-12.large-8.large-offset-2.columns
+        %blockquote
+          %p= t('member.jobs.index.testimonial')
+          %footer.clearfix
+            = image_tag('ok.png', size: "30", class: 'th radius left', alt: 'Bruno Girin')
+            %cite.left Bruno Girin, CTO, Imby
 
-    .row.mt2
-      .large-12.columns
-        =link_to('New job', new_member_job_path, class: 'button medium ')
+  .row.mt2
+    .small-12
+      =link_to('Post a job', new_member_job_path, class: 'button medium')

--- a/app/views/member/jobs/index.html.haml
+++ b/app/views/member/jobs/index.html.haml
@@ -1,6 +1,6 @@
 .job
   .row
-    .large-12.columns
+    .small-12.columns
       %br
       %ul.breadcrumbs
         %li.current=link_to t('member.jobs.title'), "#"
@@ -26,15 +26,32 @@
       .medium-6.columns.text-right
         = will_paginate(@jobs)
 
-  - else
-    .row
-      .small-12.large-8.large-offset-2.columns
-        %blockquote
-          %p= t('member.jobs.index.testimonial')
-          %footer.clearfix
-            = image_tag('ok.png', size: "30", class: 'th radius left', alt: 'Bruno Girin')
-            %cite.left Bruno Girin, CTO, Imby
+    .row.mt2
+      .small-12.columns
+        =link_to('Post a job', new_member_job_path, class: 'button medium')
 
-  .row.mt2
-    .small-12
-      =link_to('Post a job', new_member_job_path, class: 'button medium')
+  - else
+    .stripe.reverse
+      .row
+        .small-12.large-10.columns
+          %h1= t('member.jobs.index.title', students_count: @students_count)
+          %p= t('member.jobs.index.description')
+          .panel
+            %p
+              = raw t('member.jobs.index.offer.title')
+              %br
+              %span= t('member.jobs.index.offer.job_board')
+              %br
+              %span= t('member.jobs.index.offer.slack')
+              %br
+              %span= t('member.jobs.index.offer.twitter')
+          =link_to('Post a job', new_member_job_path, class: 'button medium')
+    
+    .stripe.reverse
+      .row
+        .small-12.large-8.large-offset-2.columns
+          %blockquote
+            %p= t('member.jobs.index.testimonial')
+            %footer.clearfix
+              = image_tag('ok.png', size: "30", class: 'th radius left', alt: 'Bruno Girin')
+              %cite.left Bruno Girin, CTO, Imby

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -352,15 +352,22 @@ de:
       title: My jobs
       preview: Preview
       index:
-        description: Du hast %{count} Jobs eingestellt
-        none: Du hast noch keine Jobs eingestellt
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Deine Jobeinträge in Prüfung
         description: Du hast %{count} Jobeinträge die geprüft werden.
         none: Du hast keine Jobeinträge in Prüfung.
       new:
         title: Job eintragen
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
+        degree: There is no degree requirement
+        experience: There is no previous experience requirement
         rules_intro: "Bitte prüfe vor dem Abschicken, dass:"
         details: dein Eintrag detailliert die zu erledigende Arbeit darstellt
         suitability: "der Job passend für Menschen ist, die nach Praktika und Junior-Positionen suchen, die ihnen helfen ihre Karriere aufzubauen"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,6 +445,7 @@ en:
       index:
         description: You have %{count} jobs listed
         none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,9 +443,14 @@ en:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
         testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -453,7 +458,6 @@ en:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -352,8 +352,14 @@ en-AU:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs. Please consider submitting a paid internship, apprenticeship or junior developer role to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -361,7 +367,6 @@ en-AU:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -352,8 +352,14 @@ en-GB:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -361,7 +367,6 @@ en-GB:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -350,8 +350,14 @@ en-US:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -359,7 +365,6 @@ en-US:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -352,8 +352,14 @@ es:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -361,7 +367,6 @@ es:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -352,8 +352,14 @@ fi:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -361,7 +367,6 @@ fi:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -353,8 +353,14 @@ fr:
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -362,7 +368,6 @@ fr:
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -352,8 +352,14 @@
       title: My jobs
       preview: Preview
       index:
-        description: You have %{count} jobs listed
-        none: You have not listed any jobs yet. Please consider submitting a paid internship, apprenticeship or junior developer role job to our community.
+        description: Our aim is to be the one stop shop for junior developer roles. All jobs featured on our job board must fall under the following three categories; paid internships, apprenticeships or junior developer roles. Additionally, jobs must not require previous experience or a degree and must be paid positions. Each job that is submitted will be approved by the codebar team before appearing on the job board.
+        testimonial: Within 2 days of posting an ad on the codebar job board, we had dozens of high quality applications and we made an offer to a candidate within 2 weeks. There are a lot of talented interns and junior developers; posting on the codebar job board is a great way to reach them.
+        title: Reach our community of %{students_count} junior developers
+        offer:
+          title: "For a flat fee of <strong>£50</strong> your post will be:"
+          job_board: "- shown on the job board for 30 days"
+          slack: "- promoted to our Slack community of 5500 members"
+          twitter: "- promoted to our 8600 Twitter followers"
       pending:
         title: Your pending job posts
         description: You have %{count} job posts pending submission.
@@ -361,7 +367,6 @@
       new:
         title: List a job
         degree: There is no degree requirement
-        description: "Our aim is to be the one stop shop for junior developer roles! All jobs featured on our jobs board fall under the following three categories; paid internships, apprenticeships or junior developer roles. We will not share jobs that are looking for senior, mid-weight, or junior developer with 2 years of industry experience. Each job that is submitted will be approved by the codebar team before appearing on the job board."
         details: The job description details the work that will have to be undertaken
         experience: There is no previous experience requirement
         rules_intro: "Before posting make sure that:"


### PR DESCRIPTION
## Description
This PR adds/improves the content of the member jobs page in it's "empty" state - when no jobs have been submitted yet. It adds copy about the reach of the job board (number of students in active chapter), the price of a job post and what we offer in return. It also adds a testimonial.

## Status
Ready for Review

## Related Trello issue
https://trello.com/c/emkK8msz

## Screenshots
<img width="1222" alt="Screenshot 2020-10-09 at 4 30 56 pm" src="https://user-images.githubusercontent.com/5873816/95639324-de66bf80-0a4c-11eb-87f9-737993315ab3.png">