### PR TITLE
Add option to unpublish job post

### DIFF
--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -25,6 +25,16 @@ class Admin::JobsController < SuperAdmin::ApplicationController
     redirect_to admin_jobs_path
   end
 
+  def unpublish
+    job = Job.published.find(params[:job_id])
+    authorize job
+
+    job.unpublish!
+    flash[:notice] = 'The job has been successfully unpublished'
+
+    redirect_to admin_jobs_path
+  end
+
   def page
     params.permit(:page)[:page]
   end

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -30,7 +30,7 @@ class Admin::JobsController < SuperAdmin::ApplicationController
     authorize job
 
     job.unpublish!
-    flash[:notice] = 'The job has been successfully unpublished'
+    flash[:notice] = I18n.t('admin.jobs.messages.unpublished')
 
     redirect_to admin_jobs_path
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -23,6 +23,13 @@ class Job < ActiveRecord::Base
     published!
   end
 
+  def unpublish!
+    update(approved: false,
+           approved_by_id: nil,
+           published_on: nil)
+    pending!
+  end
+
   def expired?
     expiry_date.past?
   end

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -12,6 +12,6 @@ class JobPolicy < ApplicationPolicy
   end
 
   def unpublish?
-    user.has_role?(:admin) || Chapter.find_roles(:organiser, user).any?
+    user.has_role?(:admin)
   end
 end

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -10,4 +10,8 @@ class JobPolicy < ApplicationPolicy
   def approve?
     user.has_role?(:admin) || Chapter.find_roles(:organiser, user).any?
   end
+
+  def unpublish?
+    user.has_role?(:admin) || Chapter.find_roles(:organiser, user).any?
+  end
 end

--- a/app/views/admin/jobs/_job.html.haml
+++ b/app/views/admin/jobs/_job.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td
-    =link_to job.title, admin_job_path(job.id)
+    = link_to job.title, admin_job_path(job.id)
   %td
     = job.company
   %td
@@ -9,9 +9,11 @@
     = l(job.created_at, format: :date)
   %td
     - if job.published? && job.expired?
-      %span.label.admin.status.expired= t("job.admin.status.expired")
+      %span.label.admin.status.expired= t('job.admin.status.expired')
     - else
       %span.label.admin.status{ class: job.status }= t("job.admin.status.#{job.status}")
   %td
     - if job.pending?
-      =link_to 'Review', admin_job_path(job.id)
+      = link_to 'Review', admin_job_path(job.id)
+    - if job.published?
+      = link_to 'Unpublish', admin_job_unpublish_path(job.id)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -463,8 +463,9 @@ de:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,8 +571,9 @@ en:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -464,8 +464,9 @@ en-AU:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -464,8 +464,9 @@ en-GB:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -462,8 +462,9 @@ en-US:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -464,8 +464,9 @@ es:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -464,8 +464,9 @@ fi:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -465,8 +465,9 @@ fr:
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -464,8 +464,9 @@
         approved_by_no_date: Approved by %{name}
       messages:
         approved: "The job has been approved and an email has been sent out to %{name} at %{email}"
-        cannot_approve: 'You cannot approve expired job listings'
-        confirm_approval: 'Are you sure this job listing meets all requirements and you want to approve it?'
+        cannot_approve: You cannot approve expired job listings
+        confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
+        unpublished: The job has been successfully unpublished
     members:
       unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
       eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Planner::Application.routes.draw do
 
     resources :jobs, only: %i[index show] do
       get 'approve'
+      get 'unpublish'
     end
 
     resources :announcements, only: %i[new index create edit update]

--- a/spec/features/admin/jobs_spec.rb
+++ b/spec/features/admin/jobs_spec.rb
@@ -44,6 +44,17 @@ RSpec.feature 'Admin Jobs', type: :feature do
 
       expect(page).to have_content("Approved by #{job.reload.approved_by.full_name}")
     end
+
+    scenario 'can unpublish jobs' do
+      job = Fabricate(:published_job)
+      visit admin_jobs_path
+      expect(page).to have_content('Approved')
+
+      click_on 'Unpublish'
+
+      expect(page).to have_content('The job has been successfully unpublished')
+      expect(page).to have_content('Pending approval')
+    end
   end
 
   context 'an organiser' do

--- a/spec/models/jobs_spec.rb
+++ b/spec/models/jobs_spec.rb
@@ -65,4 +65,17 @@ RSpec.describe Job, type: :model do
       expect(job.status).to eq('published')
     end
   end
+
+  context "#unpublish!" do
+    it 'unpublishes a job' do
+      job = Fabricate(:published_job)
+
+      job.unpublish!
+
+      expect(job.approved_by).to be_nil
+      expect(job.published_on).to be_nil
+      expect(job.approved).to eq(false)
+      expect(job.status).to eq('pending')
+    end
+  end
 end


### PR DESCRIPTION
## Description
This PR adds the option to unpublish job posts once they've been published. Unpublishing a job post resets the `published_on` and `approved_by` fields to nil and sets the job status to pending.

## Status
Ready for Review

## Related Trello ticket
https://trello.com/c/VpGr7xPY

## Screenshots
<img width="1438" alt="Screenshot 2020-10-20 at 11 03 29 am" src="https://user-images.githubusercontent.com/5873816/96626115-e849b780-12c3-11eb-9aa1-1d774034b656.png">