### PR TITLE
Update homepage, main events page and single workshop page to use Bootstrap 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,6 +452,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.1)
   shoulda-matchers (~> 4.3)
   simple_form
+  sprockets-rails (= 3.2.1)
   stripe
   turbolinks
   tzinfo-data

--- a/app/views/events/_events.html.haml
+++ b/app/views/events/_events.html.haml
@@ -1,4 +1,4 @@
-.container
+.container-fluid
   .event
     - grouped_events.each do |date, workshops|
       .row

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -2,15 +2,14 @@
 
 .container-fluid
   .row
-    .col
+    .col{"data-test": "upcoming-events"}
       - if @events.any?
         %h3.mb-4 Upcoming Events
         = render partial: 'events', locals: { grouped_events: @events }
 
-.stripe
+.container-fluid.stripe
   .row
-    .col
+    .col{"data-test": "past-events"}
       - if @past_events.any?
-        .events-list.events-list--past
-          %h3.mb-4 Past Events
-          = render partial: 'events', locals: { grouped_events: @past_events }
+        %h3.mb-4 Past Events
+        = render partial: 'events', locals: { grouped_events: @past_events }

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -25,7 +25,7 @@
     = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
 
 
-.container-fluid.stripe.reverse.text-center
+#sponsors.container-fluid.stripe.reverse.text-center
   .row
     .col
       %h3 Sponsors

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'event listing', type: :feature do
     end
 
     scenario 'i can view a list with upcoming events' do
-      within('.events-list--upcoming') do
+      within('*[data-test=upcoming-events]') do
         expect(page).to have_content upcoming_course.title
         expect(page).to have_content 'Workshop'
         expect(page).to have_content event.name
@@ -23,7 +23,7 @@ RSpec.feature 'event listing', type: :feature do
     end
 
     scenario 'i can view a list with past events' do
-      within('.events-list--past') do
+      within('*[data-test=past-events]') do
         expect(page).to have_content past_course.title
         expect(page).to have_content 'Workshop'
         expect(page).to have_content past_event.name
@@ -38,8 +38,8 @@ RSpec.feature 'event listing', type: :feature do
       Fabricate(:workshop, date_and_time: 3.weeks.ago)
 
       visit events_path
-      within('.events-list--past') do
-        expect(page).to have_selector('.event', count: 10)
+      within('*[data-test=past-events]') do
+        expect(page).to have_selector('.event', count: 11)
         expect(page).not_to have_content 'Workshop'
       end
     end

--- a/spec/support/shared_examples/behaves_like_viewing_workshop_details.rb
+++ b/spec/support/shared_examples/behaves_like_viewing_workshop_details.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'viewing workshop details' do
   scenario 'sponsors' do
     within '#sponsors' do
       workshop.sponsors.each do |sponsor|
-        expect(page).to have_content(sponsor.name)
+        expect(page).to have_css("img[src=\"#{sponsor.avatar}\"]")
       end
     end
   end


### PR DESCRIPTION
Even though there are lots of files it isn't that bad I promise.

There are notes about deleting CSS in some of the files that I'm unsure if I can delete just yet as I'm not 100% sure whether deleting it will break another page, so notes have been added as a very last task to delete all the unused CSS (that I don't delete as I go).

Updated homepage (with new dropdown menu)
![screencapture-localhost-3000-2020-11-05-17_12_27](https://user-images.githubusercontent.com/2683270/98266311-0d0b8380-1f82-11eb-814a-467b0e705fb4.png)

Updated single workshop page

![screencapture-localhost-3000-workshops-4-2020-11-05-17_13_11](https://user-images.githubusercontent.com/2683270/98266392-290f2500-1f82-11eb-8546-a5d85dc42e77.png)

