### PR TITLE
Render Markdown with commonmarker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'icalendar'
 gem 'tzinfo-data'
 
 gem 'chosen-rails'
-gem 'redcarpet'
+gem 'commonmarker'
 
 gem 'gibbon', '~> 3.3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -278,7 +280,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.0)
     regexp_parser (1.8.2)
     rexml (3.2.4)
     rolify (5.3.0)
@@ -317,6 +318,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
+    ruby-enum (0.8.0)
+      i18n
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
     sass (3.4.25)
@@ -396,6 +399,7 @@ DEPENDENCIES
   carrierwave-ftp
   chosen-rails
   cocoon
+  commonmarker
   compass-rails
   coveralls (~> 0.8.23)
   database_cleaner
@@ -434,7 +438,6 @@ DEPENDENCIES
   rails-html-sanitizer (~> 1.3.0)
   rails4-autocomplete
   rails_12factor
-  redcarpet
   rolify
   rollbar
   rspec-collection_matchers

--- a/app/controllers/admin/portal_controller.rb
+++ b/app/controllers/admin/portal_controller.rb
@@ -10,7 +10,5 @@ class Admin::PortalController < Admin::ApplicationController
                                .ordered.limit(20).includes(:member, :group)
   end
 
-  def guide
-    @markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, fenced_code_blocks: true, hard_wrap: true)
-  end
+  def guide; end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   end
 
   def dot_markdown(text)
-    CommonMarker.render_html(text).html_safe
+    CommonMarker.render_html(text, :DEFAULT).html_safe
   end
 
   def belongs_to_group?(group)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,8 +17,8 @@ module ApplicationHelper
     content_for?(:title) ? content_for(:title) : t(:brand)
   end
 
-  def dot_markdown(text, renderer: Rails.configuration.redcarpet)
-    renderer.render(text).html_safe
+  def dot_markdown(text)
+    CommonMarker.render_html(text).html_safe
   end
 
   def belongs_to_group?(group)

--- a/app/views/admin/portal/guide.html.haml
+++ b/app/views/admin/portal/guide.html.haml
@@ -9,28 +9,28 @@
 
       %p Chapter organisers can create and modify sponsors and workshops only for chapters that they are permissioned. To make a member into an organiser of a chapter,
 
-      = raw @markdown.render("`Member.find(:id).add_role(:organiser, Chapter.find(:id))`")
+      = raw CommonMarker.render_html("`Member.find(:id).add_role(:organiser, Chapter.find(:id))`")
 
       %p Meeting organisers can create and modify monthlies. To make a member into a meeting organiser,
 
-      = raw @markdown.render("`Member.find(:id).add_role(:organiser, Meeting`")
+      = raw CommonMarker.render_html("`Member.find(:id).add_role(:organiser, Meeting`")
 
       %p Admins can create and modify sponsors, workshops, meetings and events across all chapters. Admins can also create new chapters. To permission a member as an admin,
 
-      = raw @markdown.render("`Member.find(:id).add_role(:admin)`")
+      = raw CommonMarker.render_html("`Member.find(:id).add_role(:admin)`")
 
       %p Similarly, to remove privileges,
 
-      = raw @markdown.render("`Member.find(:id).remove_role(:organiser, Chapter.find(:id))`")
+      = raw CommonMarker.render_html("`Member.find(:id).remove_role(:organiser, Chapter.find(:id))`")
 
-      = raw @markdown.render("`Member.find(:id).remove_role(:organiser, Meeting)`")
+      = raw CommonMarker.render_html("`Member.find(:id).remove_role(:organiser, Meeting)`")
 
-      = raw @markdown.render("`Member.find(:id).remove_role(:admin)`")
+      = raw CommonMarker.render_html("`Member.find(:id).remove_role(:admin)`")
 
       %p You can also check if a member has permissions. The second argument for organiser roles can be a specific chapter or :any.
 
-      = raw @markdown.render("`Member.find(:id).has_role?(:organiser, :any)`")
+      = raw CommonMarker.render_html("`Member.find(:id).has_role?(:organiser, :any)`")
 
       %p You can query all of the organisers from a Chapter as well.
 
-      = raw @markdown.render("`Member.with_role(:organiser, Chapter.find(:13))`")
+      = raw CommonMarker.render_html("`Member.with_role(:organiser, Chapter.find(:13))`")

--- a/app/views/admin/portal/guide.html.haml
+++ b/app/views/admin/portal/guide.html.haml
@@ -9,28 +9,28 @@
 
       %p Chapter organisers can create and modify sponsors and workshops only for chapters that they are permissioned. To make a member into an organiser of a chapter,
 
-      = raw CommonMarker.render_html("`Member.find(:id).add_role(:organiser, Chapter.find(:id))`")
+      = dot_markdown("`Member.find(:id).add_role(:organiser, Chapter.find(:id))`")
 
       %p Meeting organisers can create and modify monthlies. To make a member into a meeting organiser,
 
-      = raw CommonMarker.render_html("`Member.find(:id).add_role(:organiser, Meeting`")
+      = dot_markdown("`Member.find(:id).add_role(:organiser, Meeting`")
 
       %p Admins can create and modify sponsors, workshops, meetings and events across all chapters. Admins can also create new chapters. To permission a member as an admin,
 
-      = raw CommonMarker.render_html("`Member.find(:id).add_role(:admin)`")
+      = dot_markdown("`Member.find(:id).add_role(:admin)`")
 
       %p Similarly, to remove privileges,
 
-      = raw CommonMarker.render_html("`Member.find(:id).remove_role(:organiser, Chapter.find(:id))`")
+      = dot_markdown("`Member.find(:id).remove_role(:organiser, Chapter.find(:id))`")
 
-      = raw CommonMarker.render_html("`Member.find(:id).remove_role(:organiser, Meeting)`")
+      = dot_markdown("`Member.find(:id).remove_role(:organiser, Meeting)`")
 
-      = raw CommonMarker.render_html("`Member.find(:id).remove_role(:admin)`")
+      = dot_markdown("`Member.find(:id).remove_role(:admin)`")
 
       %p You can also check if a member has permissions. The second argument for organiser roles can be a specific chapter or :any.
 
-      = raw CommonMarker.render_html("`Member.find(:id).has_role?(:organiser, :any)`")
+      = dot_markdown("`Member.find(:id).has_role?(:organiser, :any)`")
 
       %p You can query all of the organisers from a Chapter as well.
 
-      = raw CommonMarker.render_html("`Member.with_role(:organiser, Chapter.find(:13))`")
+      = dot_markdown("`Member.with_role(:organiser, Chapter.find(:13))`")

--- a/app/views/admin/portal/guide.html.haml
+++ b/app/views/admin/portal/guide.html.haml
@@ -13,7 +13,7 @@
 
       %p Meeting organisers can create and modify monthlies. To make a member into a meeting organiser,
 
-      = dot_markdown("`Member.find(:id).add_role(:organiser, Meeting`")
+      = dot_markdown("`Member.find(:id).add_role(:organiser, Meeting)`")
 
       %p Admins can create and modify sponsors, workshops, meetings and events across all chapters. Admins can also create new chapters. To permission a member as an admin,
 

--- a/config/initializers/commonmarker.rb
+++ b/config/initializers/commonmarker.rb
@@ -1,0 +1,1 @@
+require 'commonmarker'

--- a/config/initializers/haml_markdown.rb
+++ b/config/initializers/haml_markdown.rb
@@ -5,7 +5,7 @@ module Haml::Filters
     include Haml::Filters::Base
 
     def render(text)
-      CommonMarker.render_html(text)
+      CommonMarker.render_html(text, :DEFAULT).html_safe
     end
   end
 end

--- a/config/initializers/haml_markdown.rb
+++ b/config/initializers/haml_markdown.rb
@@ -1,29 +1,11 @@
 module Haml::Filters
-
   remove_filter("Markdown") #remove the existing Markdown filter
 
   module Markdown
-
     include Haml::Filters::Base
 
     def render(text)
-      markdown.render(text)
-    end
-
-  private
-
-    def markdown
-      @markdown ||= Redcarpet::Markdown.new Redcarpet::Render::HTML, {
-        autolink:         true,
-        fenced_code:      true,
-        generate_toc:     true,
-        gh_blockcode:     true,
-        hard_wrap:        true,
-        no_intraemphasis: true,
-        strikethrough:    true,
-        tables:           true,
-        xhtml:            true
-      }
+      CommonMarker.render_html(text)
     end
   end
 end

--- a/config/initializers/redcarpet.rb
+++ b/config/initializers/redcarpet.rb
@@ -1,3 +1,0 @@
-require 'redcarpet'
-
-Rails.configuration.redcarpet = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.retrieve_title).to eq('codebar.io')
     end
   end
+
+  describe '#dot_markdown' do
+    it 'renders CommonMark' do
+      text = 'This is **bold** and this is _italic_'
+      expected = '<p>This is <strong>bold</strong> and this is <em>italic</em></p>'
+      expect(helper.dot_markdown(text)).to include(expected)
+    end
+
+    it 'removes potentially harmful HTML tags' do
+      text = '<scrip>alert("Hi");</script>'
+      expected = '<p><!-- raw HTML omitted -->alert(&quot;Hi&quot;);<!-- raw HTML omitted --></p>'
+      expect(helper.dot_markdown(text)).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
### ~~Review https://github.com/codebar/planner/pull/1419 first~~ ✔

As suggested by @despo, I took a stab at replacing `redcarpet` gem with [`commonmarker`](https://github.com/gjtorikian/commonmarker) to see how troublesome would be, and… end up being pretty simple! After #1419 being merged into `master`, I’ll rebase this PR and it will be ready for review. 😄 

**Note:** I see some refactoring opportunities in this code, not sure if we’re interested in taking them. For example, homogenising the way we render Markdown straight into a view. We could move `CommonMarker.render_html(…)` into a helper so we could simply have `render_markdown(…)` in the views, abstracting use from the specific Markdown engine. I also wonder if we can get rid of those `raw` and `.html_safe`… 🤔 