### PR TITLE
Handle exception thrown by Gibbon

### DIFF
--- a/lib/services/mailing_list.rb
+++ b/lib/services/mailing_list.rb
@@ -27,6 +27,8 @@ class MailingList
 
     client.lists(list_id).members(md5_hashed_email_address(email))
           .update(body: { status: 'unsubscribed' })
+  rescue Gibbon::MailChimpError
+    false
   end
   handle_asynchronously :unsubscribe
 


### PR DESCRIPTION
- we don’t care about this exception. It happens when a user is not subscribed to mailchimp already anyway (on signups when the checkbox is left unchecked)

This should also resolve the most of the rollbar errors that we have posted all the time.