### PR TITLE
Update description of virtual workshop slack channel

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -626,7 +626,7 @@ en:
         description: 'Use text or markdown for the job description'
         location: 'e.g. London or Berlin'
       workshop:
-        slack_channel: 'e.g. virtual-london-2022-12-03'
+        slack_channel: 'e.g. barcelona-chapter or virtual-london-2022-12-03'
         slack_channel_link: 'e.g. https://codebar.slack.com/archives/CGLQD917T'
         description: 'Any details you would like to add about the workshop. This will be visible on both the public workshop and invitation pages'
       workshop_invitation:
@@ -647,7 +647,7 @@ en:
       contact:
         mailing_list_consent: Stay up to date with codebar's news and ways your company can help us make a difference.
       workshop:
-        slack_channel: 'Create a workshop specific channel in the codebar Slack. This is the place you will use for socialising and sharing details about the workshop.'
+        slack_channel: "The chapter or the workshop specific slack channel. This can be used for socialising, or sharing other details about the workshop."
         slack_channel_link: 'Right click the Slack channel to get the link'
         host: 'Required by physical workshops but not supported for virtual workshops'
         description: 'Supports HTML'


### PR DESCRIPTION
Updated to hint that chapter specific channel can be used if chapter organisers do not want to create a virtual workshop specific channel as discussed in organiser meeting.