### PR TITLE
Add ends_at to meetings and course

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,7 +33,7 @@ $(function(){
   });
 
   $('#announcement_expires_at, #ban_expires_at').pickadate();
-  $('#meeting_local_time, #workshop_local_time, #workshop_local_end_time, #event_begins_at, #event_ends_at, #workshop_rsvp_open_local_time').pickatime({
+  $('#meeting_local_time, #workshop_local_time, #workshop_local_end_time, #event_begins_at, #event_ends_at, #meeting_local_end_time, #workshop_rsvp_open_local_time').pickatime({
     format: 'HH:i'
   });
 

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -71,7 +71,7 @@ class Admin::MeetingsController < Admin::ApplicationController
 
   def meeting_params
     params.require(:meeting).permit(
-      :name, :description, :slug, :date_and_time, :local_date, :local_time,
+      :name, :description, :slug, :date_and_time, :local_date, :local_time, :local_end_time,
       :invitable, :spaces, :venue_id, :sponsor_id, :chapters
     )
   end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,7 +3,7 @@ class Meeting < ActiveRecord::Base
   include Listable
   include Invitable
 
-  attr_accessor :local_date, :local_time
+  attr_accessor :local_date, :local_time, :local_end_time
 
   resourcify :permissions, role_cname: 'Permission', role_table_name: :permission
 
@@ -12,10 +12,10 @@ class Meeting < ActiveRecord::Base
   has_many :invitations, foreign_key: 'meeting_id', class_name: 'MeetingInvitation'
   has_and_belongs_to_many :chapters
 
-  validates :date_and_time, :venue, presence: true
+  validates :date_and_time, :ends_at, :venue, presence: true
   validates :slug, uniqueness: true, if: proc { |model| model.slug.present? }
 
-  before_validation :set_date_and_time
+  before_validation :set_date_and_time, :set_end_date_and_time
   before_save :set_slug
 
   def invitees

--- a/app/views/admin/meetings/_form.html.haml
+++ b/app/views/admin/meetings/_form.html.haml
@@ -12,6 +12,8 @@
   .row
     .medium-6.columns
       = f.input :local_time, as: :string, required: true, input_html: { data: { value: @meeting.time.try(:strftime, '%H:%M') } }
+    .medium-6.columns
+      = f.input :local_end_time, label: 'Ends at', as: :string, required: true, input_html: { data: { value: @meeting.ends_at.try(:strftime, '%H:%M') } }
   .row
     .large-12.columns.admin_margin
       = f.input :description, placeholder: 'Supports HTML', as: :text, input_html: { style: 'height: 300px;' }

--- a/app/views/admin/meetings/show.html.haml
+++ b/app/views/admin/meetings/show.html.haml
@@ -19,7 +19,7 @@
         %h2
           =@meeting.name
         %h3
-          %small #{humanize_date(@meeting.date_and_time, nil, with_time: true)}
+          %small #{humanize_date(@meeting.date_and_time, @meeting.ends_at, with_time: true)}
 
     .row
       .medium-2.columns

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -6,7 +6,7 @@
       %h2
         =@meeting.name
       %h3
-        %small=humanize_date(@meeting.date_and_time, with_time: true)
+        %small=humanize_date(@meeting.date_and_time, @meeting.ends_at, with_time: true)
 
   .row
     .medium-4.columns

--- a/db/migrate/20201109043756_add_end_dt_to_meetings_courses.rb
+++ b/db/migrate/20201109043756_add_end_dt_to_meetings_courses.rb
@@ -1,0 +1,6 @@
+class AddEndDtToMeetingsCourses < ActiveRecord::Migration
+  def change
+    add_column :meetings, :ends_at, :datetime
+    add_column :courses, :ends_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201102173506) do
+ActiveRecord::Schema.define(version: 20201109043756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,8 +129,8 @@ ActiveRecord::Schema.define(version: 20201102173506) do
     t.string   "name"
     t.string   "surname"
     t.string   "email"
-    t.boolean  "mailing_list_consent",        default: false
-    t.string   "token",                                       null: false
+    t.boolean  "mailing_list_consent", default: false
+    t.string   "token",                                null: false
   end
 
   add_index "contacts", ["email", "sponsor_id"], name: "index_contacts_on_email_and_sponsor_id", unique: true, using: :btree
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 20201102173506) do
     t.integer  "sponsor_id"
     t.string   "ticket_url"
     t.integer  "chapter_id"
+    t.datetime "ends_at"
   end
 
   add_index "courses", ["chapter_id"], name: "index_courses_on_chapter_id", using: :btree
@@ -382,6 +383,7 @@ ActiveRecord::Schema.define(version: 20201102173506) do
     t.integer  "spaces"
     t.integer  "sponsor_id"
     t.boolean  "invites_sent",  default: false
+    t.datetime "ends_at"
   end
 
   add_index "meetings", ["slug"], name: "index_meetings_on_slug", unique: true, using: :btree

--- a/spec/fabricators/course_fabricator.rb
+++ b/spec/fabricators/course_fabricator.rb
@@ -4,6 +4,7 @@ Fabricator(:course) do
   description { Faker::Lorem.paragraph }
   tutor { Fabricate(:member) }
   date_and_time { Time.zone.now + 1.week }
+  ends_at       { Time.zone.now + 2.weeks }
   seats 1
   url { Faker::Internet.url }
   sponsor

--- a/spec/fabricators/meeting_fabricator.rb
+++ b/spec/fabricators/meeting_fabricator.rb
@@ -2,6 +2,7 @@ Fabricator(:meeting) do
   name        { Faker::Lorem.sentence }
   description { Faker::Lorem.paragraph }
   date_and_time { Time.zone.now + 1.week }
+  ends_at       { Time.zone.now + 1.week + 2.hours }
   # sponsor
   venue { Fabricate(:sponsor) }
   invitable true

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Managing meetings', type: :feature do
       fill_in 'Name', with: 'August meeting'
       fill_in 'Local date', with: Date.current
       fill_in 'Local time', with: '11:30'
+      fill_in 'Ends at', with: '12:00'
       select venue.name
       click_on 'Update'
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Meeting, type: :model do
   context 'validations' do
     subject(:meeting) { Fabricate(:meeting) }
     it { is_expected.to validate_presence_of(:date_and_time) }
+    it { is_expected.to validate_presence_of(:ends_at) }
     it { is_expected.to validate_presence_of(:venue) }
 
     context '#slug' do


### PR DESCRIPTION
Add ends_at to database, model, and views for meetings. Courses doesn't have views yet.
fixes #1306 