### PR TITLE
Create `MeetingInvitations` when meeting invitation emails are sent

### DIFF
--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -46,11 +46,6 @@ class Admin::MeetingsController < Admin::ApplicationController
   end
 
   def invite
-    if @meeting.invites_sent
-      return redirect_to admin_meeting_path(@meeting),
-                         notice: t('admin.messages.meeting.invitations_already_sent')
-    end
-
     InvitationManager.new.send_meeting_emails(@meeting)
 
     redirect_to admin_meeting_path(@meeting), notice: t('admin.messages.meeting.sending_invitations')

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -52,7 +52,9 @@ class Admin::MeetingsController < Admin::ApplicationController
     end
 
     @meeting.invitees.not_banned.each do |invitee|
-      MeetingInvitationMailer.invite(@meeting, invitee).deliver_now
+      invitation = MeetingInvitation
+        .create(meeting: @meeting, member: invitee, role: 'Participant')
+      MeetingInvitationMailer.invite(@meeting, invitee, invitation).deliver_now
     end
     @meeting.update_attribute(:invites_sent, true)
 

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -51,12 +51,7 @@ class Admin::MeetingsController < Admin::ApplicationController
                          notice: t('admin.messages.meeting.invitations_already_sent')
     end
 
-    @meeting.invitees.not_banned.each do |invitee|
-      invitation = MeetingInvitation
-        .create(meeting: @meeting, member: invitee, role: 'Participant')
-      MeetingInvitationMailer.invite(@meeting, invitee, invitation).deliver_now
-    end
-    @meeting.update_attribute(:invites_sent, true)
+    InvitationManager.new.send_meeting_emails(@meeting)
 
     redirect_to admin_meeting_path(@meeting), notice: t('admin.messages.meeting.sending_invitations')
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -62,7 +62,7 @@ class InvitationsController < ApplicationController
     invitation = if params[:token].present?
       MeetingInvitation.find_by(token: params[:token], member: current_user)
     else
-      MeetingInvitation.build(
+      MeetingInvitation.new(
         meeting: meeting, member: current_user, role: 'Participant'
       )
     end
@@ -71,7 +71,8 @@ class InvitationsController < ApplicationController
 
     if invitation.save
       MeetingInvitationMailer.attending(meeting, current_user).deliver_now
-      redirect_to meeting_path(meeting), notice: t('messages.invitations.meeting.rsvp')
+      redirect_to meeting_path(meeting, token: invitation.token),
+                  notice: t('messages.invitations.meeting.rsvp')
     else
       redirect_to :back, notice: 'Sorry, something went wrong'
     end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -59,7 +59,13 @@ class InvitationsController < ApplicationController
 
     meeting = Meeting.find_by(slug: params[:meeting_id])
 
-    invitation = MeetingInvitation.find_or_create_by(meeting: meeting, member: current_user, role: 'Participant')
+    invitation = if params[:token].present?
+      MeetingInvitation.find_by(token: params[:token])
+    else
+      MeetingInvitation.build(
+        meeting: meeting, member: current_user, role: 'Participant'
+      )
+    end
 
     invitation.update_attribute(:attending, true)
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -60,7 +60,7 @@ class InvitationsController < ApplicationController
     meeting = Meeting.find_by(slug: params[:meeting_id])
 
     invitation = if params[:token].present?
-      MeetingInvitation.find_by(token: params[:token])
+      MeetingInvitation.find_by(token: params[:token], member: current_user)
     else
       MeetingInvitation.build(
         meeting: meeting, member: current_user, role: 'Participant'

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -2,9 +2,9 @@ class MeetingsController < ApplicationController
   before_action :set_meeting
 
   def show
-    if @meeting.attending?(current_user)
-      @invitation = MeetingInvitation.where(meeting: @meeting, member: current_user).last
-    end
+    @invitation = MeetingInvitation
+      .where(meeting: @meeting, member: current_user)
+      .last
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @attendees = @meeting.invitations.where(attending: true)
   end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -2,9 +2,9 @@ class MeetingsController < ApplicationController
   before_action :set_meeting
 
   def show
-    @invitation = MeetingInvitation
-      .where(meeting: @meeting, member: current_user)
-      .last
+    @invitation = if params[:token].present?
+      MeetingInvitation.find_by(token: params[:token], member: current_user)
+    end
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @attendees = @meeting.invitations.where(attending: true)
   end

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -9,7 +9,7 @@ class MeetingInvitationMailer < ActionMailer::Base
     @meeting = meeting
     @invitation = invitation
     @host_address = AddressPresenter.new(@meeting.venue.address)
-    @rsvp_url = meeting_url(@meeting)
+    @rsvp_url = meeting_url(@meeting, token: @invitation.token)
 
     subject = "You are invited to codebar's #{@meeting.name} on #{humanize_date(@meeting.date_and_time)}"
     mail(mail_args(@member, subject), &:html)

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -4,9 +4,10 @@ class MeetingInvitationMailer < ActionMailer::Base
 
   helper ApplicationHelper
 
-  def invite(meeting, member)
+  def invite(meeting, member, invitation)
     @member = member
     @meeting = meeting
+    @invitation = invitation
     @host_address = AddressPresenter.new(@meeting.venue.address)
     @rsvp_url = meeting_url(@meeting)
 

--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -26,6 +26,15 @@ class InvitationManager
   end
   handle_asynchronously :send_course_emails
 
+  def send_meeting_emails(meeting)
+    meeting.invitees.not_banned.each do |invitee|
+      invitation = MeetingInvitation.new(meeting: meeting, member: invitee, role: 'Participant')
+      MeetingInvitationMailer.invite(meeting, invitee, invitation).deliver_now if invitation.save
+    end
+    meeting.update_attribute(:invites_sent, true)
+  end
+  handle_asynchronously :send_meeting_emails
+
   private
 
   def invite_students_to_event(event, chapter)

--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -31,7 +31,6 @@ class InvitationManager
       invitation = MeetingInvitation.new(meeting: meeting, member: invitee, role: 'Participant')
       MeetingInvitationMailer.invite(meeting, invitee, invitation).deliver_now if invitation.save
     end
-    meeting.update_attribute(:invites_sent, true)
   end
   handle_asynchronously :send_meeting_emails
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -22,6 +22,7 @@ class Member < ActiveRecord::Base
   validates :email, uniqueness: true
   validates :about_you, length: { maximum: 255 }
 
+  scope :order_by_email, -> { order(:email) }
   scope :subscribers, -> { joins(:subscriptions).order('created_at desc').uniq }
   scope :not_banned, lambda {
                        joins('LEFT OUTER JOIN bans ON members.id = bans.member_id')

--- a/app/presenters/meeting_presenter.rb
+++ b/app/presenters/meeting_presenter.rb
@@ -4,6 +4,7 @@ class MeetingPresenter < EventPresenter
   def attendees_emails
     Member.joins(:meeting_invitations)
           .where('meeting_invitations.meeting_id = ? and meeting_invitations.attending = ?', model.id, true)
+          .order_by_email
           .pluck(:email).join(', ')
   end
 

--- a/app/views/meetings/_meeting_actions.html.haml
+++ b/app/views/meetings/_meeting_actions.html.haml
@@ -28,8 +28,7 @@
         = link_to "Can't make it anymore? Click here to cancel your spot.", meeting_cancel_path(meeting_id: @meeting.id, token: @invitation.token)
 
     - elsif @meeting.invitable && @meeting.not_full
-      = link_to meeting_invitation_path(@meeting), class: 'button round' do
-        = "Attend"
+      = link_to "Attend", meeting_invitation_path(@meeting, token: @invitation&.token), class: "button round"
 
     - elsif !@meeting.not_full
       %h5 This event is now full.

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -85,13 +85,6 @@ RSpec.feature 'Managing meetings', type: :feature do
   end
 
   context 'sending invitations' do
-    scenario 'redirects back to the meeting if the invitations have been sent' do
-      meeting = Fabricate(:meeting, invites_sent: true)
-
-      visit invite_admin_meeting_path(meeting)
-      expect(page).to have_content("Invitations were previously sent; they will not be sent again")
-    end
-
     scenario 'sends the invitations' do
       chapter = Fabricate(:chapter_with_groups)
       meeting = Fabricate(:meeting, chapters: [chapter])

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 RSpec.describe MeetingInvitationMailer, type: :mailer do
   let(:meeting) { Fabricate(:meeting) }
   let(:member) { Fabricate(:member) }
+  let(:invitation) { Fabricate(:meeting_invitation, meeting: meeting, member: member) }
 
   describe '#invite' do
-    let(:mail) { MeetingInvitationMailer.invite(meeting, member).deliver_now }
+    let(:mail) { MeetingInvitationMailer.invite(meeting, member, invitation).deliver_now }
 
     it 'renders the headers' do
       expect(mail.subject).to eq("You are invited to codebar\'s #{meeting.name} on #{humanize_date(meeting.date_and_time)}")

--- a/spec/mailers/previews/meeting_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/meeting_invitation_mailer_preview.rb
@@ -1,6 +1,14 @@
 class MeetingInvitationMailerPreview < ActionMailer::Preview
   def invite
-    MeetingInvitationMailer.invite(Meeting.last, Member.last)
+    meeting = Meeting.last
+    member = Member.last
+
+    # In the real work, MeetingInvitation should have been created already and a
+    # token should have been assigned. The next lines are for testing purposes.
+    invitation = MeetingInvitation.new(meeting: meeting, member: member)
+    invitation.token = "tokenExample28XIcd6IxQ"
+
+    MeetingInvitationMailer.invite(meeting, member, invitation)
   end
 
   def attending

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -174,4 +174,22 @@ RSpec.describe InvitationManager, type: :model do
       manager.send_waiting_list_emails(workshop)
     end
   end
+
+  describe '#send_meeting_emails' do
+    it 'emails all invitees that are not banned' do
+      meeting = Fabricate(:meeting, chapters: [chapter])
+      Fabricate(:students, chapter: chapter, members: students)
+
+      # Ban one member
+      Fabricate(:ban, member: students.last)
+      expected_student_count = students.count - 1
+
+      expect(MeetingInvitationMailer).to receive(:invite)
+        .exactly(expected_student_count).times
+        .with(meeting, instance_of(Member), instance_of(MeetingInvitation))
+        .and_call_original
+
+      manager.send_meeting_emails(meeting)
+    end
+  end
 end

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -191,5 +191,21 @@ RSpec.describe InvitationManager, type: :model do
 
       manager.send_meeting_emails(meeting)
     end
+
+    it 'emails valid invitees only once' do
+      meeting = Fabricate(:meeting, chapters: [chapter])
+      Fabricate(:students, chapter: chapter, members: students)
+
+      # Emulate a member already invited
+      MeetingInvitation.create(meeting: meeting, member: students.last, role: 'Participant')
+      expected_student_count = students.count - 1
+
+      expect(MeetingInvitationMailer).to receive(:invite)
+        .exactly(expected_student_count).times
+        .with(meeting, instance_of(Member), instance_of(MeetingInvitation))
+        .and_call_original
+
+      manager.send_meeting_emails(meeting)
+    end
   end
 end

--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe MeetingPresenter do
   it '#attendees_emails' do
     attendees = Fabricate.times(4, :attending_meeting_invitation, meeting: meeting)
 
-    expect(event.attendees_emails).to eq(attendees.map(&:member).map(&:email).join(', '))
+    expect(event.attendees_emails).to eq(
+      attendees.map(&:member).map(&:email).sort.join(', ')
+    )
   end
 
   it '#time' do


### PR DESCRIPTION
Details on https://github.com/codebar/planner/issues/1317

I believe this is the core functionality, but please let me know if I missed something. `MeetingInvitation` are now created when the email is sent (through a delayed job) and retrieved by a token (if present).

**Update:** one test started failing with my last changes, I’ll address it this weekend. 💪🏻