### PR TITLE
Improve admin member view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -270,3 +270,6 @@ RSpec/SubjectStub:
   Enabled: true
   Exclude:
     - 'spec/models/job_spec.rb'
+
+RSpec/NestedGroups:
+  Max: 5

--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -1395,6 +1395,10 @@ body.dashboard-faq dl dt {
   color: $warning-color;
 }
 
+.info {
+  color: $info-color;
+}
+
 .top-bar {
   padding: 0 10px;
 }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -16,6 +16,7 @@
 @import 'partials/star-rating';
 @import 'partials/event';
 @import 'partials/workshop';
+@import 'partials/admin_member';
 
 .row-spaced {
   padding-bottom: 20px;

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -2,6 +2,7 @@
 @import 'partials/colors';
 
 .digg_pagination {
+  padding-bottom: 1em;
   background: white;
   cursor: default;
   /* self-clearing method: */ }

--- a/app/assets/stylesheets/partials/_admin_member.scss
+++ b/app/assets/stylesheets/partials/_admin_member.scss
@@ -62,4 +62,26 @@
       line-height: 1.2em;
     }
   }
+
+  .attendance {
+    .attended, .not-attended, .no-attendance {
+      color: $white;
+      padding-left: 10px;
+      font-size: 0.9em;
+      text-transform: uppercase;
+      font-weight: bold;
+    }
+  }
+
+  .attended {
+    background-color: $lightgreen;
+  }
+
+  .not-attended {
+    background-color: $red;
+  }
+
+  .no-attendance {
+    background-color: $lightgray;
+  }
 }

--- a/app/assets/stylesheets/partials/_admin_member.scss
+++ b/app/assets/stylesheets/partials/_admin_member.scss
@@ -1,0 +1,65 @@
+@import 'foundation_and_overrides';
+
+#admin-member {
+
+  #actions {
+    .alert {
+      color: $lightyellow;
+    }
+
+    .success {
+      color: $lightgreen;
+    }
+
+    li {
+      padding-bottom: 1em;
+
+      .note, .suspension, .warning {
+        display: inline-flex;
+      }
+
+      .details {
+        display: inline-grid;
+        padding-left: 10px;
+        padding-top: 5px;
+
+        .date {
+          font-size: 0.9em;
+        }
+
+        .explanation {
+          font-size: 0.9em;
+          color: #999;
+          display: flex;
+
+          span {
+            &.warning {
+              color: $lightyellow;
+            }
+          }
+
+          div {
+            padding: 5px;
+          }
+        }
+      }
+
+    }
+  }
+
+  section  {
+    padding-top: 50px;
+
+  }
+
+  #profile {
+    img {
+      padding-bottom: 10px;
+    }
+
+    .name {
+      font-size: 1.5em;
+      line-height: 1.2em;
+    }
+  }
+}

--- a/app/assets/stylesheets/partials/_colors.sass
+++ b/app/assets/stylesheets/partials/_colors.sass
@@ -45,3 +45,4 @@ $dark-color: #0e001b
 
 $primary-color: #596677
 $secondary-color: $codebar-blue
+$lightgray: #ccc

--- a/app/controllers/admin/bans_controller.rb
+++ b/app/controllers/admin/bans_controller.rb
@@ -11,7 +11,7 @@ class Admin::BansController < Admin::ApplicationController
 
     if @ban.save
       MemberMailer.ban(@ban.member, @ban).deliver_now
-      redirect_to [:admin, @member], notice: 'The user has been suspended'
+      redirect_to [:admin, @member], notice: t('.success')
     else
       render 'new'
     end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -23,12 +23,14 @@ class Admin::MembersController < Admin::ApplicationController
   end
 
   def send_eligibility_email
-    @member.send_eligibility_email(current_user)
+    @member.eligibility_inquiries.create!(issued_by: current_user)
+
     redirect_to [:admin, @member], notice: t('admin.members.eligibility_confirmation_request')
   end
 
   def send_attendance_email
-    @member.send_attendance_email(current_user)
+    @member.attendance_warnings.create!(issued_by: current_user)
+
     redirect_to [:admin, @member], notice: t('admin.members.attendance_warning')
   end
 

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,18 +1,19 @@
 class Admin::MembersController < Admin::ApplicationController
-  before_action :set_member, only: %i[update_subscriptions send_attendance_email send_eligibility_email]
+  before_action :set_member, only: %i[events update_subscriptions send_attendance_email send_eligibility_email]
 
   def index
     @members = Member.all
   end
 
   def show
-    @member = Member.includes(:member_notes).find(params[:id])
-    @actions = admin_actions(@member).sort_by(&:created_at).reverse
-    @workshop_attendances = @member.workshop_invitations.joins(:workshop).taken_place.attended.count
-    @event_rsvps = @member.invitations.joins(:event).taken_place.accepted.count
-    @meeting_rsvps = @member.meeting_invitations.joins(:meeting).taken_place.count
+    @member = Member.find(params[:id])
+    load_attendance_data(@member)
 
-    @member_note = MemberNote.new
+    @actions = admin_actions(@member).sort_by(&:created_at).reverse
+  end
+
+  def events
+    load_attendance_data(@member)
   end
 
   def update_subscriptions
@@ -40,6 +41,12 @@ class Admin::MembersController < Admin::ApplicationController
 
   def set_member
     @member = Member.find(params[:member_id])
+  end
+
+  def load_attendance_data(member)
+    @workshop_attendances = member.workshop_invitations.joins(:workshop).taken_place.attended.count
+    @event_rsvps = member.invitations.joins(:event).taken_place.accepted.count
+    @meeting_rsvps = member.meeting_invitations.joins(:meeting).taken_place.count
   end
 
   def admin_actions(member)

--- a/app/models/attendance_warning.rb
+++ b/app/models/attendance_warning.rb
@@ -1,4 +1,12 @@
 class AttendanceWarning < ActiveRecord::Base
   belongs_to :member
-  belongs_to :added_by, class_name: 'Member'
+  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id'
+
+  before_save :send_email
+
+  private
+
+  def send_email
+    MemberMailer.attendance_warning(member, member.email).deliver_now
+  end
 end

--- a/app/models/attendance_warning.rb
+++ b/app/models/attendance_warning.rb
@@ -1,6 +1,8 @@
 class AttendanceWarning < ActiveRecord::Base
   belongs_to :member
-  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id'
+  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id', inverse_of: false
+
+  scope :last_six_months, -> { where(created_at: 6.months.ago...Time.zone.now) }
 
   before_save :send_email
 

--- a/app/models/concerns/invitation_concerns.rb
+++ b/app/models/concerns/invitation_concerns.rb
@@ -10,6 +10,8 @@ module InvitationConcerns
 
     scope :accepted, -> { where(attending: true) }
     scope :not_accepted, -> { where('attending is NULL or attending = false') }
+    scope :upcoming_rsvps, -> { accepted.where('date_and_time >= ?', Time.zone.now) }
+    scope :taken_place, -> { where('date_and_time < ?', Time.zone.now) }
 
     before_create :set_token
   end

--- a/app/models/concerns/invitation_concerns.rb
+++ b/app/models/concerns/invitation_concerns.rb
@@ -11,6 +11,7 @@ module InvitationConcerns
     scope :accepted, -> { where(attending: true) }
     scope :not_accepted, -> { where('attending is NULL or attending = false') }
     scope :upcoming_rsvps, -> { accepted.where('date_and_time >= ?', Time.zone.now) }
+    scope :past_rsvps, -> { accepted.taken_place }
     scope :taken_place, -> { where('date_and_time < ?', Time.zone.now) }
 
     before_create :set_token

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -1,0 +1,27 @@
+module Permissions
+  extend ActiveSupport::Concern
+
+  included do
+    rolify role_cname: 'Permission', role_table_name: :permission, role_join_table_name: :members_permissions
+
+    include InstanceMethods
+  end
+
+  module InstanceMethods
+    def organiser?
+      organised_chapters.present?
+    end
+
+    def admin_or_organiser?
+      has_role?(:admin) || organiser?
+    end
+
+    def monthlies_organiser?
+      Meeting.with_role(:organiser, self).present?
+    end
+
+    def organised_chapters
+      Chapter.with_role(:organiser, self)
+    end
+  end
+end

--- a/app/models/eligibility_inquiry.rb
+++ b/app/models/eligibility_inquiry.rb
@@ -1,4 +1,12 @@
 class EligibilityInquiry < ActiveRecord::Base
   belongs_to :member
-  belongs_to :added_by, class_name: 'Member'
+  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id'
+
+  before_save :send_email
+
+  private
+
+  def send_email
+    MemberMailer.eligibility_check(member, member.email).deliver_now
+  end
 end

--- a/app/models/eligibility_inquiry.rb
+++ b/app/models/eligibility_inquiry.rb
@@ -1,6 +1,6 @@
 class EligibilityInquiry < ActiveRecord::Base
   belongs_to :member
-  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id'
+  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id', inverse_of: false
 
   before_save :send_email
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,8 @@
 class Invitation < ActiveRecord::Base
   include InvitationConcerns
 
+  self.per_page = 20
+
   belongs_to :event
   belongs_to :member
   belongs_to :verified_by, class_name: 'Member'

--- a/app/models/meeting_invitation.rb
+++ b/app/models/meeting_invitation.rb
@@ -9,4 +9,6 @@ class MeetingInvitation < ActiveRecord::Base
 
   scope :accepted, -> { where(attending: true) }
   scope :attended, -> { where(attended: true) }
+
+  alias event meeting
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -80,16 +80,6 @@ class Member < ActiveRecord::Base
     true
   end
 
-  def send_eligibility_email(user)
-    MemberMailer.eligibility_check(self, user.email).deliver_now
-    eligibility_inquiries.create(sent_by_id: user.id)
-  end
-
-  def send_attendance_email(user)
-    MemberMailer.attendance_warning(self, user.email).deliver_now
-    attendance_warnings.create(sent_by_id: user.id)
-  end
-
   def avatar(size = 100)
     "https://secure.gravatar.com/avatar/#{md5_email}?size=#{size}&default=identicon"
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -90,10 +90,11 @@ class Member < ActiveRecord::Base
   end
 
   def upcoming_rsvps
-    @upcoming_rsvps ||= (invitations.joins(:event).upcoming_rsvps +
-                         workshop_invitations.joins(:workshop).includes(workshop: :chapter).upcoming_rsvps +
-                         meeting_invitations.joins(:meeting).upcoming_rsvps)
-                        .sort_by { |i| i.event.date_and_time }
+    @upcoming_rsvps ||= rsvps(period: :upcoming)
+  end
+
+  def past_rsvps
+    @past_rsvps ||= rsvps(period: :past).reverse
   end
 
   def flag_to_organisers?
@@ -116,5 +117,13 @@ class Member < ActiveRecord::Base
 
   def md5_email
     Digest::MD5.hexdigest(email.strip.downcase)
+  end
+
+  def rsvps(period:)
+    time_period = "#{period}_rsvps"
+
+    [invitations.joins(:event),
+     workshop_invitations.joins(:workshop).includes(workshop: :chapter),
+     meeting_invitations.joins(:meeting)].map(&time_period.to_sym).inject(:+).sort_by { |i| i.event.date_and_time }
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -53,10 +53,6 @@ class Member < ActiveRecord::Base
     bans.permanent.present?
   end
 
-  def more_than_two_absences?
-    workshop_invitations.last_six_months.accepted.length - workshop_invitations.last_six_months.attended.length > 2
-  end
-
   def full_name
     pronoun = pronouns.present? ? "(#{pronouns})" : nil
     [name, surname, pronoun].compact.join ' '
@@ -91,6 +87,15 @@ class Member < ActiveRecord::Base
 
   def already_attending(event)
     invitations.where(attending: true).map { |e| e.event.id }.include?(event.id)
+  end
+
+  def flag_to_organisers?
+    multiple_no_shows? && attendance_warnings.last_six_months.length >= 2
+  end
+
+  def multiple_no_shows?
+    last_six_month_rsvps = workshop_invitations.taken_place.last_six_months.accepted
+    (last_six_month_rsvps.length - last_six_month_rsvps.attended.length) > 3
   end
 
   private

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -89,6 +89,13 @@ class Member < ActiveRecord::Base
     invitations.where(attending: true).map { |e| e.event.id }.include?(event.id)
   end
 
+  def upcoming_rsvps
+    @upcoming_rsvps ||= (invitations.joins(:event).upcoming_rsvps +
+                         workshop_invitations.joins(:workshop).includes(workshop: :chapter).upcoming_rsvps +
+                         meeting_invitations.joins(:meeting).upcoming_rsvps)
+                        .sort_by { |i| i.event.date_and_time }
+  end
+
   def flag_to_organisers?
     multiple_no_shows? && attendance_warnings.last_six_months.length >= 2
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,7 @@
 class Member < ActiveRecord::Base
+  include Permissions
+
   self.per_page = 80
-  rolify role_cname: 'Permission', role_table_name: :permission, role_join_table_name: :members_permissions
 
   has_many :attendance_warnings
   has_many :bans
@@ -69,10 +70,6 @@ class Member < ActiveRecord::Base
     groups.coaches.any?
   end
 
-  def organised_chapters
-    Chapter.with_role(:organiser, self)
-  end
-
   def received_welcome_for?(subscription)
     return received_student_welcome_email if subscription.student?
     return received_coach_welcome_email if subscription.coach?
@@ -94,18 +91,6 @@ class Member < ActiveRecord::Base
 
   def already_attending(event)
     invitations.where(attending: true).map { |e| e.event.id }.include?(event.id)
-  end
-
-  def is_organiser?
-    organised_chapters.present?
-  end
-
-  def is_admin_or_organiser?
-    has_role?(:admin) || is_organiser?
-  end
-
-  def is_monthlies_organiser?
-    Meeting.with_role(:organiser, self).present?
   end
 
   private

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -10,7 +10,6 @@ class WorkshopInvitation < ActiveRecord::Base
   validates :tutorial, presence: true, if: :student_attending?
 
   scope :year, ->(year) { joins(:workshop).where('EXTRACT(year FROM workshops.date_and_time) = ?', year) }
-  scope :accepted, -> { where(attending: true) }
   scope :attended, -> { where(attended: true) }
   scope :accepted_or_attended, -> { where('attending=? or attended=?', true, true) }
   scope :to_students, -> { where(role: 'Student') }

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -32,6 +32,8 @@ class WorkshopInvitation < ActiveRecord::Base
     workshop
   end
 
+  alias event parent
+
   def student_attending?
     for_student? && attending.present?
   end

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -4,8 +4,12 @@ class EventPresenter < BasePresenter
                 meeting: 'MeetingPresenter',
                 event: 'EventPresenter' }.freeze
 
+  def self.decorate(event)
+    PRESENTER[event.class.to_s.downcase.to_sym].constantize.new(event)
+  end
+
   def self.decorate_collection(collection)
-    collection.map { |e| PRESENTER[e.class.to_s.downcase.to_sym].constantize.new(e) }
+    collection.map { |event| decorate(event) }
   end
 
   def chapter

--- a/app/views/admin/attendance_warnings/_attendance_warning.html.haml
+++ b/app/views/admin/attendance_warnings/_attendance_warning.html.haml
@@ -5,4 +5,4 @@
   .details{ style: 'display: inline-grid' }
     %strong Sent attendance warning email by #{link_to(action.issued_by.full_name, admin_member_path(action.issued_by))}
     .date
-      #{l(action.created_at, format: :workshop)}
+      #{l(action.created_at, format: :website_format)}

--- a/app/views/admin/attendance_warnings/_attendance_warning.html.haml
+++ b/app/views/admin/attendance_warnings/_attendance_warning.html.haml
@@ -1,0 +1,8 @@
+.attendance-warning
+  %span.fa-stack.fa-lg
+    %i.fa.fa-circle.fa-stack-2x.alert
+    %i.fa.fa-clock-o.fa-stack-1x
+  .details{ style: 'display: inline-grid' }
+    %strong Sent attendance warning email by #{link_to(action.issued_by.full_name, admin_member_path(action.issued_by))}
+    .date
+      #{l(action.created_at, format: :workshop)}

--- a/app/views/admin/bans/_ban.html.haml
+++ b/app/views/admin/bans/_ban.html.haml
@@ -1,0 +1,21 @@
+.suspension
+  %span.fa-stack.fa-lg
+    %i.fa.fa-user.fa-stack-1x
+    %i.fa.fa-ban.fa-stack-2x.warning
+  .details
+    %strong
+      - if action.permanent?
+        Suspended indefinitely
+      - else
+        Suspended until #{l(action.expires_at, format: :default_date)}
+      by #{link_to(action.added_by.full_name, action.added_by)}
+    %em= action.reason
+    %blockquote
+      = action.note
+    - if action.explanation.present?
+      .explanation
+        %span.fa-stack.fa-lg
+          %i.fa.fa-envelope-open.fa-stack-1x.info
+        %div= action.explanation
+    .date
+      = l(@member.bans.active.first.created_at, format: :website_format)

--- a/app/views/admin/eligibility_inquiries/_eligibility_inquiry.html.haml
+++ b/app/views/admin/eligibility_inquiries/_eligibility_inquiry.html.haml
@@ -1,0 +1,8 @@
+.eligibility-inquiry
+  %span.fa-stack.fa-lg
+    %i.fa.fa-circle.fa-stack-2x.alert
+    %i.fa.fa-paper-plane-o.fa-stack-1x
+  .details
+    %strong Sent eligibility inquiry email by #{link_to(action.issued_by.full_name, action.issued_by)}
+    .date
+      = l(action.created_at, format: :website_format)

--- a/app/views/admin/events/_event.html.haml
+++ b/app/views/admin/events/_event.html.haml
@@ -1,0 +1,30 @@
+.event
+  .event__col-1
+    %header.event__header
+      %h3.title
+        = link_to event.to_s, [:admin, event]
+        - if event.venue.present?
+          at
+          = event.venue.name
+    .event__details
+      .date
+        %i.material-icons
+          calendar_today
+        = event.date
+      .time
+        %i.material-icons
+          access_time
+        = event.time
+
+  .event__col-2
+    .event__labels
+      - if event.chapter
+        %span.label.status
+          = event.chapter.name
+        %span.label.success= invitation.role
+    - if event.organisers.any?
+      .event__organisers
+        .event__organisers-list
+          - event.organisers.each do |organiser|
+            = link_to twitter_url_for(organiser.twitter), class: 'user-link' do
+              = image_tag(organiser.avatar(26), class: 'th radius', title: organiser.full_name, alt: organiser.full_name)

--- a/app/views/admin/events/_event.html.haml
+++ b/app/views/admin/events/_event.html.haml
@@ -1,3 +1,14 @@
+- if event.date_and_time.past?
+  .attendance
+    - if (invitation.is_a?(WorkshopInvitation) && invitation.attended?)
+      .attended
+        attended
+    - elsif (invitation.is_a?(WorkshopInvitation) && !invitation.attended?)
+      .not-attended
+        not attended
+    - else
+      .no-attendance
+        No attendance data
 .event
   .event__col-1
     %header.event__header

--- a/app/views/admin/meetings/_meeting.html.haml
+++ b/app/views/admin/meetings/_meeting.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'admin/events/event', locals: { event: meeting, invitation: invitation }

--- a/app/views/admin/member_notes/_member_note.html.haml
+++ b/app/views/admin/member_notes/_member_note.html.haml
@@ -6,4 +6,4 @@
     %strong Note added by #{link_to(action.author.full_name, admin_member_path(action.author))}
     %blockquote=action.note
     .date
-      = l(action.created_at, format: :workshop)
+      = l(action.created_at, format: :website_format)

--- a/app/views/admin/member_notes/_member_note.html.haml
+++ b/app/views/admin/member_notes/_member_note.html.haml
@@ -1,0 +1,9 @@
+.note
+  %span.fa-stack.fa-lg
+    %i.fa.fa-circle.fa-stack-2x.info
+    %i.fa.fa-pencil.fa-stack-1x
+  .details
+    %strong Note added by #{link_to(action.author.full_name, admin_member_path(action.author))}
+    %blockquote=action.note
+    .date
+      = l(action.created_at, format: :workshop)

--- a/app/views/admin/members/_actions.html.haml
+++ b/app/views/admin/members/_actions.html.haml
@@ -1,0 +1,20 @@
+.icon-bar.four-up
+  = link_to '#', class: 'item', 'data-reveal-id': 'note-modal' do
+    %i.fa.fa-pencil
+    %label
+      Add note
+    = link_to admin_member_send_eligibility_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to verify their eligibility for codebar. This cannot be undone. Are you sure?"}, class: 'item' do
+      %i.fa.fa-paper-plane-o
+      %label Send eligibility inquiry
+  - if @member.attendance_warnings.empty?
+    = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?"}, class: 'item' do
+      %i.fa.fa-clock-o
+      %label Send attendance warning
+  - else
+    = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "#{@member.name} has already received a warning about missing too many workshops on #{@member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?"}, class: 'item' do
+      %i.fa.fa-clock-o
+      %label Send attendance warning
+  = link_to new_admin_member_ban_path(@member), class: 'item' do
+    %i.fa.fa-ban.warning
+    %label Suspend
+  = render 'note'

--- a/app/views/admin/members/_member_note.html.haml
+++ b/app/views/admin/members/_member_note.html.haml
@@ -1,3 +1,5 @@
-#note
-  %p= member_note.note
-  %cite &ndash; #{member_note.author.full_name}, #{member_note.created_at.to_s(:short)}
+%li.note
+  %small #{l(member_note.created_at, format: :short)}
+  %br
+  #{link_to member_note.author.full_name, admin_member_path(member_note.author)}
+  = member_note.note

--- a/app/views/admin/members/_note.html.haml
+++ b/app/views/admin/members/_note.html.haml
@@ -1,6 +1,6 @@
 #note-modal.reveal-modal{ 'data-reveal': true, 'aria-labelledby': 'modalTitle',  'aria-hidden': 'true', role: 'dialog' }
   %h3#modalTitle Add a note for #{@member.full_name}
-  = simple_form_for [:admin, @member_note] do |f|
+  = simple_form_for [:admin, MemberNote.new] do |f|
     = f.input :note, label: false, placeholder: 'e.g. very enthusiastic student.'
     = f.hidden_field :member_id, value: @member.id
     = f.submit 'Save', class: 'button small'

--- a/app/views/admin/members/_note.html.haml
+++ b/app/views/admin/members/_note.html.haml
@@ -3,6 +3,6 @@
   = simple_form_for [:admin, @member_note] do |f|
     = f.input :note, label: false, placeholder: 'e.g. very enthusiastic student.'
     = f.hidden_field :member_id, value: @member.id
-    = f.submit 'Add note', class: 'button small'
+    = f.submit 'Save', class: 'button small'
   = link_to '#', class: 'close-reveal-modal', 'aria-label': 'Close' do
     &#215;

--- a/app/views/admin/members/_profile.html.haml
+++ b/app/views/admin/members/_profile.html.haml
@@ -1,0 +1,40 @@
+#profile
+  = image_tag(@member.avatar(200), class: 'th', title: @member.full_name, alt: @member.full_name)
+  .name= @member.full_name
+  .email= mail_to @member.email, @member.email
+  %dt= @member&.mobile
+  %p.lead= @member.about_you
+
+  %hr
+
+  - if @workshop_attendances.positive? || @meeting_rsvps.positive? || @event_rsvps.positive?
+    .attendance-summary
+      %h5 Attendance summary
+      %ul.no-bullet
+        - if @workshop_attendances.positive?
+          %label.label.round #{@workshop_attendances}
+          workshops
+
+        - if @meeting_rsvps.positive?
+          %li
+            %label.label.round #{@meeting_rsvps}
+            meetings
+
+        - if @event_rsvps.positive?
+          %li
+            %label.label.round #{@event_rsvps}
+            events
+    %hr
+  - if @member.groups.any?
+    %h4 Groups
+    %ul.no-bullet#subscriptions
+      - @member.groups.each do |group|
+        %li
+          = link_to [:admin, group] do
+            #{group.name} (#{group.chapter.name})
+          = link_to admin_member_update_subscriptions_path(member_id: @member, group: group), data: {confirm: "Clicking OK will remove this user from this subscription. This cannot be undone. Are you sure?"} do
+            %span.fa.fa-times
+  - else
+    %label.label.secondary #{@member.name} is not subscribed to any groups
+
+  %hr

--- a/app/views/admin/members/_profile.html.haml
+++ b/app/views/admin/members/_profile.html.haml
@@ -7,6 +7,13 @@
 
   %hr
 
+  - if @member.skills.any?
+    %h5 Skills
+
+    - @member.skills.each do |skill|
+      %span.label= skill.name
+    %hr
+
   - if @workshop_attendances.positive? || @meeting_rsvps.positive? || @event_rsvps.positive?
     .attendance-summary
       %h5 Attendance summary

--- a/app/views/admin/members/events.html.haml
+++ b/app/views/admin/members/events.html.haml
@@ -1,0 +1,25 @@
+#admin-member
+  = render 'actions'
+  %section
+    .row
+      .medium-3.columns
+        = render 'profile'
+      .medium-9.columns
+        %p
+          =link_to admin_member_path(@member) do
+            %i.fa.fa-arrow-left
+            Back to member summary
+        - if @member.upcoming_rsvps.any?
+          %h3 Upcoming RSVPs
+          - @member.upcoming_rsvps.each do |invitation|
+            = render EventPresenter.decorate(invitation.event), invitation: invitation
+
+        - if @member.past_rsvps.any?
+          %h3 Past RSVPs
+          .digg_pagination
+            .page_info
+              = page_entries_info(@member.past_rsvps.paginate(per_page: 20, page: params['page']), model: 'past events')
+            = will_paginate(@member.past_rsvps.paginate(per_page: 20, page: params['page']))
+
+          - @member.past_rsvps.paginate(per_page: 20, page: params['page']).each do |invitation|
+            = render EventPresenter.decorate(invitation.event), invitation: invitation

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -1,88 +1,27 @@
 #admin-member
-  .icon-bar.four-up
-    = link_to '#', class: 'item', 'data-reveal-id': 'note-modal' do
-      %i.fa.fa-pencil
-      %label
-        Add note
-      = link_to admin_member_send_eligibility_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to verify their eligibility for codebar. This cannot be undone. Are you sure?"}, class: 'item' do
-        %i.fa.fa-paper-plane-o
-        %label Send eligibility inquiry
-    - if @member.attendance_warnings.empty?
-      = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?"}, class: 'item' do
-        %i.fa.fa-clock-o
-        %label Send attendance warning
-    - else
-      = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "#{@member.name} has already received a warning about missing too many workshops on #{@member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?"}, class: 'item' do
-        %i.fa.fa-clock-o
-        %label Send attendance warning
-    = link_to new_admin_member_ban_path(@member), class: 'item' do
-      %i.fa.fa-ban.warning
-      %label Suspend
-
+  = render 'actions'
   %section
-    #profile
-      .row
-        .medium-3.columns
-          = image_tag(@member.avatar(200), class: 'th', title: @member.full_name, alt: @member.full_name)
-          .name= @member.full_name
-          .email= mail_to @member.email, @member.email
-          %dt= @member&.mobile
-          %p.lead= @member.about_you
+    .row
+      .medium-3.columns
+        = render 'profile'
+      .medium-9.columns
+        %ul.no-bullet#actions
+          - @actions.each do |action|
+            %li= render action, action: action
 
-          %hr
-
-          - if @workshop_attendances.positive? || @meeting_rsvps.positive? || @event_rsvps.positive?
-            .attendance-summary
-              %h5 Attendance summary
-              %ul.no-bullet
-                - if @workshop_attendances.positive?
-                  %label.label.round #{@workshop_attendances}
-                  workshops
-
-                - if @meeting_rsvps.positive?
-                  %li
-                    %label.label.round #{@meeting_rsvps}
-                    meetings
-
-                - if @event_rsvps.positive?
-                  %li
-                    %label.label.round #{@event_rsvps}
-                    events
-            %hr
-          - if @member.groups.any?
-            %h4 Groups
-            %ul.no-bullet#subscriptions
-              - @member.groups.each do |group|
-                %li
-                  = link_to [:admin, group] do
-                    #{group.name} (#{group.chapter.name})
-                  = link_to admin_member_update_subscriptions_path(member_id: @member, group: group), data: {confirm: "Clicking OK will remove this user from this subscription. This cannot be undone. Are you sure?"} do
-                    %span.fa.fa-times
-          - else
-            %label.label.secondary #{@member.name} is not subscribed to any groups
-
-          %hr
-
-        .medium-9.columns
-          %ul.no-bullet#actions
-            - @actions.each do |action|
-              %li= render action, action: action
-
-            %li
-              %span.fa-stack.fa-lg
-                %i.fa.fa-circle.fa-stack-2x.success
-                %i.fa.fa-user-o.fa-stack-1x
-              .details
-                %strong Signed up
-                .date
-                  = l(@member.created_at, format: :workshop)
+          %li
+            %span.fa-stack.fa-lg
+              %i.fa.fa-circle.fa-stack-2x.success
+              %i.fa.fa-user-o.fa-stack-1x
+            .details
+              %strong Signed up
+              .date
+                = l(@member.created_at, format: :website_format)
 
 
-          - if @member.upcoming_rsvps.any?
-            %h3 Upcoming RSVPs
-            - @member.upcoming_rsvps.each do |invitation|
-              = render EventPresenter.decorate(invitation.event), invitation: invitation
+        - if @member.upcoming_rsvps.any?
+          %h3 Upcoming RSVPs
+          - @member.upcoming_rsvps.each do |invitation|
+            = render EventPresenter.decorate(invitation.event), invitation: invitation
 
-          = link_to 'View all RSVPS', '#', class: 'button expand'
-
-  = render partial: 'note'
+        = link_to 'View all RSVPS', admin_member_events_path(@member), class: 'button expand'

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -1,189 +1,88 @@
-.icon-bar.six-up
-  = link_to new_admin_member_ban_path(@member), class: 'item' do
-    %i.fa.fa-ban.warning
-    %label Suspend
-  = link_to '#', class: 'item', 'data-reveal-id': 'note-modal' do
-    %i.fa.fa-pencil
-    %label Note
-  - if @member.student?
-    = link_to admin_member_send_eligibility_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to verify their eligibility for codebar. This cannot be undone. Are you sure?"}, class: 'item' do
-      %i.fa.fa-envelope
-      %label Eligibility
-  - if @member.attendance_warnings.empty?
-    = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?"}, class: 'item' do
-      %i.fa.fa-clock-o
-      %label Attendance
-  - else
-    = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "#{@member.name} has already received a warning about missing too many workshops on #{@member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?"}, class: 'item' do
-      %i.fa.fa-clock-o
-      %label Attendance
+#admin-member
+  .icon-bar.four-up
+    = link_to '#', class: 'item', 'data-reveal-id': 'note-modal' do
+      %i.fa.fa-pencil
+      %label
+        Add note
+      = link_to admin_member_send_eligibility_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to verify their eligibility for codebar. This cannot be undone. Are you sure?"}, class: 'item' do
+        %i.fa.fa-paper-plane-o
+        %label Send eligibility inquiry
+    - if @member.attendance_warnings.empty?
+      = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?"}, class: 'item' do
+        %i.fa.fa-clock-o
+        %label Send attendance warning
+    - else
+      = link_to admin_member_send_attendance_email_path(@member), data: {confirm: "#{@member.name} has already received a warning about missing too many workshops on #{@member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?"}, class: 'item' do
+        %i.fa.fa-clock-o
+        %label Send attendance warning
+    = link_to new_admin_member_ban_path(@member), class: 'item' do
+      %i.fa.fa-ban.warning
+      %label Suspend
 
-%section
-  .stripe.reverse
-    .row
-      .medium-1.columns
-        = image_tag(@member.avatar(100), class: 'th radius', title: @member.full_name, alt: @member.full_name)
-      .medium-11.columns
-        %h2= @member.full_name
-    .row
-      .medium-8.columns
-        %dl
-          %dt Pronouns
-          %dd= @member.pronouns || 'Not specified'
-
-          %dt Email
-          %dd= mail_to @member.email, @member.email
-
-          %dt Twitter
-          %dd= link_to "@#{@member.twitter}", twitter_url_for(@member.twitter)
-
-          %dt Phone number
-          %dd= @member.mobile || 'N/A'
-
-          %dt About
-          %dd= @member.about_you
-
-          = render "shared/skills", member: @member
-
-      .medium-4.columns
-        - if @member.banned?
-
-          %span.fa-stack.fa-lg
-            %i.fa.fa-user.fa-stack-1x
-            %i.fa.fa-ban.fa-stack-2x.warning
-          =link_to  '#suspensions' do
-            %label.label.warning Suspended
-        - if @member.groups.any?
-          %h3 Subscriptions
-          %ul.no-bullet#subscriptions
-            - @member.groups.each do |group|
-              %li
-                = link_to [:admin, group] do
-                  #{group.name} (#{group.chapter.name})
-                = link_to admin_member_update_subscriptions_path(member_id: @member, group: group), data: {confirm: "Clicking OK will remove this user from this subscription. This cannot be undone. Are you sure?"} do
-                  %span.fa.fa-times
-        - else
-          %label.label.secondary #{@member.name} is not subscribed to any groups
-        %br
-        Member since
-        %em #{l(@member.created_at, format: :website_format)}
-        - if @member.eligibility_inquiries.present?
-          %p
-          Sent eligibility check email on
-          %em #{l(@member.eligibility_inquiries.last.created_at, format: :website_format)}
-        - if @member.attendance_warnings.present?
-          %p
-          Sent attendance warning on
-          %em #{l(@member.attendance_warnings.last.created_at, format: :website_format)}
-
-  .stripe.reverse
-    .row
-      .medium-8.columns
-        - if @member.workshop_invitations.accepted.any?
-          .panel
-            %p
-              #{@member.name} RSVPed to
-              %label.label.secondary.round #{@invitations.accepted.count}
-              workshops and attended
-              %label.label.secondary.round #{@invitations.attended.count}.
-              - if @invitations.to_coaches.any? or @invitations.to_students.any?
-                %h4 Attended
-                %ul.no-bullet
-                  - if @invitations.to_coaches.any?
-                    %li
-                      %label.label.round #{@invitations.to_coaches.attended.count}
-                      times as a coach
-                  - if @invitations.to_students.any?
-                    %li
-                      %label.label.secondary.round #{@invitations.to_students.attended.count}
-                      times as a student
-                  - if @monthly_invitations.any?
-                    %li
-                      %label.label.round #{@monthly_invitations.attended.count}
-                      Monthlies
-        - if @invitations.any?
-          %p
-            The last workshop they attended was on <u> #{l(@last_attendance.date_and_time, format: :date)}</u>
-        - else
-          %label.label.secondary
-            #{@member.name} has not attended any events!
-
-
-        - if @invitations.any?
-          %h3 Workshops
-          %table
-            - @invitations.each do |invitation|
-              - workshop = invitation.workshop
-              - if workshop.present?
-                %tr
-                  %td
-                    - if invitation.attended?
-                      %i.fa.fa-check
-                    - else
-                      %i.fa.fa-warning
-                  %td
-                    = link_to invitation_path(invitation) do
-                      %label.label=workshop.chapter.name
-                  %td
-                    = l(workshop.date_and_time, format: :date)
-                  %td
-                    = invitation.note
-
-        - if @monthly_invitations.any?
-          %h3 Monthlies/Events
-          %table
-            - @monthly_invitations.each do |invitation|
-              %tr
-                %td
-                  - if invitation.attended?
-                    %i.fa.fa-check
-                  - else
-                    %i.fa.fa-warning
-                %td
-                  = l(invitation.meeting.date_and_time, format: :date)
-                %td
-                  =invitation.meeting.venue.name
-
-
-      .medium-4.columns
-        - if @member.member_notes.any?
-          %dl.accordion{ 'data-accordion': true }
-            %dd.accordion-navigation
-              = link_to '#notes' do
-                Notes (#{@member.member_notes.count})
-              #notes.content
-                = render partial: 'member_note', collection: @member.member_notes
-
-  - if @member.bans.any?
-    .stripe.reverse#suspensions
+  %section
+    #profile
       .row
-        .medium-12.columns
-          %h3 Suspensions
-          %table.table
-            %thead
-              %tr
-                %th
-                %th Expires on
-                %th Reason
-                %th Note
-                %th Explanation sent to user
-                %th Suspended by
-            - @member.bans.each do |ban|
-              %tr
-                %td
-                  - if ban.permanent?
-                    %label.label.success Permanent
-                    %td Indefinite
-                  - elsif ban.active?
-                    %label.label.success Active
-                    %td= l(ban.expires_at, format: :date)
-                  - else
-                    %label.label.success Expired
-                    %td= l(ban.expires_at, format: :date)
+        .medium-3.columns
+          = image_tag(@member.avatar(200), class: 'th', title: @member.full_name, alt: @member.full_name)
+          .name= @member.full_name
+          .email= mail_to @member.email, @member.email
+          %dt= @member&.mobile
+          %p.lead= @member.about_you
 
-                %td= ban.reason
-                %td= ban.note
-                %td= ban.explanation
-                %td= link_to ban.added_by.full_name, admin_member_path(ban.added_by)
+          %hr
 
-= render partial: 'note'
+          - if @workshop_attendances.positive? || @meeting_rsvps.positive? || @event_rsvps.positive?
+            .attendance-summary
+              %h5 Attendance summary
+              %ul.no-bullet
+                - if @workshop_attendances.positive?
+                  %label.label.round #{@workshop_attendances}
+                  workshops
+
+                - if @meeting_rsvps.positive?
+                  %li
+                    %label.label.round #{@meeting_rsvps}
+                    meetings
+
+                - if @event_rsvps.positive?
+                  %li
+                    %label.label.round #{@event_rsvps}
+                    events
+            %hr
+          - if @member.groups.any?
+            %h4 Groups
+            %ul.no-bullet#subscriptions
+              - @member.groups.each do |group|
+                %li
+                  = link_to [:admin, group] do
+                    #{group.name} (#{group.chapter.name})
+                  = link_to admin_member_update_subscriptions_path(member_id: @member, group: group), data: {confirm: "Clicking OK will remove this user from this subscription. This cannot be undone. Are you sure?"} do
+                    %span.fa.fa-times
+          - else
+            %label.label.secondary #{@member.name} is not subscribed to any groups
+
+          %hr
+
+        .medium-9.columns
+          %ul.no-bullet#actions
+            - @actions.each do |action|
+              %li= render action, action: action
+
+            %li
+              %span.fa-stack.fa-lg
+                %i.fa.fa-circle.fa-stack-2x.success
+                %i.fa.fa-user-o.fa-stack-1x
+              .details
+                %strong Signed up
+                .date
+                  = l(@member.created_at, format: :workshop)
+
+
+          - if @member.upcoming_rsvps.any?
+            %h3 Upcoming RSVPs
+            - @member.upcoming_rsvps.each do |invitation|
+              = render EventPresenter.decorate(invitation.event), invitation: invitation
+
+          = link_to 'View all RSVPS', '#', class: 'button expand'
+
+  = render partial: 'note'

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -19,8 +19,8 @@
             - if invitation.member.newbie?
               %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true', title: 'New attendee.' }
                 %i.fa.fa-paw
-            - elsif invitation.member.more_than_two_absences?
-              %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true', title: 'More than 2 no-shows' }
+            - elsif invitation.member.flag_to_organisers?
+              %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true', title: 'Multiple no shows and attendance warnings in the last six months' }
                 %i.fa.fa-exclamation-circle
 
             = link_to admin_member_path(invitation.member) do

--- a/app/views/admin/workshops/_workshop.html.haml
+++ b/app/views/admin/workshops/_workshop.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'admin/events/event', locals: { event: workshop, invitation: invitation }

--- a/app/views/layouts/_aside.html.haml
+++ b/app/views/layouts/_aside.html.haml
@@ -2,7 +2,7 @@
   %ul.off-canvas-list
     - if current_user.is_admin?
       = render 'layouts/admin_menu'
-    - elsif current_user.is_organiser? || current_user.is_monthlies_organiser?
+    - elsif current_user.organiser? || current_user.monthlies_organiser?
       = render 'layouts/organiser_menu'
     %li
       %label Portal

--- a/app/views/layouts/_organiser_menu.html.haml
+++ b/app/views/layouts/_organiser_menu.html.haml
@@ -1,10 +1,10 @@
 %li
   %label Admin Menu
-  - if current_user.is_admin_or_organiser?
+  - if current_user.admin_or_organiser?
     %li= link_to "New workshop", new_admin_workshop_path
     %li= link_to "New sponsor", new_admin_sponsor_path
 
-- if current_user.is_monthlies_organiser?
+- if current_user.monthlies_organiser?
   %li= link_to "New monthly", new_admin_meeting_path
 
 -if current_user.organised_chapters.any?

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -1,0 +1,1 @@
+require 'will_paginate/array'

--- a/config/locales/admin.de.yml
+++ b/config/locales/admin.de.yml
@@ -1,0 +1,15 @@
+de:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -1,6 +1,15 @@
 en:
   admin:
     bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
       new:
         title: 'Suspension'
         create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.en_AU.yml
+++ b/config/locales/admin.en_AU.yml
@@ -1,0 +1,15 @@
+en-AU:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.en_GB.yml
+++ b/config/locales/admin.en_GB.yml
@@ -1,0 +1,15 @@
+en-GB:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.en_US.yml
+++ b/config/locales/admin.en_US.yml
@@ -1,0 +1,15 @@
+en-US:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -1,0 +1,15 @@
+es:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.fi.yml
+++ b/config/locales/admin.fi.yml
@@ -1,0 +1,15 @@
+fi:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -1,0 +1,15 @@
+fr:
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/admin.no.yml
+++ b/config/locales/admin.no.yml
@@ -1,0 +1,15 @@
+"no":
+  admin:
+    bans:
+      create:
+        success: 'Member marked as supended and suspension email sent.'
+      new:
+        title: 'Suspension'
+        create: 'Suspend member'
+    members:
+      update_subscriptions:
+        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+      send_attendance_email:
+        success: 'Attendance warning email sent.'
+      send_eligibility_email:
+        success: 'Eligibility inquiry email sent.'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -468,10 +468,6 @@ de:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'Studenten und Trainer zum Workshop einladen. Die Bestätigungs-E-Mail wird ausgelöst und sie werden von der Warteliste entfernt.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
       year_month: "%Y-%B"
       log: "at %H:%M on the %d/%m/%Y"
       workshop: "%A, %e %B %Y at %R"
-      dashboard: "%A, %b %d"
+      dashboard: "%a, %d %b %Y"
   number:
     currency:
       format:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -581,10 +581,6 @@ en:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -469,10 +469,6 @@ en-AU:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -469,10 +469,6 @@ en-GB:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -467,10 +467,6 @@ en-US:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -469,10 +469,6 @@ es:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -469,10 +469,6 @@ fi:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -469,10 +469,6 @@ fr:
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: "Inscrire les étudiants et les enseignants à l'atelier. Leur email de confirmation va être envoyer et ils seront retirer de la liste d'attente."

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -469,10 +469,6 @@
         cannot_approve: You cannot approve expired job listings
         confirm_approval: Are you sure this job listing meets all requirements and you want to approve it?
         unpublished: The job has been successfully unpublished
-    members:
-      unsubscribed: "You have unsubscribed %{member} from %{city}'s %{group} group"
-      eligibility_confirmation_request: 'You have sent an eligibility confirmation request.'
-      attendance_warning: 'You have sent an attendance warning.'
     workshop:
       manage_rsvps:
         text: 'RSVP Students and Coaches to the workshop. The attendance confirmation email will be triggered and they will be removed from the waiting list.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Planner::Application.routes.draw do
     resources :announcements, only: %i[new index create edit update]
 
     resources :members, only: %i[show index] do
+      get :events
       get :send_eligibility_email
       get :send_attendance_email
       get :update_subscriptions

--- a/spec/fabricators/attendance_warning_fabricator.rb
+++ b/spec/fabricators/attendance_warning_fabricator.rb
@@ -1,0 +1,2 @@
+Fabricator(:attendance_warning) do
+end

--- a/spec/fabricators/workshop_invitation_fabricator.rb
+++ b/spec/fabricators/workshop_invitation_fabricator.rb
@@ -41,3 +41,7 @@ Fabricator(:waitinglist_invitation_reminded, from: :workshop_invitation) do
   waiting_list
   reminded_at 2.days.ago
 end
+
+Fabricator(:past_attending_workshop_invitation, from: :attending_workshop_invitation) do
+  workshop { Fabricate(:workshop, date_and_time: 1.month.ago) }
+end

--- a/spec/fabricators/workshop_invitation_fabricator.rb
+++ b/spec/fabricators/workshop_invitation_fabricator.rb
@@ -15,6 +15,7 @@ end
 
 Fabricator(:attended_workshop_invitation, from: :attending_workshop_invitation) do
   attended true
+  workshop { Fabricate(:workshop, date_and_time: 3.days.ago) }
 end
 
 Fabricator(:student_workshop_invitation, from: :workshop_invitation) do

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -1,71 +1,83 @@
 require 'spec_helper'
 
-RSpec.feature 'Managing users', type: :feature do
-  let(:member) { Fabricate(:member) }
-  let(:student) { Fabricate(:student) }
+RSpec.describe 'Admin managing members', type: :feature do
+  let(:member) { Fabricate(:student) }
   let(:admin) { Fabricate(:chapter_organiser) }
-  let!(:invitation) { Fabricate(:attended_workshop_invitation, member: member) }
-  let!(:attending_invitation) { Fabricate(:attending_workshop_invitation, member: member) }
+  let(:invitation) { Fabricate(:attended_workshop_invitation, member: member) }
 
   before do
-    login admin
+    invitation
+
+    login(admin)
+    visit admin_member_path(member)
   end
 
-  scenario 'View a user' do
-    visit admin_member_path member
-
-    expect(page).to have_content('RSVPed to 2 workshops and attended 1.')
-    expect(page).to have_content member.name
-    expect(page).to have_content member.email
-    expect(page).to have_content member.about_you
-    expect(page).to have_content invitation.note
-    expect(page).to have_content attending_invitation.note
-  end
-
-  scenario 'Add a note to a user' do
-    visit admin_member_path member
-    fill_in 'member_note_note', with: 'Bananas and custard'
-    click_on 'Add note'
-
-    expect(page).to have_content 'Bananas and custard'
-  end
-
-  scenario 'Ban a user' do
-    visit admin_member_path member
-    click_on 'Suspend'
-
-    select 'Violated attendance policy', from: 'ban_reason'
-    fill_in 'ban_note', with: Faker::Lorem.word
-    fill_in 'ban_expires_at', with: Time.zone.today + 1.month
-    click_on 'Suspend member'
-
-    expect(page).to have_content 'The user has been suspended'
-  end
-
-  scenario 'unsubscribe a user from group', js: true do
-    visit admin_member_path student
-    within '#subscriptions > li:first-child' do
-      expect do
-        accept_confirm { find('.fa-times').click }
-      end.to change { student.subscriptions.count }.by(0)
+  describe 'Admin managing members' do
+    it 'can view member information' do
+      expect(page).to have_content(member.name)
+      expect(page).to have_content(member.email)
+      expect(page).to have_content(member.about_you)
     end
 
-    expect(page).to have_content "You have unsubscribed #{student.full_name}"
+    it 'can view a summary of member event attendances' do
+      within '.attendance-summary' do
+        expect(page).to have_content('1 workshops')
+      end
+    end
+
+    it 'can add a note about a member' do
+      click_on 'Add note'
+      fill_in 'member_note_note', with: 'Bananas and custard'
+      click_on 'Save'
+
+      within '.note' do
+        expect(page).to have_content 'Bananas and custard'
+        expect(page).to have_content "Note added by #{admin.full_name}"
+      end
+    end
+
+    it 'can suspend a member' do
+      click_on 'Suspend'
+
+      select 'Violated attendance policy', from: 'ban_reason'
+      fill_in 'ban_note', with: Faker::Lorem.word
+      fill_in 'ban_expires_at', with: Time.zone.today + 1.month
+      click_on 'Suspend member'
+
+      expect(page).to have_content 'Member marked as supended and suspension email sent.'
+      within '.suspension' do
+        expect(page).to have_content "Suspended until #{I18n.l(Time.zone.today + 1.month)} by #{admin.full_name}"
+      end
+    end
+
+    it 'can unsubscribe a member from group', js: true do
+      within '#subscriptions > li:first-child' do
+        expect do
+          accept_confirm { find('.fa-times').click }
+        end.to change { member.subscriptions.count }.by(0)
+      end
+
+      expect(page).to have_content "Successfully unsubscribed #{member.full_name}"
+    end
+
+    it 'can send an eligibility email to a member' do
+      click_on 'Send eligibility inquiry'
+
+      expect(page).to have_content 'Eligibility inquiry email sent.'
+      within '.eligibility-inquiry' do
+        expect(page).to have_content "Sent eligibility inquiry email by #{admin.full_name}"
+      end
+    end
+
+    it 'can send an attendance warning to a member' do
+      expect(page).to have_selector("a[data-confirm='Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?']")
+      click_on 'Send attendance warning'
+      expect(page).to have_selector("a[data-confirm='#{member.name} has already received a warning about missing too many workshops on #{member.attendance_warnings.last.created_at.strftime('%Y-%m-%d at %H:%M')}. Are you sure you want to proceed with sending another one?']")
+
+      expect(page).to have_content 'Attendance warning email sent.'
+      within '.attendance-warning' do
+        expect(page).to have_content "Sent attendance warning email by #{admin.full_name}"
+      end
+    end
   end
-
-  scenario 'Send eligibility email to user' do
-    visit admin_member_path student
-    click_on 'Eligibility'
-
-    expect(page).to have_content 'You have sent an eligibility confirmation request.'
-  end
-
-  scenario 'Warn a user' do
-    visit admin_member_path member
-    expect(page).to have_selector("a[data-confirm='Clicking OK will send an automated email to this user now to warn them about missing too many workshops. This cannot be undone. Are you sure?']")
-    click_on 'Attendance'
-    expect(page).to have_selector("a[data-confirm='#{member.name} has already received a warning about missing too many workshops on #{member.attendance_warnings.last.created_at.strftime("%Y-%m-%d at %H:%M")}. Are you sure you want to proceed with sending another one?']")
-    expect(page).to have_content 'You have sent an attendance warning.'
-  end
-
 end

--- a/spec/models/attendance_warning_spec.rb
+++ b/spec/models/attendance_warning_spec.rb
@@ -18,5 +18,16 @@ RSpec.describe AttendanceWarning, type: :model do
 
       expect(MemberMailer).to have_received(:attendance_warning).with(member, member.email)
     end
+
+    describe '.scopes' do
+      describe 'last_six_months' do
+        it 'returns all attendance warnings issues in the last six months' do
+          Fabricate(:attendance_warning, member: member, created_at: 7.months.ago)
+          warnings = Fabricate.times(2, :attendance_warning, member: member, created_at: 5.months.ago)
+
+          expect(member.attendance_warnings.last_six_months).to contain_exactly(*warnings)
+        end
+      end
+    end
   end
 end

--- a/spec/models/attendance_warning_spec.rb
+++ b/spec/models/attendance_warning_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe AttendanceWarning, type: :model do
+  describe '#create' do
+    let(:member) { Fabricate(:member) }
+    let(:admin) { Fabricate(:member) }
+
+    it 'creates an attendance warning to a member issued by an admin' do
+      attendance_warning = described_class.create(member: member, issued_by: admin)
+
+      expect(attendance_warning.issued_by).to eq(admin)
+    end
+
+    it 'sends an attendance warning email' do
+      allow(MemberMailer).to receive(:attendance_warning).with(member, member.email).and_call_original
+
+      described_class.create(member: member, issued_by: admin)
+
+      expect(MemberMailer).to have_received(:attendance_warning).with(member, member.email)
+    end
+  end
+end

--- a/spec/models/concerns/permissions_spec.rb
+++ b/spec/models/concerns/permissions_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe Permissions, type: :model do
+  subject(:member) { Fabricate(:member) }
+
+  let(:chapter) { Fabricate(:chapter) }
+
+  describe 'organiser?' do
+    it 'returns true when the member is a chapter organiser' do
+      member.add_role(:organiser, chapter)
+
+      expect(member.organiser?).to be true
+    end
+  end
+
+  describe 'organised_chapters' do
+    it 'returns the chapters that the member has organiser access on' do
+      member.add_role(:organiser, chapter)
+      expect(member.organised_chapters).to eq([chapter])
+    end
+  end
+
+  describe 'monthlies_organiser' do
+    it 'returns true if the member is a meeting organiser' do
+      member.add_role(:organiser, Fabricate(:meeting))
+
+      expect(member.monthlies_organiser?).to be true
+    end
+  end
+
+  describe 'admin_or_organiser?' do
+    it 'returns true if the member is an admin' do
+      member.add_role(:admin)
+
+      expect(member.admin_or_organiser?).to be true
+    end
+
+    it 'returns true if the member is an organiser' do
+      member.add_role(:organiser, chapter)
+
+      expect(member.admin_or_organiser?).to be true
+    end
+
+    it 'returns false if the member is not an organiser or an admin' do
+      expect(member.admin_or_organiser?).to be false
+    end
+  end
+end

--- a/spec/models/course_invitation_spec.rb
+++ b/spec/models/course_invitation_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe CourseInvitation, type: :model do
   let(:invitation) { Fabricate(:course_invitation) }
-  it_behaves_like InvitationConcerns, :course_invitation
+  it_behaves_like InvitationConcerns, :course_invitation, :course
 
   context 'defaults' do
     it { is_expected.to have_attributes(attending: nil) }

--- a/spec/models/eligibility_inquiry_spec.rb
+++ b/spec/models/eligibility_inquiry_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe EligibilityInquiry, type: :model do
+  describe '#create' do
+    let(:member) { Fabricate(:member) }
+    let(:admin) { Fabricate(:member) }
+
+    it 'creates an eligibility inquiry to a member issued by an admin' do
+      eligibility_inquiry = EligibilityInquiry.create(member: member, issued_by: admin)
+
+      expect(eligibility_inquiry.issued_by).to eq(admin)
+    end
+
+    it 'sends an attendance warning email' do
+      allow(MemberMailer).to receive(:eligibility_check).with(member, member.email).and_call_original
+
+      described_class.create(member: member, issued_by: admin)
+
+      expect(MemberMailer).to have_received(:eligibility_check).with(member, member.email)
+    end
+  end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Invitation, type: :model do
-  it_behaves_like InvitationConcerns, :invitation
+  it_behaves_like InvitationConcerns, :invitation, :event
 
   context 'defaults' do
     it { is_expected.to have_attributes(attending: nil) }

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe MeetingInvitation, type: :model do
-  it_behaves_like InvitationConcerns, :meeting_invitation
+  it_behaves_like InvitationConcerns, :meeting_invitation, :meeting
 
   context 'defaults' do
     it { is_expected.to have_attributes(attending: nil) }

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,25 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe Member, type: :model do
-  context 'mandatory attributes' do
-    context 'validation' do
+  let(:member) { Fabricate(:member) }
+
+  describe 'mandatory attributes' do
+    describe 'validations' do
       it { is_expected.to validate_presence_of(:auth_services) }
-
-      context 'logginable member' do
-        let(:loginnable_member) { Fabricate.build(:member, can_log_in: true) }
-        it { expect(loginnable_member).to validate_presence_of(:name) }
-        it { expect(loginnable_member).to validate_presence_of(:surname) }
-        it { expect(loginnable_member).to validate_presence_of(:email) }
-        it { expect(loginnable_member).to validate_presence_of(:about_you) }
-      end
-
       it { is_expected.to validate_length_of(:about_you).is_at_most(255) }
       it { is_expected.to validate_uniqueness_of(:email) }
+
+      describe 'can_log_in' do
+        let(:member) { Fabricate.build(:member, can_log_in: true) }
+
+        it { expect(member).to validate_presence_of(:name) }
+        it { expect(member).to validate_presence_of(:surname) }
+        it { expect(member).to validate_presence_of(:email) }
+        it { expect(member).to validate_presence_of(:about_you) }
+      end
     end
 
-    context 'properties' do
-      let(:member) { Fabricate(:member) }
-
+    describe 'properties' do
       it '#full_name' do
         expect(member.full_name).to eq("#{member.name} #{member.surname} (#{member.pronouns})")
       end
@@ -33,33 +33,34 @@ RSpec.describe Member, type: :model do
 
   describe '.with_skill' do
     it 'returns members with the specified skill' do
-      ruby_member = Fabricate(:coach, skill_list: 'ruby, rails')
-      non_ruby_member = Fabricate(:coach, skill_list: 'html, jQuery')
-      expect(Member.with_skill('ruby')).to eq [ruby_member]
+      member_with_specified_skills = Fabricate(:coach, skill_list: 'ruby, rails')
+      Fabricate(:coach, skill_list: 'html, jQuery')
+
+      expect(described_class.with_skill('ruby')).to eq([member_with_specified_skills])
     end
   end
 
-  context 'scopes' do
-    context '#attending_meeting' do
+  describe 'scopes' do
+    describe '#attending_meeting' do
       it 'includes attending members' do
         invitation = Fabricate(:attending_meeting_invitation)
 
-        expect(Member.attending_meeting(invitation.meeting)).to include(invitation.member)
+        expect(described_class.attending_meeting(invitation.meeting)).to include(invitation.member)
       end
 
       it 'excludes banned attending members' do
         invitation = Fabricate(:banned_attending_meeting_invitation)
 
-        expect(Member.attending_meeting(invitation.meeting)).to_not include(invitation.member)
+        expect(described_class.attending_meeting(invitation.meeting)).not_to include(invitation.member)
       end
     end
 
-    context '#in_group' do
+    describe '#in_group' do
       it 'includes members in group' do
         chapter = Fabricate(:chapter)
         group = Fabricate(:group, chapter: chapter, members: [Fabricate(:member)])
 
-        expect(Member.in_group(chapter.groups)).to eq(group.members)
+        expect(described_class.in_group(chapter.groups)).to eq(group.members)
       end
 
       it 'excludes members outside group' do
@@ -67,15 +68,51 @@ RSpec.describe Member, type: :model do
         other_chapter = Fabricate(:chapter)
         group = Fabricate(:group, chapter: other_chapter, members: [Fabricate(:member)])
 
-        expect(Member.in_group(chapter.groups)).to_not eq(group.members)
+        expect(described_class.in_group(chapter.groups)).not_to eq(group.members)
       end
 
       it 'excludes banned members in group' do
         chapter = Fabricate(:chapter)
         group = Fabricate(:group, chapter: chapter, members: [Fabricate(:banned_member)])
 
-        expect(Member.in_group(chapter.groups)).not_to eq(group.members)
+        expect(described_class.in_group(chapter.groups)).not_to eq(group.members)
       end
+    end
+  end
+
+  describe '.multiple_no_shows?' do
+    it 'returns true when a member has missed more than three workshop in the last six months' do
+      Fabricate.times(6, :past_attending_workshop_invitation, member: member)
+
+      expect(member.multiple_no_shows?).to be true
+    end
+
+    it 'returns false when a member has not missed more than three workshop in the last six months' do
+      Fabricate.times(3, :past_attending_workshop_invitation, attended: true, member: member)
+
+      expect(member.multiple_no_shows?).to be false
+    end
+  end
+
+  describe '.flag_to_organisers' do
+    it 'returns false when a member does not have multiple_no_shows?' do
+      Fabricate.times(2, :attendance_warning, member: member)
+
+      expect(member.flag_to_organisers?).to be false
+    end
+
+    it 'returns false when a member does not have at least two two attendance warnings' do
+      Fabricate.times(6, :past_attending_workshop_invitation, member: member)
+      Fabricate(:attendance_warning, member: member)
+
+      expect(member.flag_to_organisers?).to be false
+    end
+
+    it 'returns true when a member has multiple_no_shows? and has received at least two attendance warning emails' do
+      Fabricate.times(6, :past_attending_workshop_invitation, member: member)
+      Fabricate.times(2, :attendance_warning, member: member)
+
+      expect(member.flag_to_organisers?).to be true
     end
   end
 end

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe WorkshopInvitation, type: :model do
-  it_behaves_like InvitationConcerns, :workshop_invitation
+  it_behaves_like InvitationConcerns, :workshop_invitation, :workshop
 
   context 'defaults' do
     it { is_expected.to have_attributes(attending: nil) }

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -2,32 +2,36 @@ require 'spec_helper'
 
 RSpec.describe EventPresenter do
   let(:workshop) { Fabricate(:workshop) }
-  let(:event) { EventPresenter.new(workshop) }
+  let(:event) { described_class.new(workshop) }
 
   it '#venue' do
-    expect(workshop).to receive(:venue)
+    allow(workshop).to receive(:venue)
 
     event.venue
+
+    expect(workshop).to have_received(:venue)
   end
 
   it '#sponsors' do
-    expect(workshop).to receive(:sponsors)
+    allow(workshop).to receive(:sponsors)
 
     event.sponsors
+
+    expect(workshop).to have_received(:sponsors)
   end
 
   it '#description' do
     expect(event.description).to be(workshop.description)
   end
 
-  describe 'short_#description' do
+  describe '#short_description' do
     it 'when there is no short_description on the event model it fallsback to description' do
       expect(event.short_description).to be(workshop.description)
     end
 
     it 'when there is a short_description' do
       course = Fabricate(:course)
-      event = EventPresenter.new(course)
+      event = described_class.new(course)
 
       expect(event.short_description).to be(course.short_description)
     end
@@ -46,22 +50,26 @@ RSpec.describe EventPresenter do
   end
 
   it '#month' do
-    expect(workshop).to receive(:date_and_time).and_return(Time.zone.local(2014, 9, 3, 16, 30))
+    allow(workshop).to receive(:date_and_time).and_return(Time.zone.local(2014, 9, 3, 16, 30))
 
     expect(event.month).to eq('SEPTEMBER')
   end
 
-  context '#time' do
+  describe '#time' do
     it 'when no end_time is set it only returns the start_time' do
-      event = double(:event, date_and_time: Time.zone.now, start_time: Time.zone.now, ends_at: nil)
-      presenter = EventPresenter.new(event)
+      event = double(:event, date_and_time: Time.zone.now,
+                             start_time: Time.zone.now,
+                             ends_at: nil)
+      presenter = described_class.new(event)
 
       expect(presenter.time).to eq(I18n.l(event.date_and_time, format: :time_with_zone))
     end
 
     it 'when a start and an end_time are set it returns a formatted start and end_time' do
-      event =  double(:event, date_and_time: Time.zone.now, start_time: Time.zone.now, ends_at: 1.hour.from_now)
-      presenter = EventPresenter.new(event)
+      event = double(:event, date_and_time: Time.zone.now,
+                             start_time: Time.zone.now,
+                             ends_at: 1.hour.from_now)
+      presenter = described_class.new(event)
 
       expect(presenter.time)
         .to eq("#{presenter.start_time} - #{presenter.end_time} #{I18n.l(event.date_and_time, format: :time_zone)}")
@@ -76,25 +84,25 @@ RSpec.describe EventPresenter do
     expect(event.class_string).to eq('workshop')
   end
 
-  context '#day_temporal_pronoun' do
+  describe '#day_temporal_pronoun' do
     it 'returns today if the date_and_time set set to today' do
       workshop.date_and_time = Time.zone.now
 
-      expect(event.day_temporal_pronoun). to eq('today')
+      expect(event.day_temporal_pronoun).to eq('today')
     end
 
     it 'returns yesteday if the date_and_time is not set to today' do
       workshop.date_and_time = Time.zone.now + 1.day
 
-      expect(event.day_temporal_pronoun). to eq('tomorrow')
+      expect(event.day_temporal_pronoun).to eq('tomorrow')
     end
   end
 
-  context 'rsvp_closing_date_and_time' do
+  describe '#rsvp_closing_date_and_time' do
     it 'returns the calculated RSVP closing time for an event' do
       workshop.date_and_time = Time.zone.local(2040, 10, 10, 16, 30)
 
-      expect(event.rsvp_closing_date_and_time). to eq(Time.zone.local(2040, 10, 10, 13, 00))
+      expect(event.rsvp_closing_date_and_time).to eq(Time.zone.local(2040, 10, 10, 13, 0))
     end
   end
 end

--- a/spec/support/shared_examples/behaves_like_an_invitation.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation.rb
@@ -1,31 +1,12 @@
-RSpec.shared_examples InvitationConcerns do |invitation_type|
+RSpec.shared_examples InvitationConcerns do |invitation_type, event_type|
   let(:invitation_constant) { invitation_type.to_s.camelize.constantize }
   let(:invitation) { Fabricate(invitation_type) }
+
   it 'has a token set on creation' do
     expect(invitation.token).to_not be(nil)
   end
 
   context '#scopes' do
-    context '#accepted' do
-      it 'ignores when attending nil' do
-        Fabricate(invitation_type, attending: nil)
-
-        expect(invitation_constant.accepted).to eq []
-      end
-
-      it 'ignores when attending false' do
-        Fabricate(invitation_type, attending: false)
-
-        expect(invitation_constant.accepted).to eq []
-      end
-
-      it 'selects when attending true' do
-        invitation = Fabricate(invitation_type, attending: true)
-
-        expect(invitation_constant.accepted).to include(invitation)
-      end
-    end
-
     context '#not_accepted' do
       it 'selects when attended nil' do
         Fabricate(invitation_type, attending: nil)
@@ -43,6 +24,35 @@ RSpec.shared_examples InvitationConcerns do |invitation_type|
         invitation = Fabricate(invitation_type, attending: true)
 
         expect(invitation_constant.not_accepted).to eq []
+      end
+    end
+
+    let(:past_event) { Fabricate(event_type, date_and_time: 2.days.ago) }
+    let(:future_rsvp) { Fabricate(invitation_type, attending: true) }
+    let(:past_rsvp) { Fabricate(invitation_type, attending: true, event_type => past_event) }
+    let(:past_invitation) { Fabricate(invitation_type, event_type => past_event) }
+
+    before(:each, data: true) do
+      future_rsvp
+      past_rsvp
+      past_invitation
+    end
+
+    describe '#accepted', data: true do
+      it 'returns a list of all rsvps' do
+        expect(invitation_constant.joins(event_type).accepted).to contain_exactly(future_rsvp, past_rsvp)
+      end
+    end
+
+    describe '#upcoming_rsvps', data: true do
+      it 'returns a list of all upcoming rsvps' do
+        expect(invitation_constant.joins(event_type).upcoming_rsvps).to contain_exactly(future_rsvp)
+      end
+    end
+
+    describe '#taken_place', data: true do
+      it 'returns a list of all invitations for events that have already taken place' do
+        expect(invitation_constant.joins(event_type).taken_place).to contain_exactly(past_rsvp, past_invitation)
       end
     end
   end

--- a/spec/support/shared_examples/behaves_like_date_time_concerns.rb
+++ b/spec/support/shared_examples/behaves_like_date_time_concerns.rb
@@ -6,14 +6,14 @@ RSpec.shared_examples DateTimeConcerns do |date_time_type|
   it '#date returns formatted date' do
     travel_to Time.zone.local(2010, 12, 31, 23, 59, 42) do
       date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.now)
-      expect(date_time_able.date).to eq 'Friday, Dec 31'
+      expect(date_time_able.date).to eq 'Fri, 31 Dec 2010'
     end
   end
 
   it '#date returns the date in dashboard format' do
     date_time_able = Fabricate(date_time_type, date_and_time: Time.zone.local(2018, 8, 22, 18, 30))
 
-    expect(date_time_able.date).to eq('Wednesday, Aug 22')
+    expect(date_time_able.date).to eq('Wed, 22 Aug 2018')
   end
 
   context '#time' do


### PR DESCRIPTION
Work to improve admin/member view and enable admins and organisers to make better decisions about events that need to take place, such as suspensions, attendance warnings or eligibility inquiries etc.

This is still work in progress and will likely change.


<img width="904" alt="member-with-no-rsvps" src="https://user-images.githubusercontent.com/159200/100817889-e9ccda80-3440-11eb-8cd2-e5b28d6062f8.png">


<img width="902" alt="member-with-upcoming-rsvps" src="https://user-images.githubusercontent.com/159200/100817883-e3d6f980-3440-11eb-8e83-acbdfaf3ab4e.png">
