### PR TITLE
Remove double negative in registration form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -684,7 +684,7 @@ en:
       member:
         email: 'Email address'
         name: 'First name'
-        newsletter: 'If you want to receive the codebar newsletter check this box'
+        newsletter: 'Sign up for our newsletter'
         pronouns: 'What pronouns do you use?'
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -684,7 +684,7 @@ en:
       member:
         email: 'Email address'
         name: 'First name'
-        newsletter: 'If you do not want to receive the codebar newsletter uncheck this box'
+        newsletter: 'If you want to receive the codebar newsletter check this box'
         pronouns: 'What pronouns do you use?'
     errors:
       models:


### PR DESCRIPTION
The sentence next to the newsletter checkbox took me quite a while to understand due to its use of a double negative.

I have removed both negatives so that it says the same thing just using simpler language.

It would now read: 

> 'If you want to receive the codebar newsletter check this box'