### PR TITLE
Display error message when invitation update fails

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -33,7 +33,7 @@ class Admin::InvitationsController < Admin::ApplicationController
   end
 
   def update_to_attended
-    @invitation.update_attribute(:attended, true)
+    @invitation.update(attended: true)
 
     "You have verified #{@invitation.member.full_name}’s attendace."
   end
@@ -59,7 +59,7 @@ class Admin::InvitationsController < Admin::ApplicationController
   end
 
   def update_to_not_attending
-    @invitation.update_attribute(:attending, false)
+    @invitation.update(attending: false)
 
     {
       message: "You have removed #{@invitation.member.full_name} from the workshop.",

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -4,19 +4,12 @@ class Admin::InvitationsController < Admin::ApplicationController
   def update
     set_and_decorate_workshop
     authorize @workshop
-
     set_invitation
 
-    message, error = update_attendance(params.slice(:attending, :attended))
-
-    unless error
-      waiting_listed = WaitingList.find_by(invitation: @invitation)
-      waiting_listed&.destroy
-    end
+    message = update_attendance(attending: params[:attending], attended: params[:attended])
 
     if request.xhr?
       set_admin_workshop_data
-
       render partial: 'admin/workshops/invitation_management'
     else
       redirect_to :back, notice: message
@@ -28,35 +21,50 @@ class Admin::InvitationsController < Admin::ApplicationController
   def update_attendance(attending:, attended:)
     return update_to_attended if attended
 
-    if attending.eql? 'true'
-      update_to_attending
-    else
-      update_to_not_attending
+    result = attending.eql?('true') ? update_to_attending : update_to_not_attending
+    message, error = result.values_at(:message, :error)
+
+    unless error
+      waiting_listed = WaitingList.find_by(invitation: @invitation)
+      waiting_listed&.destroy
     end
+
+    message
   end
 
   def update_to_attended
     @invitation.update_attribute(:attended, true)
 
-    ["You have verified #{@invitation.member.full_name}'s attendace."]
+    "You have verified #{@invitation.member.full_name}’s attendace."
   end
 
   def update_to_attending
-    if @invitation.update(attending: true, rsvp_time: Time.zone.now, automated_rsvp: true)
-      @workshop.send_attending_email(@invitation) if @workshop.future?
+    update_successful = @invitation.update(attending: true, rsvp_time: Time.zone.now, automated_rsvp: true)
 
-      ["You have added #{@invitation.member.full_name} to the workshop as a #{@invitation.role}."]
-    else
-      error_message = @invitation.errors.full_messages.to_sentence
+    {
+      message: update_successful ? attending_successful : attending_failed,
+      error: !update_successful
+    }
+  end
 
-      ["Error adding #{@invitation.member.full_name} as a #{@invitation.role}. #{error_message}.", false]
-    end
+  def attending_successful
+    @workshop.send_attending_email(@invitation) if @workshop.future?
+
+    "You have added #{@invitation.member.full_name} to the workshop as a #{@invitation.role}."
+  end
+
+  def attending_failed
+    "Error adding #{@invitation.member.full_name} as a #{@invitation.role}. "\
+      "#{@invitation.errors.full_messages.to_sentence}."
   end
 
   def update_to_not_attending
     @invitation.update_attribute(:attending, false)
 
-    ["You have removed #{@invitation.member.full_name} from the workshop."]
+    {
+      message: "You have removed #{@invitation.member.full_name} from the workshop.",
+      error: false
+    }
   end
 
   def set_invitation

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -7,32 +7,11 @@ class Admin::InvitationsController < Admin::ApplicationController
 
     set_invitation
 
-    if params.key?(:attending)
-      attending = params[:attending]
-      if attending.eql?('true')
-        if @invitation.update(attending: true, rsvp_time: Time.zone.now, automated_rsvp: true)
-          @workshop.send_attending_email(@invitation) if @workshop.future?
+    message, error = update_attendance(params.slice(:attending, :attended))
 
-          message = "You have added #{@invitation.member.full_name} to the workshop as a #{@invitation.role}."
-        else
-          invitation_update_error = true
-
-          message = "Error adding #{@invitation.member.full_name} as a #{@invitation.role}. #{@invitation.errors.full_messages.to_sentence}."
-        end
-      else
-        @invitation.update_attribute(:attending, false)
-
-        message = "You have removed #{@invitation.member.full_name} from the workshop."
-      end
-
-      unless invitation_update_error
-        waiting_listed = WaitingList.find_by(invitation: @invitation)
-        waiting_listed&.destroy
-      end
-    elsif params.key?(:attended)
-      @invitation.update_attribute(:attended, true)
-
-      message = "You have verified #{@invitation.member.full_name}'s attendace."
+    unless error
+      waiting_listed = WaitingList.find_by(invitation: @invitation)
+      waiting_listed&.destroy
     end
 
     if request.xhr?
@@ -45,6 +24,40 @@ class Admin::InvitationsController < Admin::ApplicationController
   end
 
   private
+
+  def update_attendance(attending:, attended:)
+    return update_to_attended if attended
+
+    if attending.eql? 'true'
+      update_to_attending
+    else
+      update_to_not_attending
+    end
+  end
+
+  def update_to_attended
+    @invitation.update_attribute(:attended, true)
+
+    ["You have verified #{@invitation.member.full_name}'s attendace."]
+  end
+
+  def update_to_attending
+    if @invitation.update(attending: true, rsvp_time: Time.zone.now, automated_rsvp: true)
+      @workshop.send_attending_email(@invitation) if @workshop.future?
+
+      ["You have added #{@invitation.member.full_name} to the workshop as a #{@invitation.role}."]
+    else
+      error_message = @invitation.errors.full_messages.to_sentence
+
+      ["Error adding #{@invitation.member.full_name} as a #{@invitation.role}. #{error_message}.", false]
+    end
+  end
+
+  def update_to_not_attending
+    @invitation.update_attribute(:attending, false)
+
+    ["You have removed #{@invitation.member.full_name} from the workshop."]
+  end
 
   def set_invitation
     @invitation = @workshop.invitations.find_by(token: invitation_id)

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe Admin::InvitationsController, type: :controller do
+  let(:invitation) { Fabricate(:student_workshop_invitation) }
+  let(:workshop) { invitation.workshop }
+  let(:admin) { Fabricate(:chapter_organiser) }
+
+  describe "PUT #update" do
+    before do
+      admin.add_role(:organiser, workshop.chapter)
+
+      login admin
+      request.env["HTTP_REFERER"] = "/admin/member/3"
+
+      expect(invitation.attending).to be_nil
+    end
+
+    it "Successfuly updates an invitation" do
+      put :update, id: invitation.token, workshop_id: workshop.id, attending: "true"
+      
+      expect(invitation.reload.attending).to be true
+      expect(flash[:notice]).to match("You have added")
+    end
+
+    it "Warns the user about failed updates" do
+      # Trigger an error when trying to update the `attending` attribute
+      invitation.update_attribute(:tutorial, nil)
+
+      put :update, id: invitation.token, workshop_id: workshop.id, attending: "true"
+      
+      # State didn't change and we have an error message explaining why
+      expect(invitation.reload.attending).to be_nil
+      expect(flash[:notice]).to match("Tutorial must be selected.")
+    end
+  end
+end


### PR DESCRIPTION
Alex documented on #1474 the issue of adding someone manually from the waitlist, sometimes the member gets the correct email but they disappear from the list they were supposed to be added to.

Despo pointed me to this particular case there the invitation update could fail and we would have no way to know it. When this happens, their spot on the waiting list would be deleted.

This pull request addresses that issue now, paying attention to the result of the update, notifying the admin if it failed and only removing the WaitList entity if no error occurred.

Since every PR also gets some notes from Code Climate and CodeFactor, the diff grew because I had to deal with their comments. Let me know if you want to pair on reviewing this. 😃