### PR TITLE
Quick design update to make the sponsors section on event pages look better

### DIFF
--- a/app/views/events/_sponsors.html.haml
+++ b/app/views/events/_sponsors.html.haml
@@ -1,10 +1,3 @@
 - sponsors.each do |sponsor|
-  %li
-    .row
-      .large-2.columns
-        = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
-      .large-10.columns
-        = link_to sponsor.name, sponsor.website
-        %p
-          = sponsor.description
-  %br
+  .large-3.columns.sponsor-image
+    = link_to image_tag(sponsor.avatar.url, class: "sponsor", alt: sponsor.name), sponsor.website

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -54,18 +54,17 @@
         %i= t('events.thx_to_sponsors')
       %br
       - if @event.sponsors?
-        %ul.no-bullet
-          - if @event.sponsors?(:gold)
-            %h3.text-center Gold 
-            = render partial: "sponsors", object: @event.gold_sponsors
-          - if @event.sponsors?(:silver)
-            %h3.text-center Silver
-            = render partial: "sponsors", object: @event.silver_sponsors
-          - if @event.sponsors?(:bronze)
-            %h3.text-center Bronze
-            = render partial: "sponsors", object: @event.bronze_sponsors
-          - if @event.sponsors?(:standard)
-            = render partial: "sponsors", object: @event.sponsors
+        - if @event.sponsors?(:gold)
+          %h3.text-center Gold
+          = render partial: "sponsors", object: @event.gold_sponsors
+        - if @event.sponsors?(:silver)
+          %h3.text-center Silver
+          = render partial: "sponsors", object: @event.silver_sponsors
+        - if @event.sponsors?(:bronze)
+          %h3.text-center Bronze
+          = render partial: "sponsors", object: @event.bronze_sponsors
+        - if @event.sponsors?(:standard)
+          = render partial: "sponsors", object: @event.sponsors
 - if @event.verified_coaches.any?
   .stripe.reverse
     .row


### PR DESCRIPTION
The sponsors section on the events pages currently looks a bit crap, I've put in a quick fix to make them look better.

- They will now stack next to each other rather than above
- The logo itself will link out rather than the bit of text next to it

This change has been done on my bigger Bootstrap PR but I'm not sure when this will be merged in, this is a quick fix.

| Before | After |
|-------|------|
|![Screenshot 2021-01-27 at 11 37 09](https://user-images.githubusercontent.com/2683270/105979536-b480e980-608b-11eb-9789-d6793b2f53cf.png)|![Screenshot 2021-01-27 at 11 35 24](https://user-images.githubusercontent.com/2683270/105979539-b5198000-608b-11eb-9bd9-264bc4e483de.png)|

