### PR TITLE
Add skils section to member admin #show page

### DIFF
--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -43,6 +43,8 @@
           %dt About
           %dd= @member.about_you
 
+          = render "shared/skills", member: @member
+
       .medium-4.columns
         - if @member.banned?
 

--- a/app/views/members/_show.html.haml
+++ b/app/views/members/_show.html.haml
@@ -26,11 +26,7 @@
           %dt About
           %dd= member.about_you
 
-          - if member.skills.any?
-            %dt Skills
-            %p
-              - member.skills.each do |skill|
-                = link_to skill.name, skill_url(skill.name), class: "skill"
+          = render "shared/skills", member: member
         = link_to "Update your details", edit_member_path, class: 'button tiny round'
 
       .medium-4.columns

--- a/app/views/shared/_skills.html.haml
+++ b/app/views/shared/_skills.html.haml
@@ -1,0 +1,5 @@
+- if member.skills.any?
+  %dt Skills
+  %dd
+    - member.skills.each do |skill|
+      = link_to skill.name, skill_url(skill.name), class: "skill"


### PR DESCRIPTION
I sent a few emails yesterday asking for coaches to add their skills to their profiles. After getting a couple of emails back with confused answers, one of the screenshots I received exampled this mystery. 

|before|after|
|-|-|
|![Screen Shot 2021-02-02 at 08 57 47](https://user-images.githubusercontent.com/385232/106582645-2188f900-653c-11eb-863d-a01ef7f43695.png)|![Screen Shot 2021-02-02 at 09 42 44](https://user-images.githubusercontent.com/385232/106582660-25b51680-653c-11eb-80f9-7175a81ab404.png)|

These coaches have filled in their _skills_ on their profile, which they can see, but the admin version of that profile is powered by a different partial that _did not_ display these skills. This pull request moves the skill rendering into its own small partial and reusues it on both profiles.
