### PR TITLE
Improve member checkin freeze

### DIFF
--- a/app/assets/javascripts/invitations.js
+++ b/app/assets/javascripts/invitations.js
@@ -1,13 +1,17 @@
 $(document).ready(function() {
   $(document).on("ajax:success", "a[data-remote]", function(e, data, status, xhr) {
-    $("#invitations").html(xhr.responseText);
+    var $invitations = $("#invitations");
 
-    $('select').chosen(function(){
+    $invitations.html(xhr.responseText);
+
+    $invitations.find('select').chosen(function () {
       allow_single_deselect: true
       no_results_text: 'No results matched'
     });
-    $(document).foundation();
+
+    $invitations.foundation('tooltip', 'reflow');
   });
+  
   $(document).on('change','#workshop_invitations ',function() {
     this.form.submit();
   })

--- a/app/assets/stylesheets/animations.scss
+++ b/app/assets/stylesheets/animations.scss
@@ -1,0 +1,12 @@
+.spin {
+  animation: spin 2s infinite linear;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,4 +18,5 @@
  *= require chosen
  *= require jquery-ui
  *= require pagination
+ *= require animations
  */

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -6,7 +6,9 @@
           %td.small-1.columns
             - if (invitation.parent.date_and_time - 30.minutes).past?
               - if invitation.attended.nil?
-                = link_to admin_workshop_invitation_path(@workshop, invitation, attended: true), class: 'verify_attendance', title: 'Verify attendance', method: :put, remote: true do
+                = link_to admin_workshop_invitation_path(@workshop, invitation, attended: true),
+                  class: 'verify_attendance', title: 'Verify attendance', method: :put, remote: true,
+                  data: { disable_with: "<i class='fa fa-spinner spin'></i>" } do
                   %i.fa.fa-square-o
               - else
                 %i.fa.fa-check-square-o


### PR DESCRIPTION
This pull request tries to help with the slowdown felt when admins try to check members in for a workshop. It does that in two ways:
- Tries to be a bit more specific with the HTML that is being replaced, targeting a smaller DOM surface area and only re-instantiating Foundation’s features that it needs (I think we only need the _tooltips_);
- When clicking on a check-in link, it gets replaced with a spinning icon until it gets replaced with the new HTML:
  ![codebar--loading](https://user-images.githubusercontent.com/385232/107700148-fd9d8400-6cae-11eb-92b6-5129bdc58030.gif)

---

![image](https://user-images.githubusercontent.com/385232/107700290-2d4c8c00-6caf-11eb-86a6-54dd5597b6ff.png)
This freeze happens because a lot of JavaScript gets triggered with we call `$(document).foundation()`. In order to make this much faster than it is, I think we need to change the technique we follow to update this page.
