### PR TITLE
Don't allow rsvp-ing a workshop that is in the past #1484

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -9,7 +9,7 @@ class WorkshopsController < ApplicationController
   end
 
   def rsvp
-    redirect_to :back, notice: t('workshops.registration_not_open') unless @workshop.invitable_yet?
+    return redirect_to :back, notice: t('workshops.registration_not_open') unless @workshop.available_for_rsvp?
 
     if role_params.nil?
       @invitation = find_attending_invitation(@workshop, current_user)

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -72,6 +72,10 @@ class Workshop < ActiveRecord::Base
     open_for_rsvp? || invitable
   end
 
+  def available_for_rsvp?
+    invitable_yet? && date_and_time.future?
+  end
+
   # Is this person attending this event?
   def attendee?(person)
     return false if person.nil?

--- a/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
+++ b/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
@@ -163,8 +163,8 @@ RSpec.shared_examples 'managing workshop attendance' do
             visit workshop_path(workshop)
 
             expect(page).to have_button('Manage your invitation')
-            expect(page).not_to have_link('Attend as a student')
-            expect(page).not_to have_link('Attend as a coach')
+            expect(page).not_to have_button('Attend as a student')
+            expect(page).not_to have_button('Attend as a coach')
           end
         end
 

--- a/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
+++ b/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
@@ -167,6 +167,17 @@ RSpec.shared_examples 'managing workshop attendance' do
             expect(page).not_to have_link('Attend as a coach')
           end
         end
+
+        context 'when the workshop has already happened' do
+          it 'can not rsvp to workshop that is now in the past' do
+            travel_into_the_future = Time.zone.now + 3.days
+            allow(Time).to receive(:now).and_return(travel_into_the_future)
+      
+            click_on 'Attend as a coach'
+            expect(page).to have_content('This event has already taken place')
+            expect(page).not_to have_button('Attend as a coach')
+          end    
+        end
       end
     end
 


### PR DESCRIPTION
The backend did not do validation on the workshop's time and date when
a user sent an rsvp. There is validation in the view when the workshop
page is rendered, so the button to attend does not show up on past
workshops. However if the page was old and the button was there, a user
could still sign up and get an invitation created. The workshop was then
displayed as in the past.

For virtual workshops it is possible to attend anyway, so a confirmation
email would be sent. This change stops the system from ever creating
invitations for past workshops.

I think the new test file should also contain tests for the other validation criteria in the `workshops_controller#rsvp action`. I decided not to include them here to keep the PR to the scope of the issue.

Closes #1484 