### PR TITLE
Add Community partner option to Sponsor levels

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,6 +60,13 @@ module ApplicationHelper
     super(number, options)
   end
 
+  def sponsorship_level_title(level)
+    return t('sponsors.standard_title') if level === 'standard'
+    return t('sponsors.community_partner_title') if level === 'community'
+
+    "#{level.humanize} sponsors"
+  end
+
   private
 
   def humanize_date_with_time(datetime, end_time)

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -9,7 +9,8 @@ class Sponsor < ActiveRecord::Base
     standard: 1,
     bronze: 2,
     silver: 3,
-    gold: 4
+    gold: 4,
+    community: 5
   }
 
   has_one :address

--- a/app/views/sponsors/index.html.haml
+++ b/app/views/sponsors/index.html.haml
@@ -11,14 +11,13 @@
         If you are interested in becoming a host please do get in touch with us at #{mail_to "hello@codebar.io", "hello@codebar.io"}
         ='.'
 
-
-- ['gold', 'silver', 'bronze', 'standard'].each do |level|
+- ['gold', 'silver', 'bronze', 'community', 'standard'].each do |level|
   - if @sponsor_levels[level]
     .stripe.reverse
       .row
         .large-12.columns
           %h3.sponsor-header-margin.text-center
-            #{level == 'standard' ? 'And thanks to our other ' : level.humanize} sponsors
+            = sponsorship_level_title(level)
       - @sponsor_levels[level].in_groups_of(6) do |grouped_sponsors|
         .row.sponsor-row
           - grouped_sponsors.compact.each do |sponsor|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,6 +287,8 @@ en:
       contact: "contact us"
       email_subject: "Regarding code of conduct"
   sponsors:
+    standard_title: And thanks to our other sponsors
+    community_partner_title: Community partners
     sponsoring: "Sponsoring"
   members:
     sign_up: "Sign up"

--- a/db/migrate/20180307221521_add_level_to_sponsors.rb
+++ b/db/migrate/20180307221521_add_level_to_sponsors.rb
@@ -5,6 +5,7 @@ class AddLevelToSponsors < ActiveRecord::Migration
     # bronze: 2,
     # silver: 3,
     # gold: 4,
+    # community: 5,
     add_column :sponsors, :level, :integer, null: false, default: 1, index: true
   end
 

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Event creation', type: :feature do
         expect(page).to have_content('Event successfully created')
 
         expect(page).to have_content('A test event')
-        expect(page).to have_content("#{I18n.l(date, format: :humanised)} | 16:00 - 18:00 GMT (GMT+00:00)")
+        expect(page).to have_content(humanize_date(date))
         expect(page).to have_content('A test event description')
         expect(page).to have_content('25 student spots, 19 coach spots')
         expect(find('#schedule', visible: false).text).to eq('9:00 Sign up & breakfast 9:30 kick off')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,4 +49,21 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.dot_markdown(text)).to include(expected)
     end
   end
+
+  describe '#sponsorship_level_title' do
+    it 'returns title for sponsorship level sections on /sponsors page' do
+      title = helper.sponsorship_level_title('gold')
+      expect(title).to eq('Gold sponsors')
+    end
+
+    it 'returns custom title for standard level' do
+      title = helper.sponsorship_level_title('standard')
+      expect(title).to eq('And thanks to our other sponsors')
+    end
+
+    it 'returns custom title for community level' do
+      title = helper.sponsorship_level_title('community')
+      expect(title).to eq('Community partners')
+    end
+  end
 end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Sponsor, type: :model do
 
     it 'defines enum level' do
       is_expected.to define_enum_for(:level)
-        .with_values(%i[hidden standard bronze silver gold])
+        .with_values(%i[hidden standard bronze silver gold community])
     end
   end
 end


### PR DESCRIPTION
## Description
This PR adds the Community partner option to Sponsor levels.

## Status
Ready for Review

## Screenshots
<img width="1440" alt="Screenshot 2021-03-25 at 9 11 43 pm" src="https://user-images.githubusercontent.com/5873816/112576386-69473680-8daf-11eb-8332-f0c65d84cf8e.png">

## Related Github issue
Fixes #1492 