### PR TITLE
Add newsletter signup form to homepage

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -79,3 +79,6 @@
     .row
       .medium-offset-1.medium-10.columns
         = render partial: 'members/testimonials'
+
+%section.stripe.reverse
+  = render partial: 'shared/newsletter'

--- a/app/views/shared/_newsletter.html.haml
+++ b/app/views/shared/_newsletter.html.haml
@@ -1,0 +1,35 @@
+.row
+  .medium-10.medium-offset-1.columns
+    %h2 Subscribe to our newsletter
+    %p Summary of what's in the newsletter. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+    -# Mailchimp Signup Form
+    #mc_embed_signup
+      %form.validate#mc-embedded-subscribe-form{ action: "https://codebar.us8.list-manage.com/subscribe/post?u=b4652d85b385945c79f2ffa2e&amp;id=3798974cb3",
+                                                 method: "post",
+                                                 name: "mc-embedded-subscribe-form",
+                                                 target: "_blank",
+                                                 novalidate: true }
+        #mc_embed_signup_scroll
+          #indicates-required
+            %small.right
+              %span.asterisk *
+              indicates required
+
+          .mc-field-group
+            %label{ for: "mce-EMAIL" }
+              Email Address 
+              %span.asterisk *
+            %input.required.email#mce-EMAIL{ type: 'email', value: '', name: 'EMAIL' }
+
+          .clear#mce-responses
+            .response#mce-error-response{ style: 'display:none' }
+            .response#mce-success-response{ style: 'display:none' }
+
+          -# real people should not fill this in and expect good things - do not remove this or risk form bot signups
+          %div{ style: 'position: absolute; left: -5000px;', 'aria-hidden': 'true' }
+            %input{ type: 'text', name: 'b_b4652d85b385945c79f2ffa2e_3798974cb3', tabindex: '-1', value: '' }
+          .clear
+            %input.button.small#mc-embedded-subscribe{ type: 'submit', value: 'Subscribe', name: 'subscribe' }
+
+          %a{ href: 'https://us8.campaign-archive.com/home/?u=b4652d85b385945c79f2ffa2e&id=3798974cb3' } View previous newsletters.

--- a/app/views/shared/_newsletter.html.haml
+++ b/app/views/shared/_newsletter.html.haml
@@ -1,7 +1,7 @@
 .row
   .medium-10.medium-offset-1.columns
-    %h2 Subscribe to our newsletter
-    %p Summary of what's in the newsletter. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    %h2= t('homepage.newsletter.title')
+    %p= t('homepage.newsletter.description')
 
     -# Mailchimp Signup Form
     #mc_embed_signup

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,9 @@ en:
       workshop_email_subject: "Regarding hosting a workshop"
     chapters:
       title: "Chapters"
+    newsletter:
+      title: Subscribe to our newsletter
+      description: Get regular updates about the codebar community. Be informed about upcoming events, jobs, scholarships and other learning opportunities.
   mailer:
     workshop_invitation:
       attending:


### PR DESCRIPTION
## Description
This PR adds a newsletter signup form on the homepage that subscribes people to the main codebar Mailchimp audience. It uses Mailchimps embedded signup form.

## Status
Work in Progress

## TODO
@KimberleyCook @despo there's a piece of copy that needs to be written that explains what to expect from the newsletter, let me know if you have a good idea for this. 1 or 2 short sentences would do.

## Related Github issue
Resolves #1494

## Screenshots
<img width="1440" alt="Screenshot 2021-03-30 at 7 13 29 pm" src="https://user-images.githubusercontent.com/5873816/113080747-3d9bc600-918c-11eb-8d9b-277f48abed63.png">