### PR TITLE
Cache Ruby gems on GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,9 @@ jobs:
       with:
         ruby-version: 2.4.2
         bundler-cache: true
+      env:
+        BUNDLE_JOBS: 4
+        BUNDLE_RETRY: 3
 
     - name: Setup test database
       env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,12 +25,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4.2
-
-    - name: Install dependencies
-      run: |
-        gem install bundler -v 1.17.3
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
 
     - name: Setup test database
       env:


### PR DESCRIPTION
While working on , I’ve noticed that GitHub Actions were taking a surprising amount of time:
![image](https://user-images.githubusercontent.com/385232/113586913-07e05c80-9626-11eb-868d-803ed611ba9e.png)

Looking into the most recent one, the overall time spent on dependencies alone was surprising (notice the times on the right):
![image](https://user-images.githubusercontent.com/385232/113587024-27778500-9626-11eb-9cb8-52bf711d4f0f.png)

This seems like missing cache on GitHub Actions, so I [researched a bit](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically) and I was able to largely improve this time (notice the times on the right):
![image](https://user-images.githubusercontent.com/385232/113587142-4aa23480-9626-11eb-8f5a-60dd16f4bde7.png)

I moved the config options we had on the `Install dependencies` step into `.bundle/config` (example below) but also to the GitHub Action:
```diff
---
BUNDLE_WITHOUT: "production"
+BUNDLE_JOBS: 4
+BUNDLE_RETRY: 3
```

#### Example

[Here’s the first run](https://github.com/codebar/planner/actions/runs/719512688) of this pull request and [here’s the second one](https://github.com/codebar/planner/actions/runs/719528470).



