### PR TITLE
Update calls to deleted methods in _admin_menu partial & in coach/feedback/index page

### DIFF
--- a/app/views/coach/feedback/index.html.haml
+++ b/app/views/coach/feedback/index.html.haml
@@ -19,7 +19,7 @@
             .large-2.columns
               - (0...feedback.rating).each do |rating|
                 .fa.fa-star
-          - if current_user.is_admin_or_organiser? and feedback.coach.present?
+          - if current_user.admin_or_organiser? and feedback.coach.present?
             .row
               .large-12.columns
                 %p

--- a/app/views/layouts/_admin_menu.html.haml
+++ b/app/views/layouts/_admin_menu.html.haml
@@ -3,14 +3,14 @@
 %li= link_to 'Admin Dashboard', admin_root_path
 %li= link_to 'View Feedback', admin_feedback_index_path
 %li= link_to 'New Announcement', new_admin_announcement_path
-- if current_user.is_admin_or_organiser?
-  %li= link_to 'New workshop', new_admin_workshop_path
-  %li= link_to 'New sponsor', new_admin_sponsor_path
+%li= link_to 'New workshop', new_admin_workshop_path
+%li= link_to 'New sponsor', new_admin_sponsor_path
 %li= link_to 'New event', new_admin_event_path
 %li= link_to 'New monthly', new_admin_meeting_path
 %li= link_to 'New chapter', new_admin_chapter_path
 %li= link_to 'New group', new_admin_group_path
 %li= link_to "Review jobs (#{jobs_pending_approval})", admin_jobs_path
+
 - if current_user.has_role?(:organiser, :any)
   %li
     %label My Chapters


### PR DESCRIPTION
## Description
This PR fixes a small bug in the admin left hand side menu. Some Member method names got update is #1455 which meant that the New Workshop and Add Sponsor options in the menu were permanently hidden, as the `is_admin_or_organiser?` method always evaluated to false.

## Status
Ready for Review

## Related Github issue
Bug introduced in #1455

## Screenshots
<img width="1440" alt="Screenshot 2021-04-15 at 9 02 10 am" src="https://user-images.githubusercontent.com/5873816/114901067-49f96300-9dc9-11eb-86d4-8344173f36e6.png">