### PR TITLE
Fix Sponsors logo grid layout on event & workshop pages

### DIFF
--- a/app/views/events/_sponsors.html.haml
+++ b/app/views/events/_sponsors.html.haml
@@ -1,4 +1,0 @@
-- sponsors.each do |sponsor|
-  .col-4.pl-3.pr-3
-    =link_to sponsor.website, class: 'border-0' do
-      = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -22,11 +22,9 @@
   .row
     .col
       - if @event.announce_only
-        %a{ name: "information" }
-        %h3{ "data-magellan-destination" => "information"} Information
+        %h3 Information
       - else
-        %a{ name: "schedule" }
-        %h3{ "data-magellan-destination" => "schedule"}
+        %h3
           = t('events.schedule')
       = dot_markdown(@event.schedule)
 
@@ -34,36 +32,37 @@
   .stripe.reverse
     .row
       .col
-        %a{ name: "faq" }
-          %h2{ "data-magellan-destination" => "faq"}
-            .text-center FAQ
+        %h2.text-center FAQ
         - if @event.announce_only
           %p.text-center If you have any questions, #{mail_to(@event.email, "get in contact")}
-
         - else
           = render partial: 'events/faq'
 
 -if @event.sponsors?
-  .stripe.reverse
+  #sponsors.container-fluid.stripe.reverse
     .row
       .col
-        %a{ name: "sponsors" }
-        %h2.text-center{ "data-magellan-destination" => "sponsors"}
+        %h2.text-center
           = t('events.sponsors')
         %p.text-center
           %i= t('events.thx_to_sponsors')
-    .row.mt-4
       - if @event.sponsors?(:gold)
-        %h3.text-center Gold
-        = render partial: "sponsors", object: @event.gold_sponsors
+        .row.mt-4
+          .col
+            %h3.text-center Gold
+        = render partial: 'shared/sponsors', object: @event.gold_sponsors
       - if @event.sponsors?(:silver)
-        %h3.text-center Silver
-        = render partial: "sponsors", object: @event.silver_sponsors
+        .row.mt-4
+          .col
+            %h3.text-center Silver
+        = render partial: 'shared/sponsors', object: @event.silver_sponsors
       - if @event.sponsors?(:bronze)
-        %h3.text-center Bronze
-        = render partial: "sponsors", object: @event.bronze_sponsors
+        .row.mt-4
+          .col
+            %h3.text-center Bronze
+        = render partial: 'shared/sponsors', object: @event.bronze_sponsors
       - if @event.sponsors?(:standard)
-        = render partial: "sponsors", object: @event.sponsors
+        = render partial: 'shared/sponsors', object: @event.sponsors
 
 - if @event.verified_coaches.any?
   .container-fluid.stripe.reverse

--- a/app/views/shared/_sponsors.html.haml
+++ b/app/views/shared/_sponsors.html.haml
@@ -1,0 +1,4 @@
+.row.align-items-center
+  - sponsors.each do |sponsor|
+    .col-4.col-md-3.col-lg-2.mt-3
+      = link_to image_tag(sponsor.avatar, class: 'small-image', alt: sponsor.name), sponsor.website, title: sponsor.name, class: 'd-inline-block'

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -23,15 +23,11 @@
 .container-fluid.stripe.reverse
   = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
 
-
-#sponsors.container-fluid.stripe.reverse.text-center
+#sponsors.container-fluid.stripe.reverse
   .row
     .col
-      %h3 Sponsors
-  .row.mt-4
-    - @workshop.sponsors.each do |sponsor|
-      .col-4
-        = image_tag(sponsor.avatar.url, class: 'sponsor-md', alt: sponsor.name)
+      %h3.text-center Sponsors
+  = render partial: 'shared/sponsors', object: @workshop.sponsors
 
 .container-fluid.stripe.reverse
   = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: false }


### PR DESCRIPTION
## Description
This PR fixes and improves the layout Sponsors logo grid on the workshop and event pages and standardizes on one partial.

## Status
Ready for Review

## Related Github issue
Fixes #1506

## Screenshots
Workshop Mobile Before | Workshop Mobile After
------------ | -------------
<img width="390" alt="Screenshot 2021-04-24 at 12 28 42 pm" src="https://user-images.githubusercontent.com/5873816/115970664-c7735080-a4f8-11eb-9230-d803fa45a9b9.png"> | <img width="394" alt="Screenshot 2021-04-24 at 12 29 19 pm" src="https://user-images.githubusercontent.com/5873816/115970674-d3f7a900-a4f8-11eb-81ad-a570953073a5.png">

Event Before | Event After
------------ | -------------
<img width="1440" alt="Screenshot 2021-04-24 at 12 33 09 pm" src="https://user-images.githubusercontent.com/5873816/115970778-8a5b8e00-a4f9-11eb-9819-e0d077fd34c3.png"> | <img width="1440" alt="Screenshot 2021-04-24 at 12 35 10 pm" src="https://user-images.githubusercontent.com/5873816/115970784-92b3c900-a4f9-11eb-912d-4d85e9701fb3.png">
