### PR TITLE
Fix event page Coaches and Organisers grid layout bugs

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -66,29 +66,18 @@
         = render partial: "sponsors", object: @event.sponsors
 
 - if @event.verified_coaches.any?
-  .stripe.reverse
+  .container-fluid.stripe.reverse
     .row
       .col
-        %a{ name: "coaches" }
-          %h2{ "data-magellan-destination" => "coaches"}
-            .text-center= t('events.coaches')
-    .row.mt-4
-      .col-md-2.col-sm-3
+        %h2.text-center
+          = t('events.coaches')
+    .row.mt-4.text-center
+      .col-sm-4.col-md-3.mb-4
         - @event.verified_coaches.each do |coach|
-          =link_to twitter_url_for(coach.twitter), class: 'user-link' do
-            =image_tag(coach.avatar(56), class: 'th radius', title: coach.full_name, alt: coach.full_name)
+          = link_to twitter_url_for(coach.twitter), class: 'user-link' do
+            = image_tag(coach.avatar(56), class: 'rounded-circle', title: coach.full_name, alt: coach.full_name)
             %p.mt-3.mb-1= coach.full_name
 
 - if @event.organisers.any?
-  .stripe.reverse
-    .row
-      .col
-        %a{ name: "organisers" }
-          %h2{ "data-magellan-destination" => "organisers"}
-            .text-center= t('events.organisers')
-    .row.mt-4
-      .col-sm-4.col-md-3.mb-4
-        - @event.organisers.each do |organiser|
-          =link_to twitter_url_for(organiser.twitter), class: 'user-link' do
-            =image_tag(organiser.avatar(56), class: 'th radius', title: organiser.full_name, alt: organiser.full_name)
-            %p.mt-3.mb-1= organiser.full_name
+  .container-fluid.stripe.reverse
+    = render partial: 'members/organisers_grid', locals: { members: @event.organisers, show_info: false }


### PR DESCRIPTION
## Description
This PR fixes the layout issues within the Coaches and Organisers grids on the event page. It also replaces the Organisers grid with the organisers_grid partial. It also removes the Foundation magellan code that was left in there, Bootstrap doesn't have a magellan feature.

## Status
Ready for Review

## Related Github issues
Fixes #1508
Fixes #1509

## Screenshots
Event page Coaches & Organisers grid Before | Event page Coaches & Organisers grid After
------------ | -------------
<img width="1283" alt="Screenshot 2021-04-24 at 2 11 41 pm" src="https://user-images.githubusercontent.com/5873816/115973040-07413480-a507-11eb-8cef-af5de0e533bc.png"> | <img width="1283" alt="Screenshot 2021-04-24 at 2 10 21 pm" src="https://user-images.githubusercontent.com/5873816/115973024-df51d100-a506-11eb-8a3e-195137ad2c1f.png">