### PR TITLE
Fix meeting page Venue & Who else will be there sections layout bugs

### DIFF
--- a/app/views/meetings/_meeting_actions.html.haml
+++ b/app/views/meetings/_meeting_actions.html.haml
@@ -1,8 +1,8 @@
 - if @meeting.venue.present?
   %h4 Venue
-  %p.mb-1
+  %p
     %strong= @meeting.venue.name
-  =link_to @meeting.venue.website, class: 'border-0' do
+  = link_to @meeting.venue.website, class: 'd-block border-0 mb-4' do
     = image_tag(@meeting.venue.avatar.thumb, alt: @meeting.venue.name)
   %strong Address
   %p= @host_address
@@ -14,7 +14,6 @@
     %p= @meeting.venue.accessibility_info
 
   %h4 RSVP
-
   - if logged_in?
     - if @meeting.past?
       %p.badge.bg-primary This event has already occurred.
@@ -23,21 +22,24 @@
       %p.badge.bg-danger Your invitations have been temporarily suspended.
 
     - elsif @meeting.attending?(current_user)
-      %p.badge.bg-success You are attending this event
-      = link_to "Can't make it anymore? Click here to cancel your spot.", meeting_cancel_path(meeting_id: @meeting.id, token: @invitation.token)
+      %p.badge.bg-success You are attending this event.
+      %p
+        %strong
+          = link_to "Can't make it anymore? Click here to cancel your spot.", meeting_cancel_path(meeting_id: @meeting.id, token: @invitation.token)
 
     - elsif @meeting.invitable && @meeting.not_full
       = link_to meeting_invitation_path(@meeting), class: 'btn btn-primary' do
-        = "RSVP here"
+        = 'RSVP here'
 
     - elsif !@meeting.not_full
-      %p.badge.bg-warning.text-dark This event is now full
+      %p.badge.bg-warning.text-dark This event is now full.
       %p
         %strong To join the waitlist, please <a href="https://airtable.com/shrWPRlXDgjDGSYk6">fill in your details here</a>.
 
     - else
-      %h5 This event is not open for RSVP.
+      %p
+        %strong This event is not open for RSVP.
 
   - else
-    = link_to "Sign up", new_member_path, class: 'btn btn-primary'
-    = link_to "Log in", login_path, class: 'btn btn-primary'
+    = link_to 'Sign up', new_member_path, class: 'btn btn-primary'
+    = link_to 'Log in', login_path, class: 'btn btn-primary'

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -4,9 +4,9 @@
   .row
     .col
       %h2
-        =@meeting.name
+        = @meeting.name
       %h3
-        %small=humanize_date(@meeting.date_and_time, @meeting.ends_at, with_time: true)
+        %small= humanize_date(@meeting.date_and_time, @meeting.ends_at, with_time: true)
 
   .row
     .col-md-4.col-sm-12
@@ -20,17 +20,18 @@
   .row
     .col
       %iframe{ width: '100%', height: '250', frameborder: '0', scrolling: 'no', marginheight: '0', marginwidth: '0', src: %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&t=m&z=15&output=embed} }
-        =link_to "View larger map", %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
+        = link_to 'View larger map', %{https://maps.google.com/maps?f=q&source=s_q&hl=en&amp;geocode=&q=#{@host_address.for_map}&ie=UTF8&hq=&t=m&z=15}, style: "color:#0000FF;text-align:left"
 
-.stripe.reverse
-  .row
-    .col
-      %h3.text-center Who else will be there?
-  .row.mt-4
-    - @attendees.each do |a|
-      .col-md-2.col-sm-4
-        =image_tag(a.member.avatar(96), class: 'rounded-circle', title: a.member.full_name, alt: a.member.full_name)
-        =a.member.full_name
+- if @attendees.any?
+  .container-fluid.stripe.reverse.text-center
+    .row
+      .col
+        %h3 Who else will be there?
+    .row
+      - @attendees.each do |attendee|
+        .col-sm-4.col-md-3.mt-4
+          = image_tag(attendee.member.avatar(56), class: 'rounded-circle', title: attendee.member.full_name, alt: attendee.member.full_name)
+          %p.mt-3= attendee.member.full_name
 
 .stripe.reverse
   = render partial: 'members/organisers_grid', locals: { members: @meeting.organisers, show_info: false }


### PR DESCRIPTION
## Description

## Status
Ready for Review

## Related Github issues
Fixes #1511 
Fixes #1512 

## Screenshots
Venue section Before | Venue section After
------------ | -------------
<img width="1299" alt="Screenshot 2021-04-24 at 5 01 24 pm" src="https://user-images.githubusercontent.com/5873816/115979611-bdbf0c80-a53b-11eb-88ef-1ad2d2134617.png"> | <img width="1295" alt="Screenshot 2021-04-24 at 4 27 55 pm" src="https://user-images.githubusercontent.com/5873816/115979615-c57eb100-a53b-11eb-8ffd-2d676daea62e.png">

Who else will be there section Before | Who else will be there section After
------------ | -------------
<img width="1442" alt="Screenshot 2021-04-24 at 1 35 16 pm" src="https://user-images.githubusercontent.com/5873816/115979676-15f60e80-a53c-11eb-801d-3a3316645e47.png"> | <img width="1301" alt="Screenshot 2021-04-24 at 8 00 20 pm" src="https://user-images.githubusercontent.com/5873816/115979686-21493a00-a53c-11eb-9810-4aed249b39bd.png">