### PR TITLE
Update the layout of the CoC, Student & Coach Guide pages to match that of the FAQ page

### DIFF
--- a/app/views/dashboard/code.html.haml
+++ b/app/views/dashboard/code.html.haml
@@ -1,18 +1,19 @@
 .stripe.reverse#code-of-conduct
-  .row
-    .col
-      %h1
-        = t('code_of_conduct.title')
-.stripe.reverse
-  .row
-    .col
+  .row.justify-content-md-center
+    .col.col-md-8
       %h2
+        = t('code_of_conduct.title')
+
+.stripe.reverse
+  .row.justify-content-md-center
+    .col.col-md-8
+      %h3
         = t('code_of_conduct.summary.title')
 
       %p.lead
         = t('code_of_conduct.summary.intro')
 
-      %h2
+      %h3
         = t('code_of_conduct.content.title')
 
       %p
@@ -35,4 +36,4 @@
 
       %p
         = t('code_of_conduct.content.questions')
-        =mail_to 'hello@codebar.io', t('code_of_conduct.content.contact'), subject: t('code_of_conduct.content.email_subject')
+        = mail_to 'hello@codebar.io', t('code_of_conduct.content.contact'), subject: t('code_of_conduct.content.email_subject')

--- a/app/views/dashboard/effective-teacher-guide.html.haml
+++ b/app/views/dashboard/effective-teacher-guide.html.haml
@@ -1,14 +1,14 @@
 .stripe.reverse
-  .row
-    .col
-      %h3
+  .row.justify-content-md-center
+    .col.col-lg-8
+      %h2
         Coach Guide
-      %p
+      %p.lead
         This is a brief guide we've put together for our coaches. If you have any suggestions to make open a #{link_to "pull request", "https://github.com/codebar/planner"} or #{link_to "create an issue", "https://github.com/codebar/planner/issues/new"}.
 
 .stripe.reverse
-  .row
-    .col
+  .row.justify-content-md-center
+    .col.col-lg-8
       %ul
         %li
           %p.mb-2= t('dashboard.teacher_guide.laptop')

--- a/app/views/dashboard/participant_guide.html.haml
+++ b/app/views/dashboard/participant_guide.html.haml
@@ -1,6 +1,6 @@
 .stripe.reverse#banner
-  .row
-    .col
+  .row.justify-content-md-center
+    .col.col-md-8
       %h2= t('participant_student_guide.title')
       = link_to t('participant_student_guide.attendance_policy.title') , '#attendance'
       \|
@@ -9,8 +9,8 @@
       = link_to t('participant_student_guide.disability.title') , '#disability'
 
 .stripe.reverse
-  .row
-    .col
+  .row.justify-content-md-center
+    .col.col-md-8
       %h3#attendance= t('participant_student_guide.attendance_policy.title')
       %p
         = t('participant_student_guide.attendance_policy.intro')


### PR DESCRIPTION
## Description
This PR updates the layout of the CoC, Student guide & Coach guide pages to match that of the FAQ page. The FAQ page has a narrower width on large viewports which I think makes the content easier to read.

## Status
Ready for Review

## Related Github issue
Fixes #1514 

## Screenshots
CoC page Before | CoC page After
------------ | -------------
![Screen Shot 2021-04-26 at 14 45 58](https://user-images.githubusercontent.com/5873816/116010763-f7dcec80-a5d5-11eb-8fa3-3e0aef6c80fd.png) | ![Screen Shot 2021-04-26 at 14 53 26](https://user-images.githubusercontent.com/5873816/116010770-088d6280-a5d6-11eb-8c7b-86a58ca6b4f3.png)

Student Guide page Before | Student Guide page After
------------ | -------------
![Screen Shot 2021-04-26 at 14 48 43](https://user-images.githubusercontent.com/5873816/116010786-25299a80-a5d6-11eb-801f-4b8c6b3c1d85.png) | ![Screen Shot 2021-04-26 at 14 48 21](https://user-images.githubusercontent.com/5873816/116010796-2fe42f80-a5d6-11eb-97ab-910e01ea6440.png)


Coach Guide page Before | Coach Guide page After
------------ | -------------
![Screen Shot 2021-04-26 at 14 48 49](https://user-images.githubusercontent.com/5873816/116010821-4b4f3a80-a5d6-11eb-9e70-13470e1edba0.png) | ![Screen Shot 2021-04-26 at 14 48 09](https://user-images.githubusercontent.com/5873816/116010811-438f9600-a5d6-11eb-858f-ff35947956e1.png)