### PR TITLE
Update /sponsors page to use shared sponsors partial

### DIFF
--- a/app/assets/stylesheets/partials/_sponsors.scss
+++ b/app/assets/stylesheets/partials/_sponsors.scss
@@ -11,7 +11,3 @@
   flex-wrap: wrap;
   align-items: center;
 }
-
-.sponsor-header-margin {
-  margin-bottom: 35px;
-}

--- a/app/views/shared/_sponsors.html.haml
+++ b/app/views/shared/_sponsors.html.haml
@@ -1,4 +1,4 @@
 .row.align-items-center
   - sponsors.each do |sponsor|
-    .col-4.col-md-3.col-lg-2.mt-3
-      = link_to image_tag(sponsor.avatar, class: 'small-image', alt: sponsor.name), sponsor.website, title: sponsor.name, class: 'd-inline-block'
+    .col-4.col-md-3.col-lg-2.mt-4.d-flex.justify-content-center
+      = link_to image_tag(sponsor.avatar, class: 'small-image mw-100', alt: sponsor.name), sponsor.website, title: sponsor.name, class: 'd-inline-block border-0'

--- a/app/views/sponsors/index.html.haml
+++ b/app/views/sponsors/index.html.haml
@@ -1,13 +1,12 @@
 .stripe.reverse
   .row
-    .large-12.columns
+    .col.col-lg-9
       %h2 Sponsors
       %p.lead
         Without our sponsors running <strong>codebar</strong> would be impossible. They provide us with space, food and drinks, internet, and they also help us cover our running costs.
       %p.lead
         Thank you for sharing our dream of creating a more welcoming, equal and diverse tech industry.
-
-      %p
+      %p.mb-0
         If you are interested in becoming a host please do get in touch with us at #{mail_to "hello@codebar.io", "hello@codebar.io"}
         ='.'
 
@@ -15,11 +14,7 @@
   - if @sponsor_levels[level]
     .stripe.reverse
       .row
-        .large-12.columns
-          %h3.sponsor-header-margin.text-center
+        .col
+          %h3.text-center
             = sponsorship_level_title(level)
-      - @sponsor_levels[level].in_groups_of(6) do |grouped_sponsors|
-        .row.sponsor-row
-          - grouped_sponsors.compact.each do |sponsor|
-            .medium-2.small-4.columns.sponsor-image
-              = link_to image_tag(sponsor.avatar, class: "small-image", alt: sponsor.name), sponsor.website
+      = render partial: 'shared/sponsors', object: @sponsor_levels[level].compact


### PR DESCRIPTION
## Description
This PR updates the sponsors index view to use the shared sponsors partial.

## Status
Ready for Review

## Related Github issue
Fixes #1523 

## Screenshots
Sponsors page Before | Sponsors page After
------------ | -------------
![Screenshot_2021-05-03 codebar(1)](https://user-images.githubusercontent.com/5873816/116961647-c066e380-ac58-11eb-870d-ec95e0e8ee6e.png) | ![Screenshot_2021-05-03 codebar](https://user-images.githubusercontent.com/5873816/116961479-49314f80-ac58-11eb-9ec9-9ee8f2d4780e.png)
