### PR TITLE
Fix chapter page layout issues after Bootstrap migration + replace Sponsors grid with shared sponsors partial

### DIFF
--- a/app/assets/stylesheets/partials/_organisers.scss
+++ b/app/assets/stylesheets/partials/_organisers.scss
@@ -1,14 +1,3 @@
 .user-link {
   border-bottom: none;
 }
-
-.organiser-content {
-  @extend .card;
-  align-items: center;
-  justify-content: center;
-}
-
-.organiser-image {
-  border-radius: 3.57143rem;
-  margin-bottom: 0.5rem;
-}

--- a/app/views/chapter/_subscriptions.html.haml
+++ b/app/views/chapter/_subscriptions.html.haml
@@ -1,14 +1,11 @@
-.row
-  .medium-12.columns
-    - @chapter.groups.each do |group|
-      - if belongs_to_group?(group)
-        %span{ "data-tooltip" =>"", "aria-haspopup" => "true",  class: "has-tip", title: "Unsubscribe from #{@chapter.name} #{group.name}" }
-          = link_to subscriptions_path(subscription: { group_id: group }), method: 'delete', class: 'button secondary small' do
-            =group.name
-            %i.fa.fa-check
-      - else
-        %span{ "data-tooltip" =>"", "aria-haspopup" => "true",  class: "has-tip", title: "Subscribe to #{@chapter.name} #{group.name}" }
-
-          = link_to subscriptions_path(subscription: { group_id: group }), method: 'post', class: 'button small' do
-            = group.name
-            %i.fa.fa-rss
+- @chapter.groups.each do |group|
+  - if belongs_to_group?(group)
+    %span{ title: "Unsubscribe from #{@chapter.name} #{group.name}" }
+      = link_to subscriptions_path(subscription: { group_id: group }), method: 'delete', class: 'btn btn-success' do
+        = group.name
+        %i.fa.fa-check
+  - else
+    %span{ title: "Subscribe to #{@chapter.name} #{group.name}" }
+      = link_to subscriptions_path(subscription: { group_id: group }), method: 'post', class: 'btn btn-secondary' do
+        = group.name
+        %i.fa.fa-rss

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -52,17 +52,9 @@
         %h2.text-center Sponsors
     = render partial: 'shared/sponsors', object: @recent_sponsors
 
-.stripe.reverse
-  .container.row
-    .col.text-center
-      %a{ name: 'organisers' }
-      %h2 Team
-  .container.row.mt-4
-    - @chapter.organisers.shuffle.each do |organiser|
-      .col-4.col-md-3.text-center.border.pt-4
-        = link_to twitter_url_for(organiser.twitter), title: "#{organiser.full_name} Twitter profile" do
-          = image_tag(organiser.avatar(65), class: "mt-3", alt: organiser.full_name, class: 'rounded-circle')
-          = organiser.full_name
-  .container.row.mt-4
-    .col.alert.alert-primary
+.container-fluid.stripe.reverse
+  = render partial: 'members/organisers_grid', locals: { members: @chapter.organisers.shuffle, show_info: false, title: t('chapters.team') }
+
+  .row.mt-5
+    .col.alert.alert-primary.mb-0
       = t('chapters.contact', city: @chapter.name, email: @chapter.email)

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -46,14 +46,11 @@
       %script(async src="https://platform.twitter.com/widgets.js" charset="utf-8")
 
 - if @recent_sponsors.any?
-  .stripe.reverse
+  .container-fluid.stripe.reverse
     .row
-      .col.text-center
-        %h2 Sponsors
-    .row.mt-4.d-flex.align-items-center
-      - @recent_sponsors.each do |sponsor|
-        .col-3.col-md-2
-          = link_to image_tag(sponsor.avatar, class: "border-0", alt: sponsor.name), sponsor.website, title: sponsor.name
+      .col
+        %h2.text-center Sponsors
+    = render partial: 'shared/sponsors', object: @recent_sponsors
 
 .stripe.reverse
   .container.row

--- a/app/views/chapter/show.html.haml
+++ b/app/views/chapter/show.html.haml
@@ -1,24 +1,25 @@
-.container
-  .row
-    .col-md-6.col-sm-12
+.container-fluid
+  .row.align-items-center
+    .col-md-6.pt-4.pb-4
       %h1= @chapter.name
       - if @chapter.description
         %p.lead= @chapter.description
       - else
-        %p.lead= t('chapters.intro_html')
+        %p.lead.mb-0= t('chapters.intro_html')
     - if @chapter.image.present?
-      .medium-6.columns.chapter-header-image
+      .col-md-6
         = image_tag @chapter.image.bg, alt: "#{@chapter.name} chapter"
 
-.alert.alert-primary
-  .row
-    .col-6
-      = t('chapters.info', email: h(@chapter.email)).html_safe
-    .col-6.text-center
-      - if logged_in?
-        = render partial: 'subscriptions'
-      - else
-        =link_to 'Sign up', new_member_path, class: 'btn btn-primary'
+.alert-primary.pt-4.pb-4
+  .container-fluid
+    .row.align-items-center
+      .col-md-6.mb-4.mb-md-0
+        = t('chapters.info', email: h(@chapter.email)).html_safe
+      .col-md-6.text-center
+        - if logged_in?
+          = render partial: 'subscriptions'
+        - else
+          =link_to 'Sign up', new_member_path, class: 'btn btn-primary'
 
 .container.stripe.reverse#chapter
   .row

--- a/app/views/members/_avatar_listing.html.haml
+++ b/app/views/members/_avatar_listing.html.haml
@@ -1,7 +1,7 @@
 - member.each do |member|
-  .col-sm-4.col-md-3.mb-4
-    =link_to twitter_url_for(member.twitter), class: 'user-link' do
-      =image_tag(member.avatar(56), class: 'rounded-circle', title: member.full_name, alt: member.full_name)
-    %p.mt-3.mb-1= member.full_name
+  .col-sm-4.col-md-3.mt-4
+    = link_to twitter_url_for(member.twitter), class: 'border-0' do
+      = image_tag(member.avatar(56), class: 'rounded-circle', title: member.full_name, alt: member.full_name)
+    %p.mt-3= member.full_name
     - if show_info
-      %p.mt-1.mb-1= member.mobile
+      %p.mt-1= member.mobile

--- a/app/views/members/_organisers_grid.html.haml
+++ b/app/views/members/_organisers_grid.html.haml
@@ -1,7 +1,9 @@
+- title = local_assigns[:title] ? local_assigns[:title] : t('events.organisers')
+
 #organisers.text-center
   .row
     .col
-      %h3= t('events.organisers')
+      %h3= title
 
-  .row.mt-4
+  .row
     = render partial: 'members/avatar_listing', locals: { member: members, show_info: show_info }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,6 +392,7 @@ en:
     sign_up: "to be invited to our workshops."
     no_incoming: "There are no workshops coming up."
     contact: "To contact the %{city} team, send an email to %{email}"
+    team: Team
   job:
     status:
       draft: Draft


### PR DESCRIPTION
## Description
This PR fixes a few layout issues on the chapter page and ensures the whole page is migrated to Bootstrap classes. It also replaces the Sponsors grid with the shared sponsors partial.

## Status
Ready for Review

## Related Github issues
Fixes #1532 
Resolves #1533 
Fixes #1534 

## Screenshots
Header section before | Header section after
------------ | -------------
<img width="300" alt="Screenshot 2021-05-10 at 7 30 13 pm" src="https://user-images.githubusercontent.com/5873816/118578026-4c403b80-b740-11eb-8486-1ec0142e58b3.png"> | <img width="300" alt="Screenshot 2021-05-17 at 6 49 46 pm" src="https://user-images.githubusercontent.com/5873816/118578253-accf7880-b740-11eb-89f7-7789a32586d8.png">

Team section before | Team section after
------------ | -------------
<img width="1297" alt="Screenshot 2021-05-07 at 6 17 12 pm" src="https://user-images.githubusercontent.com/5873816/118578428-00da5d00-b741-11eb-8df6-193b94065268.png"> | <img width="1293" alt="Screenshot 2021-05-17 at 6 53 21 pm" src="https://user-images.githubusercontent.com/5873816/118578561-2ebfa180-b741-11eb-8c69-34a57402ec7c.png">
