### PR TITLE
Replace 'minority groups' language

### DIFF
--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -48,7 +48,7 @@ en-GB:
         format: '%u%n'
   homepage:
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people in groups that are underrepresented in technology to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from a variety of backgrounds. Some want to become full-time developers, whereas some would like to learn the basics of coding in a supportive environment."


### PR DESCRIPTION
Hey all 👋🏻 no pressure to merge this PR, as I know codebar is very deliberate about language. But I just wanted to offer this alternative, since "minority group members" wouldn't cover women.

Note that we'd want to replicate this in `en_US` and `en_AU` etc. But I thought I'd just change this one in case you want to tweak the language first. Happy to change the others if helpful.