### PR TITLE
Add development environment to Skylight

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,10 @@ module Planner
     config.time_zone = 'London'
     config.active_record.default_timezone = :local
     config.active_record.raise_in_transactional_callbacks = true
+    
+    # Allow Skylight to show insights from local development.
+    # More info at https://skylight.io/support/environments
+    config.skylight.environments << 'development'
   end
 end
 


### PR DESCRIPTION
I’m looking into using Skylight to perf some local changes before deploying them, and I believe this is how you do it, according to their documentation: https://www.skylight.io/support/environments
I’m happy to revert this change if it doesn’t work.