### PR TITLE
Migrate Privacy Policy & Cookie Policy pages to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -19,7 +19,7 @@
 @import "bootstrap/images";
 @import "bootstrap/containers";
 @import "bootstrap/grid";
-// @import "bootstrap/tables";
+@import "bootstrap/tables";
 // @import "bootstrap/forms";
 @import "bootstrap/buttons";
 @import "bootstrap/transitions";

--- a/app/views/pages/cookie-policy.html.haml
+++ b/app/views/pages/cookie-policy.html.haml
@@ -1,50 +1,77 @@
-.row.mt2
-  .large-12.columns
-    :markdown
+.stripe.reverse
+  .row.justify-content-md-center
+    .col.col-md-8
+      :markdown
+        ## #{t('pages.cookies.title')}
 
-      ##{t('pages.cookies.title')}
+.stripe.reverse
+  .row.justify-content-md-center
+    .col.col-md-8
+      :markdown
+        #{t('pages.cookies.p1')}
 
-      #{t('pages.cookies.p1')}
+        #{t('pages.cookies.p2')}
 
-      #{t('pages.cookies.p2')}
+        #{t('pages.cookies.sub.title')}
 
-      #{t('pages.cookies.sub.title')}
+        ### #{t('pages.cookies.functional.title')}
 
+        #{t('pages.cookies.functional.description')}
 
-      ## #{t('pages.cookies.functional.title')}
+      %table.table.table-secondary
+        %thead
+          %tr
+            %th= t('pages.cookies.table.header.h1')
+            %th= t('pages.cookies.table.header.h2')
+            %th= t('pages.cookies.table.header.h3')
+        %tbody
+          %tr
+            %th
+              %code= t('pages.cookies.functional.planner_name')
+            %th= t('pages.cookies.functional.planner_purpose')
+            %th= t('pages.cookies.functional.planner_expiry')
+      %br
 
-       #{t('pages.cookies.functional.description')}
-      <br/>
+      :markdown
+        ### #{t('pages.cookies.google_analytics.title')}
 
-      | Cookie name | Purpose | Expires |
-      | ---- | ------- |    ----- |
-      | `_planner_session` | #{t('pages.cookies.functional.planner')} | #{t('pages.cookies.functional.planner_expiry ')} |
+        #{t('pages.cookies.google_analytics.description')}
 
-      <div style="height:1px;font-size:1px;">&nbsp;</div>
+        **#{t('pages.cookies.google_analytics.info')}**
 
-      ## #{t('pages.cookies.google_analytics.title')}
+      %table.table.table-secondary
+        %thead
+          %tr
+            %th= t('pages.cookies.table.header.h1')
+            %th= t('pages.cookies.table.header.h2')
+            %th= t('pages.cookies.table.header.h3')
+        %tbody
+          %tr
+            %th
+              %code= t('pages.cookies.google_analytics.ga_name')
+            %th= t('pages.cookies.google_analytics.ga_purpose')
+            %th= t('pages.cookies.google_analytics.ga_expiry')
+          %tr
+            %th
+              %code= t('pages.cookies.google_analytics.gid_name')
+            %th= t('pages.cookies.google_analytics.gid_purpose')
+            %th= t('pages.cookies.google_analytics.gid_expiry')
+      %br
 
-      #{t('pages.cookies.google_analytics.description')}
+      :markdown
+        #{t('pages.cookies.google_analytics.opt_out')}
 
-      **#{t('pages.cookies.google_analytics.info')}**
+        ### #{t('pages.cookies.cloudflare.title')}
 
-      <div style="height:1px;font-size:1px;">&nbsp;</div>
-
-      | Name |	Purpose | 	Expires |
-      | ---- | ------- |    ----- |
-      | `_ga` | #{t('pages.cookies.google_analytics.ga')} | #{t('pages.cookies.google_analytics.ga_expiry ')} |
-      | `_ga` | #{t('pages.cookies.google_analytics.gid')} | #{t('pages.cookies.google_analytics.gid_expiry ')} |
-
-      <div style="height:1px;font-size:1px;">&nbsp;</div>
-
-      #{t('pages.cookies.google_analytics.opt_out')}
-
-      ### #{t('pages.cookies.cloudflare.title')}
-
-      <div style="height:1px;font-size:1px;">&nbsp;</div>
-
-      | Name | Purpose | Expires |
-      | ---- | ------- |    ----- |
-      | `_cfduid` | #{t('pages.cookies.cloudflare.cfduid')} | #{t('pages.cookies.cloudflare.cfduid_expiry')} |
-
-      <div class='mb4'>&nbsp;</div>
+      %table.table.table-secondary
+        %thead
+          %tr
+            %th= t('pages.cookies.table.header.h1')
+            %th= t('pages.cookies.table.header.h2')
+            %th= t('pages.cookies.table.header.h3')
+        %tbody
+          %tr
+            %th
+              %code= t('pages.cookies.cloudflare.cfduid_name')
+            %th= t('pages.cookies.cloudflare.cfduid_purpose')
+            %th= t('pages.cookies.cloudflare.cfduid_expiry')

--- a/app/views/pages/privacy-policy.html.haml
+++ b/app/views/pages/privacy-policy.html.haml
@@ -1,21 +1,19 @@
 .stripe.reverse
-  .row
-    .large-12.columns
+  .row.justify-content-md-center
+    .col.col-md-8
       :markdown
-        # #{t('pages.privacy_policy.title')}
+        ## #{t('pages.privacy_policy.title')}
 
-      %h2.subheader= t('pages.privacy_policy.subtitle')
+      %p.lead= t('pages.privacy_policy.subtitle')
 
 .stripe.reverse
-  .row
-    .large-12.columns
+  .row.justify-content-md-center
+    .col.col-md-8
       :markdown
-
         #{t('pages.privacy_policy.intro.p1')}
 
-      %p
-        %address
-          #{t('pages.privacy_policy.intro.address_html')}
+      %address
+        #{t('pages.privacy_policy.intro.address_html')}
 
       :markdown
         #{t('pages.privacy_policy.intro.p2')}
@@ -28,7 +26,7 @@
 
         #{t('pages.privacy_policy.information.what_we_collect.p1')}
 
-      %table
+      %table.table.table-secondary
         %thead
           %tr
             %th= t('pages.privacy_policy.information.what_we_collect.table.headers.h1')
@@ -83,6 +81,7 @@
               %ul
                 %li= t('pages.privacy_policy.information.what_we_collect.table.r6.c4.l1')
                 %li= t('pages.privacy_policy.information.what_we_collect.table.r6.c4.l2')
+      %br
 
       :markdown
         #### #{t('pages.privacy_policy.information.how_we_share.title')}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -387,29 +387,38 @@ de:
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,7 +139,7 @@ en:
       student_intro_3_html: 'Please make sure you <b>bring your laptop</b> with you.'
       shared_intro_4_html: 'PS: There will also be food at the workshop. We always make an effort to have vegetarian, vegan and gluten-free options available. If you have any other dietary requirements, send us an email at %{email_link}.'
   workshop_invitation:
-    coach_skills_tooltip: 'Keeping your skills up-to-date enables Organisers to plan ahead and makes running workshops easier.'
+    coach_skills_tooltip: Keeping your skills up-to-date enables organisers to plan ahead and makes running workshops easier.
   meeting:
     title: "%{name} - %{date}"
   messages:
@@ -503,29 +503,38 @@ en:
 
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -388,29 +388,38 @@ en-AU:
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -388,29 +388,38 @@ en-GB:
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -386,29 +386,38 @@ en-US:
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -154,8 +154,7 @@ es:
     title: "Eventos"
     past: "Pasados"
     no_upcoming_events: "No hay eventos próximos."
-    view_past_events: "Ver eventos pasados
-"
+    view_past_events: "Ver eventos pasados"
     view_all: "Ver todos"
     hosted_by: "Alojado por"
     organisers: "Organizadores"
@@ -388,29 +387,38 @@ es:
         title: Editar listado de trabajos
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: Después de 2 años
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: Después de 24 horas
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -388,29 +388,38 @@ fi:
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -387,29 +387,38 @@ fr:
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -388,29 +388,38 @@
         title: Edit job listing
   pages:
     cookies:
-      title: Cookies
+      title: Cookie Policy
       p1: 'Cookies are small pieces of text used to store information on web browsers. They are used by websites accross a number of different devices to store and receive identifiers and other information. Our Website and Service use cookies and other similar technologies (collectively in this Policy, "cookies"), in order to provide a better service to you and to generally improve our Website and Service. For example, we may use cookies to help direct you to the appropriate part of our Website, by indicating that you are a repeat visitor. We also may use information to present you with services that are matched to your preferences and to manage and track the effectiveness of our marketing efforts.'
       p2: Some portions of the codebar website are functional without cookies, and you may generally choose whether to accept cookies. Most web browsers are set to accept cookies by default, however, you may be able to delete cookies yourself through your browser's cookie manager. To do so, please follow the instructions provided by your web browser. Please note that disabling cookies will reset your session, disable auto-login, and may adversely affect the availability and functionality of our Website and the services we can provide to you.
       sub:
-        title: Below the cookies used by the codebar website.
+        title: Below are the cookies used by the codebar website.
+      table:
+        header:
+          h1: Name
+          h2: Purpose
+          h3: Expires
       functional:
         title: Functional Cookies
         description: Stores information about your session.
-        planner: Stores session data
+        planner_name: _planner_session
+        planner_purpose: Stores session data
         planner_expiry: Expires after 24 hours
       google_analytics:
         title: Google Analytics
-        description: Google Analytics  collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
+        description: Google Analytics collects information about how you use the codebar website. This enables us to identify how busy the website is and possible improvements.
         info: We don’t allow Google to use or share our analytics data.
         opt_out: You can [opt out of Google Analytics](https://tools.google.com/dlpage/gaoptout).
-        ga: Tracks if you have visited codebar.io before
+        ga_name: _ga
+        ga_purpose: Tracks if you have visited codebar.io before
         ga_expiry: After 2 years
-        gid: Tracks if you have visited codebar.io before
+        gid_name: _ga
+        gid_purpose: Tracks if you have visited codebar.io before
         gid_expiry: After 24 hours
       cloudflare:
         title: Cloudflare
-        cfduid: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
-        cfduid_expiry: '1 year'
+        cfduid_name: _pfduid
+        cfduid_purpose: Used to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
+        cfduid_expiry: 1 year
     privacy_policy:
       title: Privacy Policy
       subtitle: This Privacy Policy was last updated on 13 May 2021.


### PR DESCRIPTION
### Description
This PR migrates the Cookie policy and Privacy Policy pages to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github ticket
Fixes #1584
Fixes #1587 

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-08-09 at 18-50-48 codebar](https://user-images.githubusercontent.com/5873816/128796277-12e043e6-cad0-47c9-8a66-db4d6a88728a.png) | ![Screenshot 2021-08-09 at 18-47-03 codebar](https://user-images.githubusercontent.com/5873816/128796149-0adce3bf-110e-4e3a-b312-479de7f40704.png)
![Screenshot 2021-08-03 at 16-42-29 codebar](https://user-images.githubusercontent.com/5873816/129838325-720c1b01-a73e-4d71-a012-405b1a8e26bd.png) | ![Screenshot 2021-08-17 at 20-36-59 codebar](https://user-images.githubusercontent.com/5873816/129838345-d91a4414-d8a9-4918-980b-7bda3936ebdb.png)