### PR TITLE
Convert virtual workshop page to Bootstrap 5 classes

### DIFF
--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -2,40 +2,33 @@
 
 = render partial: 'virtual_workshops/meta_tags', locals: { workshop: @workshop }
 
-.stripe-reverse
+.container-fluid.stripe.reverse
   .row
-    .large-12.columns
+    .col
       %h2
         = t('workshops.virtual.title', chapter: @workshop.chapter.name)
         %br
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
-        %label.label.warning= t('messages.already_taken_place')
+        %span.badge.bg-danger= t('messages.already_taken_place')
 
-  %section#banner
-    .row
-      .medium-12.columns
-        %p.lead
-          = t("workshops.virtual.lead")
-        %p.lead
-          = t("workshops.virtual.intro", chapter_email: @workshop.chapter.email)
-        %p.lead.description
+  .row.mt-3#banner
+    .col.col-md-9
+      %p.lead
+        = t('workshops.virtual.lead')
+      %p.lead
+        = t('workshops.virtual.intro', chapter_email: @workshop.chapter.email)
+      - unless @workshop.description.blank?
+        %p.description
           = sanitize(@workshop.description)
-
-        = render 'workshops/actions' unless current_user&.banned?
+      = render 'workshops/actions' unless current_user&.banned?
 
 - if @workshop.sponsors.any?
-  .stripe.reverse
+  .container-fluid.stripe.reverse#sponsors
     .row
-      #sponsors
-        .small-12.column
-          %h3= t('events.sponsors')
-          %ul.row.no-bullet
-            - @workshop.sponsors.each do |sponsor|
-              %li.small-4.columns
-                = image_tag(sponsor.avatar.url, class: 'sponsor', alt: sponsor.name)
-                %p
-                  = link_to sponsor.name, sponsor.website
+      .col
+        %h3.text-center Sponsors
+    = render partial: 'shared/sponsors', object: @workshop.sponsors
 
-.stripe.reverse
+.container-fluid.stripe.reverse
   = render partial: 'members/organisers_grid', locals: { members: @workshop.organisers, show_info: false }

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -11,19 +11,20 @@
         %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)} #{@workshop.distance_of_time}
       - if @workshop.date_and_time.past?
         %span.badge.bg-danger= t('messages.already_taken_place')
-  .row.mt-3
-    .col
-      %p.lead
-        = t("workshops.lead")
-      %p
-        = sanitize(@workshop.description)
 
+  .row.mt-3
+    .col.col-md-9
+      %p.lead
+        = t('workshops.lead')
+      - unless @workshop.description.blank?
+        %p
+          = sanitize(@workshop.description)
       = render 'actions' unless current_user&.banned?
 
 .container-fluid.stripe.reverse
   = render partial: 'shared/venue', locals: { venue: @workshop.host, address: @workshop.address}
 
-#sponsors.container-fluid.stripe.reverse
+.container-fluid.stripe.reverse#sponsors
   .row
     .col
       %h3.text-center Sponsors

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Viewing a workshop page', type: :feature do
             expect(page).to have_content('Participate in our workshops')
             expect(page).to have_content('Our virtual workshops take place online')
 
-            within '.lead.description' do
+            within '.description' do
               expect(page).to have_content(workshop.description)
             end
           end


### PR DESCRIPTION
### Description
This PR migrates the virtual workshop page to Bootstrap 5.

### Status
Ready for Review

### Related Github issue
Fixes #1589

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-08-19 at 16-07-42 codebar](https://user-images.githubusercontent.com/5873816/130155478-a51c76b6-8432-4df8-a593-31675e32ff81.png) | ![Screenshot 2021-08-19 at 16-07-01 codebar](https://user-images.githubusercontent.com/5873816/130155721-e93d6e67-4896-4372-8a88-6fb50e0841ba.png)