### PR TITLE
Update member/new page header and layout to follow convention of other text only pages

### DIFF
--- a/app/views/members/new.html.haml
+++ b/app/views/members/new.html.haml
@@ -1,10 +1,11 @@
-.container.pt-5.pb-5
-  .row
-    .cols
-      %h2=@page_title
 .container-fluid.stripe.reverse
-  .row
-    .col
+  .row.justify-content-md-center
+    .col.col-md-8
+      %h1= @page_title
+
+.container-fluid.stripe.reverse
+  .row.justify-content-md-center
+    .col.col-md-8
       %p.lead
         = t('members.new.intro')
         = link_to t('members.code_of_conduct'), code_of_conduct_path
@@ -16,9 +17,9 @@
       %p.lead
         = t('members.new.students.github')
       .d-flex.flex-column.align-items-start
-        = link_to registration_path(member_type: "student"), class: "btn-lg btn-primary mb-4" do
+        = link_to registration_path(member_type: 'student'), class: 'btn-lg btn-primary mb-4' do
           = t('members.sign_up_as_student')
           %i.fa.fa-github.fa-fw
-        = link_to registration_path(member_type: "coach"), class: "btn-lg btn-primary" do
+        = link_to registration_path(member_type: 'coach'), class: 'btn-lg btn-primary' do
           = t('members.sign_up_as_coach')
           %i.fa.fa-github.fa-fw


### PR DESCRIPTION
### Description
This is a quick PR that updates the member/new pages to bring it in line with other text heavy pages (like the CoC, Cookie Policy and Privacy Policy pages).

### Status
Ready for Review

### Related Github issue
Fixes #1598 

### Screenshots
member/new page before | member/new page after
------------ | -------------
![Screenshot 2021-08-26 at 15-16-51 codebar](https://user-images.githubusercontent.com/5873816/131043288-80775680-0af6-431f-8e57-3f426c6f8fd0.png) | ![Screenshot 2021-08-26 at 15-16-08 codebar](https://user-images.githubusercontent.com/5873816/131043237-56d54146-a6ac-4bd2-b5db-66ee2e7d7960.png)