### PR TITLE
Migrate Terms and conditions page to Bootstrap 5 classes

### DIFF
--- a/app/views/terms_and_conditions/show.html.haml
+++ b/app/views/terms_and_conditions/show.html.haml
@@ -1,17 +1,17 @@
-%section#banner
-  .row
-    .medium-12.columns
+.container-fluid.stripe.reverse
+  .row.justify-content-md-center
+    .col.col-md-8
       %h1= t('terms_and_conditions.title')
       %p
         = t('terms_and_conditions.body')
         %br
-          = link_to t('terms_and_conditions.link_text'), code_of_conduct_path, target: '_blank'
+        = link_to t('terms_and_conditions.link_text'), code_of_conduct_path, target: '_blank'
 
   = simple_form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|
-    .row
-      .large-12.columns
+    .row.justify-content-md-center
+      .col.col-md-8
         = f.check_box :terms
         = f.label :terms
-    .row
-      .large-12.columns
-        = f.submit t('terms_and_conditions.accept'), class: 'button round right'
+    .row.justify-content-md-center
+      .col.col-md-8
+        = f.button :button, t('terms_and_conditions.accept'), class: 'btn btn-primary'


### PR DESCRIPTION
### Description
This PR migrates the terms and conditions page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1597 

### Screenshots
T&C's page before | T&C's page after
------------ | -------------
<img width="1295" alt="Screenshot 2021-08-31 at 7 04 49 pm" src="https://user-images.githubusercontent.com/5873816/131601749-6470b463-8129-47be-ba6f-8a49f9529f87.png"> | <img width="1299" alt="Screenshot 2021-08-31 at 7 02 04 pm" src="https://user-images.githubusercontent.com/5873816/131601773-4f4b1373-71db-4fee-8704-bfa746817bb2.png">