### PR TITLE
Migrate /jobs page to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/partials/_jobs.scss
+++ b/app/assets/stylesheets/partials/_jobs.scss
@@ -1,34 +1,3 @@
-ul.jobs {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-
-
-  li.job {
-    border-bottom: 1px solid #dee0e2;
-    padding: 10px 0 5px;
-    margin: 5px 0;
-
-    dl {
-      font-size: '0.9em';
-
-      dt {
-        color: #6f777b;
-        display: inline-block;
-        width: 24%;
-      }
-      dd {
-        display: inline-block;
-        width: 24%;
-        margin-bottom: 0;
-      }
-      dd.double {
-        width: 60%;
-      }
-    }
-  }
-}
-
 .job {
   .stripe:not(.reverse):first-child {
     padding: 40px 0px 20px;

--- a/app/views/jobs/_job.html.haml
+++ b/app/views/jobs/_job.html.haml
@@ -1,13 +1,14 @@
-%li.job
-  %h3.mb0= link_to job.title, job_path(job)
-  %p.lead.mb0="#{job.company}, #{job.location}"
-  %dl
-    - if job.salary.present?
-      %dt= t('job.salary')
-      %dd.double= number_to_currency(job.salary)
-    %dt= t('job.published_on')
-    %dd= job.published_on
-    %dt= t('job.expires_on')
-    %dd= l(job.expiry_date, format: :full_date)
-    %dt= t('job.location.title')
-    %dd= job.location_or_remote
+%li.card.mb-4.shadow-sm
+  .card-body
+    %h3.h5.mb-2= link_to job.title, job_path(job)
+    %p.mb-3="#{job.company}, #{job.location}"
+    %dl.row
+      - if job.salary.present?
+        %dt.col-4.text-muted= t('job.salary')
+        %dd.col-8.mb-2= number_to_currency(job.salary)
+      %dt.col-4.text-muted= t('job.published_on')
+      %dd.col-8.mb-2= job.published_on
+      %dt.col-4.text-muted= t('job.expires_on')
+      %dd.col-8.mb-2= l(job.expiry_date, format: :full_date)
+      %dt.col-4.text-muted.mb-0= t('job.location.title')
+      %dd.col-8.mb-0= job.location_or_remote

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -1,18 +1,19 @@
 - title t('jobs.title')
-.stripe.reverse
+
+.container-fluid.stripe.reverse
   .row
-    .large-12.columns
-      %h1=t('jobs.title')
+    .col
+      %h1= t('jobs.title')
       %p.lead
         - if @jobs.any?
-          =t('jobs.index.description', count: @jobs.count)
+          = t('jobs.index.description', count: @jobs.count)
         - else
-          =t('jobs.index.none')
+          = t('jobs.index.none')
         %br
         %small #{link_to('Click here', new_member_job_path)} if you would like to post a new job.
   - if @jobs.any?
     .row
-      .large-12.columns
-        %ul.jobs
+      .col.col-md-8.col-lg-6
+        %ul.jobs.list-unstyled.ml-0.mb-0
           - @jobs.each do |job|
             = render partial: 'job', locals: { job: job }


### PR DESCRIPTION
### Description
This PR migrates the /jobs page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1622 

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-22 at 18-14-19 codebar](https://user-images.githubusercontent.com/5873816/134441710-34049eac-5992-482c-8a89-ad882a391840.png) | ![Screenshot 2021-09-22 at 18-12-03 codebar](https://user-images.githubusercontent.com/5873816/134441623-98c0a950-6185-4ccb-8cae-b60543f2bf4a.png)