### PR TITLE
Migrate the job post page to Bootstrap 5 classes

### DIFF
--- a/app/views/jobs/_show.html.haml
+++ b/app/views/jobs/_show.html.haml
@@ -1,52 +1,53 @@
-.stripe.reverse
+.container-fluid.stripe.reverse
   - if @job.expired?
     .row
-      .large-12.columns
-        .panel
-          =t('job.expired')
-          =t('job.check_out_jobs_html', link: link_to('jobs', jobs_url))
-  .row
-    .medium-12.columns
-      %h2
-        #{@job.title}
-    .medium-9.columns
+      .col-12
+        .alert.alert-primary
+          = t('job.expired')
+          = t('job.check_out_jobs_html', link: link_to('jobs', jobs_url, class: 'alert-link'))
+  .row.justify-content-between
+    .col-12
+      %h1= @job.title
+    .col-12.col-md-9.col-lg-8
       = dot_markdown(@job.description)
-      %br
       %h4 Company
-      = @job.company
-      -if @job.company_website.present?
-        %br
-        =link_to(@job.company_website, @job.company_website)
+      %p
+        = @job.company
+        - if @job.company_website.present?
+          %br
+          = link_to(@job.company_website, @job.company_website)
 
-
-    .medium-3.columns
-      -if @job.salary.present?
-        %p.salary
-          %strong=t('job.salary')
-          %br
-          =number_to_currency(@job.salary)
-      %p.location
-        %strong=t('job.location.title')
-        %br
-        = @job.location_or_remote
-      %p.closing-date
-        %strong=t('job.closing_date')
-        %br
-        #{I18n.l(@job.expiry_date, format: :date)}
-        - if @job.expired?
-          %br
-          %span.label.warning=t('job.status.expired')
-      -if @job.email?
-        %p.email
-          %strong=t('job.contact_email')
-          %br
-          =mail_to(@job.email, @job.email, subject:"#{@job.title} job enquiry")
-      %p.posted-by
-        %strong=t('job.posted_by')
-        %br
-          =link_to @job.created_by.full_name, twitter_url_for(@job.created_by.twitter)
-      %p.published_on
-        %strong=t('job.published_on')
-        %br
-        = @job.published_on
-      =link_to t('job.apply'), @job.link_to_job, class: 'button small expand'
+    .col-12.col-md-3
+      .card
+        .card-body
+          - if @job.salary.present?
+            %p.salary
+              %strong= t('job.salary')
+              %br
+              = number_to_currency(@job.salary)
+          %p.location
+            %strong= t('job.location.title')
+            %br
+            = @job.location_or_remote
+          %p.closing-date
+            %strong= t('job.closing_date')
+            %br
+            #{I18n.l(@job.expiry_date, format: :date)}
+            - if @job.expired?
+              %br
+              %span.label.warning=t('job.status.expired')
+          -if @job.email?
+            %p.email
+              %strong= t('job.contact_email')
+              %br
+              = mail_to(@job.email, @job.email, subject:"#{@job.title} job enquiry")
+          %p.posted-by
+            %strong= t('job.posted_by')
+            %br
+              =link_to @job.created_by.full_name, twitter_url_for(@job.created_by.twitter)
+          %p.published_on
+            %strong= t('job.published_on')
+            %br
+            = @job.published_on
+        .card-footer
+          = link_to t('job.apply'), @job.link_to_job, class: 'btn btn-primary w-100', role: 'button'

--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -1,5 +1,6 @@
 - title "#{@job.title} | #{t('jobs.title')}"
 
-=render partial: 'jobs/show', locals: { admin: false }
+= render partial: 'jobs/show', locals: { admin: false }
+
 %script.jobref{type: 'application/ld+json'}
   = raw(render partial: 'job.json.jbuilder', locals: { job: @job })


### PR DESCRIPTION
### Description
This PR migrates the job post page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1623 

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-23 at 17-38-56 codebar](https://user-images.githubusercontent.com/5873816/134601344-e365a0ea-20c8-4b7f-980e-a5911ec6609c.png) | ![Screenshot 2021-09-23 at 17-38-16 codebar](https://user-images.githubusercontent.com/5873816/134601303-257e3b3b-f5fb-4811-950b-c7f4abf41a5b.png)