### PR TITLE
Migrate member jobs page [/my/jobs] to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -28,7 +28,7 @@
 @import "bootstrap/nav";
 @import "bootstrap/navbar";
 @import "bootstrap/card";
-// @import "bootstrap/breadcrumb";
+@import "bootstrap/breadcrumb";
 // @import "bootstrap/pagination";
 @import "bootstrap/badge";
 @import "bootstrap/alert";

--- a/app/views/member/jobs/_job.html.haml
+++ b/app/views/member/jobs/_job.html.haml
@@ -3,26 +3,26 @@
     = link_to job.title, member_job_path(job.id)
   %td
     -if job.company_website.present?
-      =link_to(job.company, job.company_website)
+      = link_to(job.company, job.company_website)
     - else
       = job.company
   %td
     - if job.remote
-      =t('job.location.remote')
+      = t('job.location.remote')
     - else
-      =job.location
+      = job.location
   %td
     - if job.published_on.present?
       %dd= l(job.published_on, format: :date)
     - else
-      %dd= "-"
+      %dd= '-'
   %td
     = l(job.expiry_date, format: :date)
   %td
     - if job.expired?
-      %span.label.status= t('job.status.expired')
+      %span.badge.bg-warning= t('job.status.expired')
     - else
-      %span.label.status= t("job.status.#{job.status.to_s}")
+      %span.badge.bg-secondary= t("job.status.#{job.status.to_s}")
   %td
-    -if job.status.eql?(:pending) || job.status.eql?(:draft)
-      =link_to 'Edit', edit_member_job_path(job.id)
+    - if job.status.eql?(:pending) || job.status.eql?(:draft)
+      = link_to 'Edit', edit_member_job_path(job.id)

--- a/app/views/member/jobs/index.html.haml
+++ b/app/views/member/jobs/index.html.haml
@@ -1,57 +1,59 @@
 .job
-  .row
-    .small-12.columns
-      %br
-      %ul.breadcrumbs
-        %li.current=link_to t('member.jobs.title'), "#"
+  .row.pt-4
+    .col
+      %nav{'aria-label': 'breadcrumb'}
+        %ol.breadcrumb.ml-0
+          %li.breadcrumb-item.active= link_to t('member.jobs.title'), '#'
 
   - if @jobs.any?
-    .row
-      %table.large-12.columns
-        %thead
-          %tr
-            %th Job title
-            %th Company
-            %th Location
-            %th Published on
-            %th Expires on
-            %th Status
-            %th
-        %tbody
-          - @jobs.each do |job|
-            = render partial: 'member/jobs/job', locals: { job: job }
-    .row
-      .medium-6.columns.text-left
-        = page_entries_info(@jobs, model: 'job')
-      .medium-6.columns.text-right
-        = will_paginate(@jobs)
+    .stripe.reverse
+      .row
+        %table.table.table-striped
+          %thead
+            %tr
+              %th Job title
+              %th Company
+              %th Location
+              %th Published on
+              %th Expires on
+              %th Status
+              %th
+          %tbody
+            - @jobs.each do |job|
+              = render partial: 'member/jobs/job', locals: { job: job }
 
-    .row.mt2
-      .small-12.columns
-        =link_to('Post a job', new_member_job_path, class: 'button medium')
+      .row.mb-4
+        .col-12.col-md-6.text-left
+          = page_entries_info(@jobs, model: 'job')
+        .col-12.col-md-6.text-right
+          = will_paginate(@jobs)
 
+      .row
+        .col.text-right
+          = link_to('Post a job', new_member_job_path, class: 'btn btn-primary')
   - else
     .stripe.reverse
-      .row
-        .small-12.large-10.columns
-          %h1= t('member.jobs.index.title', students_count: @students_count)
+      .row.justify-content-center
+        .col.col-md-10.col-lg-8
+          %h1.h2= t('member.jobs.index.title', students_count: @students_count)
           %p= t('member.jobs.index.description')
-          .panel
-            %p
-              = raw t('member.jobs.index.offer.title')
-              %br
-              %span= t('member.jobs.index.offer.job_board')
-              %br
-              %span= t('member.jobs.index.offer.slack')
-              %br
-              %span= t('member.jobs.index.offer.twitter')
-          =link_to('Post a job', new_member_job_path, class: 'button medium')
-    
+          .card.mb-4.border-primary
+            .card-body
+              %p.mb-0
+                = raw t('member.jobs.index.offer.title')
+                %br
+                %span= t('member.jobs.index.offer.job_board')
+                %br
+                %span= t('member.jobs.index.offer.slack')
+                %br
+                %span= t('member.jobs.index.offer.twitter')
+          = link_to('Post a job', new_member_job_path, class: 'btn btn-primary')
+
     .stripe.reverse
-      .row
-        .small-12.large-8.large-offset-2.columns
+      .row.justify-content-center
+        .col.col-md-10.col-lg-8
           %blockquote
             %p= t('member.jobs.index.testimonial')
             %footer.clearfix
-              = image_tag('ok.png', size: "30", class: 'th radius left', alt: 'Bruno Girin')
+              = image_tag('ok.png', size: '30', class: 'th radius left', alt: 'Bruno Girin')
               %cite.left Bruno Girin, CTO, Imby


### PR DESCRIPTION
### Description
This PR migrates the member jobs page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1626

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-24 at 08-52-15 codebar](https://user-images.githubusercontent.com/5873816/134704657-d9a2d62a-d78a-44ee-ab97-27bba785b8fe.png) | ![Screenshot 2021-09-24 at 08-50-46 codebar](https://user-images.githubusercontent.com/5873816/134704681-f581d521-5c12-4534-aabb-cf60af54a855.png)
------------ | -------------
![Screenshot 2021-09-24 at 08-56-58 codebar](https://user-images.githubusercontent.com/5873816/134705358-eec26b88-164b-4cc0-bdab-8bdbf0b56363.png) | ![Screenshot 2021-09-24 at 08-57-26 codebar](https://user-images.githubusercontent.com/5873816/134705392-707117a0-d17e-429b-b36c-5d8f6f1407ce.png)