### PR TITLE
Migrate member new job page to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -20,7 +20,7 @@
 @import "bootstrap/containers";
 @import "bootstrap/grid";
 @import "bootstrap/tables";
-// @import "bootstrap/forms";
+@import "bootstrap/forms";
 @import "bootstrap/buttons";
 @import "bootstrap/transitions";
 @import "bootstrap/dropdown";

--- a/app/views/member/jobs/_form.html.haml
+++ b/app/views/member/jobs/_form.html.haml
@@ -1,51 +1,32 @@
-#new_job
-  %h4 Job post details
-  .row
-    .small-12.columns
-      = f.input :title, required: true
-  .row
-    .small-12.columns
-      = f.input :description, input_html: { rows: 10 }, required: true
-  .row
-    .small-12.columns
-      = f.input :salary, required: true
-  .row
-    .small-12.columns
-      = f.input :remote, wrapper: :checkbox
-      %br
-  .row
-    .small-12.columns
-      = f.input :email
-  .row
-    .small-12.columns
-      = f.input :link_to_job, required: true
-  .row
-    .small-12.columns
-      = f.input :expiry_date, as: :string, required: true, input_html: { data: { value: @job.expiry_date.try(:strftime, '%d/%m/%Y') } }
+%fieldset.mt-0
+  %legend.mb-3 Job post details
+  .mb-3
+    = f.input :title, required: true
+  .mb-3
+    = f.input :description, input_html: { rows: 10 }, required: true
+  .mb-3
+    = f.input :salary, required: true
+  .mb-3
+    = f.input :remote, wrapper: :checkbox
+  .mb-3
+    = f.input :email
+  .mb-3
+    = f.input :link_to_job, required: true
+  = f.input :expiry_date, as: :string, required: true, input_html: { data: { value: @job.expiry_date.try(:strftime, '%d/%m/%Y') } }
 
-  %hr
-  %h4 Company details
-  .row
-    .small-12.columns
-      = f.input :company, required: true
-  .row
-    .small-12.columns
-      = f.input :company_website, required: true
-  .row
-    .small-12.columns
-      = f.input :location, required: true
+%fieldset
+  %legend.mb-3 Company details
+  .mb-3
+    = f.input :company, required: true
+  .mb-3
+    = f.input :company_website, required: true
+  = f.input :location, required: true
 
-  .row
-    .small-12.columns
-      %small
-        = t('member.jobs.new.optional_details_message')
+%fieldset
+  %p
+    %small= t('member.jobs.new.optional_details_message')
+  .mb-3
+    = f.input :company_address
+  = f.input :company_postcode
 
-  .row
-    .small-12.columns
-      = f.input :company_address
-  .row
-    .small-12.columns
-      = f.input :company_postcode
-  .row
-    .small-12.columns
-      = f.submit "Submit job for approval", class: "button"
+= f.button :button, 'Submit job for approval', class: "btn btn-primary"

--- a/app/views/member/jobs/new.html.haml
+++ b/app/views/member/jobs/new.html.haml
@@ -1,55 +1,42 @@
 .job
-  .stripe
-    .row
-      .large-12.columns
-        %ul.breadcrumbs
-          %li
-            %span=link_to t('member.jobs.title'), member_jobs_path
-          %li.current
-            %span=t('member.jobs.new.title')
+  .row.pt-4
+    .col
+      %nav{'aria-label': 'breadcrumb'}
+        %ol.breadcrumb.ml-0
+          %li.breadcrumb-item=link_to t('member.jobs.title'), member_jobs_path
+          %li.breadcrumb-item.active=t('member.jobs.new.title')
 
+  .stripe.reverse
     .row
-      .small-12.large-5.large-push-7.columns
-        .panel
-          %p=t('member.jobs.new.rules_intro')
-          %ul.no-bullet
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#roles{type: 'checkbox'}
-              .small-11.columns.mb1
-                %label{for: 'roles'}= t('member.jobs.new.suitability')
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#degree{type: 'checkbox'}
-              .small-11.columns.mb1
-                %label{for: 'degree'}= t('member.jobs.new.degree')
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#experience{type: 'checkbox'}
-              .small-11.columns.mb1
-                %label{for: 'experience'}= t('member.jobs.new.experience')
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#work-details{type: 'checkbox'}
-              .small-11.columns.mb1
-                %label{for: 'work-details'}= t('member.jobs.new.details')
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#short{type: 'checkbox'}
-              .small-11.columns.mb1
-                %label{for: 'short'}= t('member.jobs.new.short')
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#pay{type: 'checkbox'}
-              .small-11.columns.mb1
-                %label{for: 'pay'}= t('member.jobs.new.salary')
-            %li.row.collapse
-              .small-1.columns.text-center
-                %input#payment{type: 'checkbox'}
-              .small-11.columns
-                %label{for: 'payment'}= t('member.jobs.new.pay.html', link: new_payment_path)
-        %p= raw t('member.jobs.new.newsletter')
+      .col-12.col-lg-5.order-lg-2
+        .card
+          .card-header
+            %h6.mb-0=t('member.jobs.new.rules_intro')
+          .card-body
+            %ul.list-unstyled.ml-0
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#roles{type: 'checkbox'}
+                %label.form-check-label{for: 'roles'}= t('member.jobs.new.suitability')
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#degree{type: 'checkbox'}
+                %label.form-check-label{for: 'degree'}= t('member.jobs.new.degree')
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#experience{type: 'checkbox'}
+                %label.form-check-label{for: 'experience'}= t('member.jobs.new.experience')
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#work-details{type: 'checkbox'}
+                %label.form-check-label{for: 'work-details'}= t('member.jobs.new.details')
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#short{type: 'checkbox'}
+                %label.form-check-label{for: 'short'}= t('member.jobs.new.short')
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#pay{type: 'checkbox'}
+                %label.form-check-label{for: 'pay'}= t('member.jobs.new.salary')
+              %li.form-check.mb-3
+                %input.form-check-input.mt-1#payment{type: 'checkbox'}
+                %label.form-check-label{for: 'payment'}= t('member.jobs.new.pay.html', link: new_payment_path)
+            %p.mb-0= raw t('member.jobs.new.newsletter')
         %br
-      .small-12.large-7.large-pull-5.columns
+      .col-12.col-lg-7.order-lg-1
         = simple_form_for @job, url: member_jobs_path, method: :post do |f|
           = render partial: 'form', locals: { f: f }


### PR DESCRIPTION
### Description
This PR migrates the member new job page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1629 

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-26 at 20-33-50 codebar](https://user-images.githubusercontent.com/5873816/134841758-1b52b4e4-33db-45cc-9b56-0c78e3203bb5.png) | ![Screenshot 2021-09-26 at 20-31-57 codebar](https://user-images.githubusercontent.com/5873816/134841621-b08fc997-d856-4b00-835d-18cf7879bd5f.png)