### PR TITLE
Migrate member edit job page to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -150,3 +150,7 @@ form .hint {
 .announcement p:last-child {
   margin-bottom: 0;
 }
+
+.picker {
+  width: 320px !important;
+}

--- a/app/views/member/jobs/edit.html.haml
+++ b/app/views/member/jobs/edit.html.haml
@@ -1,15 +1,14 @@
 .job
-  .stripe
-    .row
-      .large-12.columns
-        %br
-        %ul.breadcrumbs
-          %li=link_to  t('member.jobs.title'), member_jobs_path
-          %li=link_to @job.title, member_job_path(@job.id)
-          %li.current
-            %span Edit
+  .row.pt-4
+    .col
+      %nav{'aria-label': 'breadcrumb'}
+        %ol.breadcrumb.ml-0
+          %li.breadcrumb-item= link_to t('member.jobs.title'), member_jobs_path
+          %li.breadcrumb-item= link_to @job.title, member_job_path(@job.id)
+          %li.breadcrumb-item.active Edit
 
+  .stripe.reverse
     .row
-      .large-12.columns
+      .col
         = simple_form_for @job, url: member_job_path, method: :put do |f|
           = render partial: 'form', locals: { f: f }


### PR DESCRIPTION
### Description
This PR migrates the member edit job page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1631

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-27 at 11-46-09 codebar](https://user-images.githubusercontent.com/5873816/134967152-af503f07-647c-4645-bf94-0e32d900be44.png) | ![Screenshot 2021-09-27 at 12-08-46 codebar](https://user-images.githubusercontent.com/5873816/134969902-c8dcd576-8b9a-4d6b-baa8-6f589042853b.png)