### PR TITLE
Migrate member job page to Bootstrap 5 classes

### DIFF
--- a/app/views/admin/jobs/show.html.haml
+++ b/app/views/admin/jobs/show.html.haml
@@ -60,4 +60,4 @@
         %h2 Preview
         %hr
 
-  =render partial: 'jobs/show', locals: { admin: true }
+  = render partial: 'jobs/show', locals: { admin: true, preview: false }

--- a/app/views/jobs/_show.html.haml
+++ b/app/views/jobs/_show.html.haml
@@ -7,7 +7,10 @@
           = t('job.check_out_jobs_html', link: link_to('jobs', jobs_url, class: 'alert-link'))
   .row.justify-content-between
     .col-12
-      %h1= @job.title
+      - if preview
+        %h2= @job.title
+      - else
+        %h1= @job.title
     .col-12.col-md-9.col-lg-8
       = dot_markdown(@job.description)
       %h4 Company

--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -1,6 +1,6 @@
 - title "#{@job.title} | #{t('jobs.title')}"
 
-= render partial: 'jobs/show', locals: { admin: false }
+= render partial: 'jobs/show', locals: { admin: false, preview: true }
 
 %script.jobref{type: 'application/ld+json'}
   = raw(render partial: 'job.json.jbuilder', locals: { job: @job })

--- a/app/views/member/jobs/show.html.haml
+++ b/app/views/member/jobs/show.html.haml
@@ -1,32 +1,28 @@
-.job.mb4
-  .stripe
-    .row
-      .large-12.columns
+.job
+  .row.pt-4.mb-4
+    .col
+      %nav{'aria-label': 'breadcrumb'}
+        %ol.breadcrumb.ml-0
+          %li.breadcrumb-item= link_to t('member.jobs.title'), member_jobs_path
+          %li.breadcrumb-item.active= @job.title
+
+  .row.mb-5
+    .col-12
+      .alert.alert-info
+        = t("job.messages.#{@job.status}_html")
+        - if @job.published?
+          = t('job.messages.public_page_html', link: link_to('public page', job_path(@job)))
+    .col-12
+      - if @job.draft? || @job.pending?
+        = link_to 'Edit', edit_member_job_path(@job.id), class: 'btn btn-primary', role: 'button'
+      - if @job.pending?
+        = link_to 'Submit', '#', class: 'btn btn-primary disabled', role: 'button'
+      - else
+        = link_to 'Submit', member_job_submit_path(@job.id), class: 'btn btn-primary', method: :post, role: 'button'
+        = link_to t('member.jobs.new.button.pay'), new_payment_path, class: 'btn btn-info', role: 'button'
         %br
-        %ul.breadcrumbs
-          %li= link_to t('member.jobs.title'), member_jobs_path
-          %li.current
-            %span= @job.title
-    .row
-      .large-12.columns
-        .panel
-          = t("job.messages.#{@job.status}_html")
+        %small= t('member.jobs.new.approval_info')
+  .row
+    %h1 Preview
 
-          - if @job.published?
-            =t('job.messages.public_page_html', link: link_to('public page', job_path(@job)))
-    .row
-      .large-12.columns
-        - if @job.draft? || @job.pending?
-          = link_to "Edit", edit_member_job_path(@job.id), class: 'button round'
-        - if @job.pending?
-          = link_to "Submit", '#', class: 'button disabled round default'
-        - else
-          = link_to "Submit", member_job_submit_path(@job.id), class: 'button round default', method: :post
-          =link_to t('member.jobs.new.button.pay'), new_payment_path, class: 'button info'
-          %br
-          %small= t('member.jobs.new.approval_info')
-
-        %h2 Preview
-        %hr
-
-  = render partial: 'jobs/show', locals: { admin: false }
+  = render partial: 'jobs/show', locals: { admin: false, preview: true }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -328,7 +328,7 @@ de:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -419,7 +419,7 @@ en:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -328,7 +328,7 @@ en-AU:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -328,7 +328,7 @@ en-GB:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -326,7 +326,7 @@ en-US:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -327,7 +327,7 @@ es:
       title: Localización
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -328,7 +328,7 @@ fi:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -326,7 +326,7 @@ fr:
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -328,7 +328,7 @@
       title: Location
       remote: 'Remote'
     messages:
-      draft_html: 'This is a preview of your job.<b>Edit</b> to amend or <b>Submit</b> for approval.'
+      draft_html: 'This is a preview of your job. <b>Edit</b> to amend or <b>Submit</b> for approval.'
       pending_html: 'This job is pending approval. <b>Edit</b> to amend your post.'
       published_html: 'This job has been published.'
       expired_html: 'This job has expired.'

--- a/spec/features/member/jobs_spec.rb
+++ b/spec/features/member/jobs_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'Member managing jobs', type: :feature do
 
       click_on 'Submit job'
 
-      expect(page).to have_content('This is a preview of your job.Edit to amend or Submit for approval')
+      expect(page).to have_content('This is a preview of your job. Edit to amend or Submit for approval')
     end
 
     scenario 'can view text that address and postcode fields are optional' do
@@ -86,7 +86,7 @@ RSpec.feature 'Member managing jobs', type: :feature do
 
       visit member_job_path(job.id)
 
-      expect(page).to have_content('This is a preview of your job.Edit to amend or Submit for approval')
+      expect(page).to have_content('This is a preview of your job. Edit to amend or Submit for approval')
       expect(page).to have_content(job.title)
     end
 
@@ -101,7 +101,7 @@ RSpec.feature 'Member managing jobs', type: :feature do
       job = Fabricate(:job, created_by: member)
       visit member_job_path(job.id)
 
-      expect(page).to have_content('This is a preview of your job.Edit to amend or Submit for approval.')
+      expect(page).to have_content('This is a preview of your job. Edit to amend or Submit for approval.')
 
       click_on 'Submit'
       expect(page).to have_content("Job submitted for approval. You will receive an email when it's been approved.")


### PR DESCRIPTION
### Description
This PR migrates the member job page to Bootstrap 5 classes.

### Status
Ready for Review

### Related Github issue
Fixes #1630 

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-27 at 12-26-48 codebar](https://user-images.githubusercontent.com/5873816/134972181-13717449-bb58-48b2-bf74-e0d7040f608b.png) | ![Screenshot 2021-09-27 at 12-24-10 codebar](https://user-images.githubusercontent.com/5873816/134972088-ecba59a5-7e0c-4c89-80c1-89873166a9c6.png)