### PR TITLE
Migrates attendance policy page to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -186,7 +186,7 @@ $list-style-position: outside;
 // $list-ordered-side-margin: 1.4rem;
 // $list-side-margin-no-bullet: 0;
 // $list-nested-margin: rem-calc(20);
-$definition-list-header-weight: 100;
+// $definition-list-header-weight: 100;
 // $definition-list-header-margin-bottom: .3rem;
 // $definition-list-margin-bottom: rem-calc(12);
 
@@ -1360,7 +1360,7 @@ blockquote::before {
   top: 5px;
 }
 
-blockquote::after{
+blockquote::after {
   content: "";
 }
 
@@ -1368,7 +1368,6 @@ blockquote em {
   font-style: italic;
 }
 
-.top-bar a,
 #sponsors a,
 .icon-bar a {
   border-bottom: none;
@@ -1380,10 +1379,6 @@ blockquote em {
 
 .info {
   color: $info-color;
-}
-
-.top-bar {
-  padding: 0 10px;
 }
 
 .underline {

--- a/app/views/dashboard/attendance_policy.html.haml
+++ b/app/views/dashboard/attendance_policy.html.haml
@@ -1,11 +1,11 @@
-.stripe.reverse#banner
-  .row
-    .large-12.columns
-      %h2 Attendance Policy
+.container-fluid.stripe.reverse
+  .row.justify-content-md-center
+    .col-md-10.col-lg-8
+      %h1 Attendance Policy
 
-.stripe.reverse
-  .row
-    .large-12.columns
+.container-fluid.stripe.reverse
+  .row.justify-content-md-center
+    .col-md-10.col-lg-8
       %p
         = t('dashboard.policy.intro')
         %ul

--- a/app/views/dashboard/code.html.haml
+++ b/app/views/dashboard/code.html.haml
@@ -1,12 +1,11 @@
-.stripe.reverse#code-of-conduct
+.container-fluid.stripe.reverse#code-of-conduct
   .row.justify-content-md-center
-    .col.col-md-8
-      %h2
-        = t('code_of_conduct.title')
+    .col-md-10.col-lg-8
+      %h1= t('code_of_conduct.title')
 
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
+    .col-md-10.col-lg-8
       %h3
         = t('code_of_conduct.summary.title')
 

--- a/app/views/dashboard/effective-teacher-guide.html.haml
+++ b/app/views/dashboard/effective-teacher-guide.html.haml
@@ -1,14 +1,13 @@
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-lg-8
-      %h2
-        Coach Guide
+    .col-md-10.col-lg-8
+      %h1 Coach Guide
       %p.lead
         This is a brief guide we've put together for our coaches. If you have any suggestions to make open a #{link_to "pull request", "https://github.com/codebar/planner"} or #{link_to "create an issue", "https://github.com/codebar/planner/issues/new"}.
 
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-lg-8
+    .col-md-10.col-lg-8
       %ul
         %li
           %p.mb-2= t('dashboard.teacher_guide.laptop')

--- a/app/views/dashboard/faq.html.haml
+++ b/app/views/dashboard/faq.html.haml
@@ -1,10 +1,11 @@
-.stripe.reverse#banner
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col-12.col-md-8
-      %h2 Frequently Asked Questions
-.stripe.reverse
+    .col-md-10.col-lg-8
+      %h1 Frequently Asked Questions
+
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col-12.col-md-8
+    .col-md-10.col-lg-8
       %dl
         %dt= t('faq.payment.q')
         %dd

--- a/app/views/dashboard/participant_guide.html.haml
+++ b/app/views/dashboard/participant_guide.html.haml
@@ -1,16 +1,16 @@
-.stripe.reverse#banner
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
-      %h2= t('participant_student_guide.title')
+    .col-md-10.col-lg-8
+      %h1= t('participant_student_guide.title')
       = link_to t('participant_student_guide.attendance_policy.title') , '#attendance'
       \|
       = link_to t('participant_student_guide.eligibility_criteria.title') , '#eligibility'
       \|
       = link_to t('participant_student_guide.disability.title') , '#disability'
 
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
+    .col-md-10.col-lg-8
       %h3#attendance= t('participant_student_guide.attendance_policy.title')
       %p
         = t('participant_student_guide.attendance_policy.intro')

--- a/app/views/pages/cookie-policy.html.haml
+++ b/app/views/pages/cookie-policy.html.haml
@@ -1,12 +1,12 @@
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
+    .col-md-10.col-lg-8
       :markdown
-        ## #{t('pages.cookies.title')}
+        # #{t('pages.cookies.title')}
 
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
+    .col-md-10.col-lg-8
       :markdown
         #{t('pages.cookies.p1')}
 

--- a/app/views/pages/privacy-policy.html.haml
+++ b/app/views/pages/privacy-policy.html.haml
@@ -1,14 +1,14 @@
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
+    .col-md-10.col-lg-8
       :markdown
-        ## #{t('pages.privacy_policy.title')}
+        # #{t('pages.privacy_policy.title')}
 
       %p.lead= t('pages.privacy_policy.subtitle')
 
-.stripe.reverse
+.container-fluid.stripe.reverse
   .row.justify-content-md-center
-    .col.col-md-8
+    .col-md-10.col-lg-8
       :markdown
         #{t('pages.privacy_policy.intro.p1')}
 


### PR DESCRIPTION
### Description
This PR migrates the attendance policy page to Bootstrap 5 classes. Also updates all static pages to the same page layout.

### Status
Ready for Review

### Related Github issue
Fixes #1628 

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-09-28 at 16-50-07 codebar](https://user-images.githubusercontent.com/5873816/135180541-8b28d270-2b80-4eaa-a7f7-0afecfaf1e15.png) | ![Screenshot 2021-09-28 at 16-49-26 codebar](https://user-images.githubusercontent.com/5873816/135180498-0c7a0ba3-5cdc-4713-b312-40e050931840.png)