### PR TITLE
Update Open Collective link

### DIFF
--- a/app/views/shared/_donation_platforms.html.haml
+++ b/app/views/shared/_donation_platforms.html.haml
@@ -22,7 +22,7 @@
       %div.card-header.bg-white.border-0.pb-0.pt-4
         =image_tag("open-collective-logo.png", style: "max-height: 50px;", alt: "Open Collective logo")
       %div.card-body
-        %h3.h6=link_to(t("donation_platforms.open_collective.title"), "https://opencollective.com/")
+        %h3.h6=link_to(t("donation_platforms.open_collective.title"), "https://opencollective.com/codebar")
         %p= t("donation_platforms.open_collective.text")
   .d-flex.col-sm-12.col-md-6.col-lg-3
     .card.mt-1.border-0


### PR DESCRIPTION
### Description
This PR updates the Open Collective link from the generic https://opencollective.com/ to the more specific https://opencollective.com//codebar.

### Status
Ready for Review

### Related Github issue
Fixes #1625 