### PR TITLE
localised admin.de.yml

### DIFF
--- a/config/locales/admin.de.yml
+++ b/config/locales/admin.de.yml
@@ -2,14 +2,14 @@ de:
   admin:
     bans:
       create:
-        success: 'Member marked as supended and suspension email sent.'
+        success: 'Mitglied wurde gesperrt und per E-mail informiert.'
       new:
-        title: 'Suspension'
-        create: 'Suspend member'
+        title: 'Sperrung'
+        create: 'Mitglied sperren'
     members:
       update_subscriptions:
-        unsubscribe: "Successfully unsubscribed %{member} from %{chapter}'s %{group} group"
+        unsubscribe: "%{member} wurde erfolgreich aus der Liste der %{chapter}er %{group} ausgetragen."
       send_attendance_email:
-        success: 'Attendance warning email sent.'
+        success: 'Anwesenheits-Warn-E-mail verschickt.'
       send_eligibility_email:
-        success: 'Eligibility inquiry email sent.'
+        success: 'Anfrage zur Teilnahmeberechtigung verschickt'


### PR DESCRIPTION
localised strings to be output by the program into german.
i was not able to follow the contributing guidelines as i ran into problems running bundle, conflicting versions of ruby, and permissions issues. However, all i changed was output strings and this should not have any impact on how the program runs. Therefore i am creating a PR anyway. Let me know if this is not a good idea for some reason and maybe advise me how to best set up a local test environment that will not run into conflicts with my machine's setup.

note on translations in general: i think it would be a good idea to do the whole site by one person at once. or alternatively, create a database/spreadsheet for what different things are called. otherwise, you will run into the problem that different translators (or the same one at different times) use different terms for what should be uniform across the site ("manage subscriptions" for example can be translated into german in so many ways and it should be coherent across the site what things are called)

