### PR TITLE
Migrate admin group members index page to Bootstrap 5 classes

### DIFF
--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -1,16 +1,18 @@
-%section#banner
+.container-fluid.pt-3
   .row
-    .large-12.columns
-      %h1
+    .col
+      %h1.mb-3
         = @group.name
-        %small.subheader #{@group.chapter.name}
-    .large-12.columns
+        %small.text-muted #{@group.chapter.name}
+
+  .row
+    .col
       %h3 Members (#{@group.members.count})
-      %table
-        - @group.members.each do |member|
-          %tbody
+      %table.table
+        %tbody
+          - @group.members.each do |member|
             %tr
-              %td= image_tag(member.avatar(32), class: 'th radius', title: member.full_name, alt: member.full_name)
-              %td= link_to member.full_name, admin_member_path(member)
-              %td= mail_to member.email, member.email
+              %td= image_tag(member.avatar(32), class: 'rounded-circle', title: member.full_name, alt: member.full_name)
+              %td= link_to member.full_name, admin_member_path(member), class: 'border-0'
+              %td= mail_to member.email, member.email, class: 'border-0'
               %td= member.mobile


### PR DESCRIPTION
### Description
This PR migrates the admin group members index page (admin/groups/:id) to Bootstrap 5 classes.

### Status
Ready for Review

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-10-07 at 20-20-53 codebar](https://user-images.githubusercontent.com/5873816/136493158-c1fa3106-bc21-42fa-9650-d61617a667a9.png) | ![Screenshot 2021-10-07 at 20-19-45 codebar](https://user-images.githubusercontent.com/5873816/136493056-0dcafcbc-85bd-47f9-869c-801518742a29.png)