### PR TITLE
Migrate admin chapter workshops page to Bootstrap 5 classes

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -1111,10 +1111,6 @@ $table-line-height: rem-calc(16);
 // $table-display: table-cell;
 $table-margin-bottom: rem-calc(10);
 
-table tr {
-  border-top: 1px solid scale-color($codebar-blue, $lightness: 95%);
-}
-
 //
 // TABS
 //

--- a/app/views/admin/workshops/index.html.haml
+++ b/app/views/admin/workshops/index.html.haml
@@ -1,29 +1,29 @@
-%section#banner
+.container-fluid.pt-3
   .row
-    .medium-12.columns
-      %h2.subheader
+    .col
+      %h1.mb-3
         Workshops
-        %small=@chapter.name
+        %small.text-muted= @chapter.name
 
   .row
-    %table.large-12.columns
-      %thead
-        %td Date
-        %td Attendances
-        %td Sponsors
-        %td
-
-      %tbody
-        - @workshops.each do |workshop|
-          %tr
-            %td
-              = link_to admin_workshop_path(workshop) do
-                = humanize_date(workshop.date_and_time, with_time: true, with_year: true)
-            %td
-              = workshop.invitations.accepted.count
-            %td
-              - workshop.sponsors.each do |sponsor|
-                = link_to sponsor.name, sponsor.website
-            %td
-              - if workshop.date_and_time.future?
-                %label.label upcoming
+    .col
+      %table.table
+        %thead
+          %td Date
+          %td Attendances
+          %td Sponsors
+          %td
+        %tbody
+          - @workshops.each do |workshop|
+            %tr
+              %td
+                = link_to admin_workshop_path(workshop), class: 'border-0' do
+                  = humanize_date(workshop.date_and_time, with_time: true, with_year: true)
+              %td
+                = workshop.invitations.accepted.count
+              %td
+                - workshop.sponsors.each do |sponsor|
+                  = link_to sponsor.name, sponsor.website, class: 'border-0'
+              %td
+                - if workshop.date_and_time.future?
+                  %span.badge.bg-primary Upcoming


### PR DESCRIPTION
### Description
This PR migrates the admin chapter workshops page (/admin/chapters/:id/workshops) to Bootstrap 5 classes.

### Status
Ready for Review

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-10-08 at 16-50-47 codebar](https://user-images.githubusercontent.com/5873816/136635909-847ddc71-78fc-4d03-b0c4-f062c976ccad.png) | ![Screenshot 2021-10-08 at 16-50-29 codebar](https://user-images.githubusercontent.com/5873816/136635922-5270592a-89ca-4a43-8117-576559ff9372.png)