### PR TITLE
Migrate the contact preferences page to Bootstrap 5 classes

### DIFF
--- a/app/views/contact_preferences/show.html.haml
+++ b/app/views/contact_preferences/show.html.haml
@@ -1,10 +1,9 @@
-%section
-  .stripe.reverse
-    .row
-      .large-6.columns
-        %h1 Contact Preferences
-        - if @contact.present?
-          = simple_form_for @contact, url: :contact_preferences, method: :put do |f|
-            = f.input :token, as: :hidden
-            = f.input :mailing_list_consent, label: 'Sponsors mailing list'
-            = f.submit 'Update', class: 'button'
+.container-fluid.stripe.reverse
+  .row.justify-content-md-center
+    .col-md-10.col-lg-8
+      %h1 Contact Preferences
+      - if @contact.present?
+        = simple_form_for @contact, url: :contact_preferences, method: :put do |f|
+          = f.input :token, as: :hidden
+          = f.input :mailing_list_consent, label: 'Sponsors mailing list'
+          = f.button :button, 'Update', class: 'btn btn-primary'


### PR DESCRIPTION
### Description
This PR migrates the contact preferences page to Bootstrap 5 classes.

### Status
Ready for Review

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-10-08 at 18-55-37 codebar](https://user-images.githubusercontent.com/5873816/136639856-3875b442-fb95-4814-98e2-ef1015a75f73.png) | ![Screenshot 2021-10-08 at 16-41-21 codebar](https://user-images.githubusercontent.com/5873816/136639861-e74b39e4-2d00-4324-81af-d7262b70fae2.png)