### PR TITLE
Migrate admin sponsor page to Bootstrap 5 classes

### DIFF
--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -1,104 +1,97 @@
-%section#admin#banner
+.container-fluid.pt-3
   .row
-    .large-12.columns
-      %ul.breadcrumbs
-        %li=link_to 'Sponsors', admin_sponsors_path
-        %li.current=@sponsor.name
-
-  .row
-    .medium-6.columns
-      %dl
-        %dt Name
-        %dd= @sponsor.name
-
-        %dt Logo
-        %dd.large-6= image_tag(@sponsor.avatar.url, alt: @sponsor.name)
-
-        %dt Website
-        %dd= link_to @sponsor.website
-
-        %dt Description
-        %dd= @sponsor.description
-
-        %dt
-          Level
-          %i.fa.fa-trophy
-        %dd= @sponsor.level
-
-        %dt Contacts
-        %dd
-          %ul.no-bullet#contacts
-            - @sponsor.contacts.each do |contact|
-              %li
-                = mail_to(contact.email, contact.full_name)
-                %i.fa{ class: contact.mailing_list_subscription_class }
-
-    .medium-6.columns
-
-      .row
-        .large-6.columns
-          %dl
-            %dt Student spots
-            %dd= @sponsor.seats
-        .large-6.columns
-          %dl
-            %dt Coach spots
-            %dd= @sponsor.coach_spots
-
-      %dl
-        %dt
-          Accessibility information
-          .fa.fa-universal-access
-        %dd
-          = @sponsor.accessibility_info
-
-        %dt Address
-        - if @sponsor.address.present?
-          %dd= @sponsor.address.to_html
-
-        %dt Directions
-        - if @sponsor.address.present?
-          %dd= @sponsor.address.directions
+    .col
+      %nav{'aria-label': 'breadcrumb'}
+        %ol.breadcrumb.ml-0
+          %li.breadcrumb-item= link_to t('admin.shared.sponsors'), admin_sponsors_path, class: 'border-0'
+          %li.breadcrumb-item.active= @sponsor.name
 
   .row
-    .medium-12.columns.text-right
-      = link_to edit_admin_sponsor_path(@sponsor), class: 'button small' do
-        Edit
+    .d-flex.justify-content-between.align-items-center.mb-4
+      %h1= @sponsor.name
+      = link_to t('.edit_button'), edit_admin_sponsor_path(@sponsor), class: 'btn btn-primary'
+    .col-12.col-lg-3
+      .d-flex.justify-content-center.py-3.mb-4
+        = image_tag(@sponsor.avatar.url, alt: @sponsor.name, class: 'small-image')
+      .bg-light.p-3.mb-4
+        %dl.row
+          %dt= t('.website')
+          %dd= link_to @sponsor.website
 
-  .row#map
-    .medium-12.columns
-      %dl
-        %dt Map preview
-        %dd.panel.medium-12.columns
+          %dt= t('.address')
+          - if @sponsor.address.present?
+            %dd= @sponsor.address.to_html
+
+          %dt= t('.directions')
+          %dd
+            - if @sponsor&.address&.directions.present?
+              = @sponsor.address.directions
+            - else
+              = t('.empty_state.directions')
+
+          %dt= t('.description')
+          %dd
+            - if @sponsor.description.present?
+              = @sponsor.description
+            - else
+              = t('.empty_state.description')
+
+          %dt.col-8= t('.student_spots')
+          %dd.col-4= @sponsor.seats
+
+          %dt.col-8= t('.coach_spots')
+          %dd.col-4= @sponsor.coach_spots
+
+          %dt
+            = t('.level')
+            %i.fa.fa-trophy
+          %dd= @sponsor.level
+
+          %dt
+            = t('.accessibility_info')
+            %i.fa.fa-universal-access
+          %dd
+            - if @sponsor.accessibility_info.present?
+              = @sponsor.accessibility_info
+            - else
+              = t('.empty_state.accessibility_info')
+
+          %dt.mb-0= t('.contacts')
+          %dd
+            %ul.list-unstyled.ml-0.mb-0#contacts
+              - @sponsor.contacts.each do |contact|
+                %li.mt-1
+                  = mail_to(contact.email, contact.full_name)
+                  %i.fa{ class: contact.mailing_list_subscription_class }
+
+    .col-12.col-lg-9
+      %h2.h3.mb-3= t('.map_preview')
+      .card.mb-4
+        .card-body
           - if @sponsor.address.present?
             = render partial: 'shared/venue', locals: { venue: @sponsor, address: @sponsor.address}
           - else
-            An address must be specified for the map preview to be generated
+            = t('.empty_state.map')
 
-
-
-  .row#sponsorships
-    .medium-12.columns
-      %dl
-        %dt Sponsorships
-        %dd
-          - if @sponsor.workshops.none? && @sponsor.events.none? && @sponsor.meetings.none?
-            No sponsorships
-          - else
-            .row
+      #sponsorships.mb-4
+        %h2.h3.mb-3= t('.sponsorships')
+        - if @sponsor.workshops.none? && @sponsor.events.none? && @sponsor.meetings.none?
+          = t('.empty_state.sponsorships')
+        - else
+          .row.row-cols-md-3
             - if @sponsor.workshops.any?
-              .large-4.columns
-                %strong Workshops
-                %ul.no-bullet
+              .col
+                %strong= t('admin.shared.workshops')
+                %ul.list-unstyled.ml-0
                   - @sponsor.workshop_sponsors.each do |ws|
                     %li
                       = link_to admin_workshop_path(ws.workshop) do
                         = I18n.l(ws.workshop.date_and_time, format: :default_date)
                         #{ws.workshop.chapter.name} #{ws.workshop.host ? '(host)' : ''}
             - if @sponsor.event_sponsorships.any?
-              .large-4.columns
-                %strong Events
-                %ul.no-bullet
+              .col
+                %strong= t('admin.shared.events')
+                %ul.list-unstyled.ml-0
                   - @sponsor.event_sponsorships.each do |sponsorship|
                     %li
                       = link_to admin_event_path(sponsorship.event) do
@@ -107,18 +100,16 @@
                         \- #{sponsorship&.level&.upcase || 'Standard'}
 
             - if @sponsor.meetings.any?
-              .large-4.columns
-                %strong Meetings
-                %ul.no-bullet
+              .col
+                %strong= t('admin.shared.meetings')
+                %ul.list-unstyled.ml-0
                   - @sponsor.meetings.each do |meeting|
                     %li
                       = link_to admin_meeting_path(meeting) do
                         #{I18n.l(meeting.date_and_time, format: :default_date)}
                         = meeting.title
 
-  .row#activities
-    .medium-12.columns
-      %dl
-        %dt Activities
-        %ul
+      #activities.mb-4
+        %h2.h3.mb-3= t('.activities')
+        %ul.list-unstyled.ml-0
           = render_activities @sponsor.activities

--- a/config/locales/admin.de.yml
+++ b/config/locales/admin.de.yml
@@ -1,5 +1,14 @@
 de:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Mitglied wurde gesperrt und per E-mail informiert.'
@@ -13,3 +22,25 @@ de:
         success: 'Anwesenheits-Warn-E-mail verschickt.'
       send_eligibility_email:
         success: 'Anfrage zur Teilnahmeberechtigung verschickt'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -1,5 +1,14 @@
 en:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ en:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.en_AU.yml
+++ b/config/locales/admin.en_AU.yml
@@ -1,5 +1,14 @@
 en-AU:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ en-AU:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.en_GB.yml
+++ b/config/locales/admin.en_GB.yml
@@ -1,5 +1,14 @@
 en-GB:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ en-GB:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.en_US.yml
+++ b/config/locales/admin.en_US.yml
@@ -1,5 +1,14 @@
 en-US:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ en-US:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -1,5 +1,14 @@
 es:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ es:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.fi.yml
+++ b/config/locales/admin.fi.yml
@@ -1,5 +1,14 @@
 fi:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ fi:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -1,5 +1,14 @@
 fr:
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@ fr:
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships

--- a/config/locales/admin.no.yml
+++ b/config/locales/admin.no.yml
@@ -1,5 +1,14 @@
 "no":
   admin:
+    shared:
+      workshops: Workshops
+      events: Events
+      meetings: Meetings
+      sponsors: Sponsors
+      students: Students
+      coaches: Coaches
+      organisers: Organisers
+
     bans:
       create:
         success: 'Member marked as supended and suspension email sent.'
@@ -13,3 +22,25 @@
         success: 'Attendance warning email sent.'
       send_eligibility_email:
         success: 'Eligibility inquiry email sent.'
+
+    sponsors:
+      show:
+        edit_button: Edit sponsor
+        website: Website
+        address: Address
+        directions: Directions
+        description: Description
+        student_spots: Student spots
+        coach_spots: Coach spots
+        level: Level
+        accessibility_info: Accessibility information
+        contacts: Contacts
+        map_preview: Map preview
+        sponsorships: Sponsorships
+        activities: Activities
+        empty_state:
+          directions: No directions provided.
+          description: No description provided.
+          accessibility_info: No accessibility information provided. Please reach out to the sponsor so they can provide you with this information.
+          map: An address must be specified for the map preview to be generated.
+          sponsorships: No sponsorships


### PR DESCRIPTION
### Description
This PR migrates the admin sponsor page to Bootstrap 5 classes.

### Status
Ready for Review

### Screenshots
Before | After
------------ | -------------
![Screenshot 2021-10-16 at 16-07-10 codebar](https://user-images.githubusercontent.com/5873816/137604168-800fb034-1f98-4889-ad13-e78247413829.png) | ![Screenshot 2021-10-16 at 16-05-37 codebar](https://user-images.githubusercontent.com/5873816/137604147-33f4b672-74f4-4395-9586-503d59984d7f.png)