### PR TITLE
Convert /admin page on website to Bootstrap

### DIFF
--- a/app/views/admin/portal/index.html.haml
+++ b/app/views/admin/portal/index.html.haml
@@ -1,35 +1,36 @@
-%section#banner
+.container-fluid
   .row
-    .large-4.columns
-      %h3 Chapters
-      %ul.side-nav
+    .col-12.col-md-3
+      %h3.mb-3 Chapters
+      %ul.list-unstyled.m-0
         - @chapters.each do |chapter|
-          %li= link_to chapter.name, [ :admin, chapter ]
-    .large-4.columns
-      %h3 Upcoming Workshops
-      %ul.side-nav
+          %li.pb-2.mb-3.border-bottom.border-dark
+            = link_to chapter.name, [ :admin, chapter ], class: 'border-0 pl-2'
+    .col-12.col-md-5
+      %h3.mb-3 Upcoming Workshops
+      %ul.list-unstyled.m-0
         - @workshops.each do |workshop|
-          %li
-            = link_to admin_workshop_path(workshop) do
+          %li.border-bottom.border-dark.pb-2.mb-3
+            = link_to admin_workshop_path(workshop), class: 'border-0' do
               %strong= workshop.chapter.name
               %br
               = humanize_date(workshop.date_and_time, with_time: true)
-    .large-4.columns
-      = link_to 'View all sponsors', admin_sponsors_path, class: 'button expand round'
-      = link_to 'Sponsor contacts', admin_contacts_path, class: 'button expand round'
-      = link_to 'Admin Guide', admin_guide_path, class: 'button expand round'
-      = link_to 'Members Directory', admin_members_path, class: 'button expand round'
+    .col-12.col-md-4.d-flex.flex-column
+      = link_to 'View all sponsors', admin_sponsors_path, class: 'btn btn-primary btn-lg mb-3'
+      = link_to 'Sponsor contacts', admin_contacts_path, class: 'btn btn-primary btn-lg mb-3'
+      = link_to 'Admin Guide', admin_guide_path, class: 'btn btn-primary btn-lg mb-3'
+      = link_to 'Members Directory', admin_members_path, class: 'btn btn-primary btn-lg mb-3'
     %hr
 
   .row
-    .large-3.columns
-      %h3 Groups
-      %ul.side-nav
+    .col-12.col-md-3
+      %h3.mb-3 Groups
+      %ul.list-unstyled.m-0
         - @groups.each do |group|
-          %li
-            = link_to [:admin, group] do
+          %li.border-bottom.border-dark.pb-2.mb-3
+            = link_to [:admin, group], class: 'border-0' do
               #{group.name} (#{group.chapter.name})
 
-    .large-9.columns
-      %h3 Latest Subscribers
+    .col-12.col-md-9
+      %h3.mb-3 Latest Subscribers
       = render partial: 'admin/subscriptions/index', locals: { subscribers: @subscribers }


### PR DESCRIPTION
I haven't translated some of the strings as I think that should be a separate task.

P.S I have no idea what the big white space on the after picture is, it isn't like that locally or in the screenshot. Some weird formatting Github is doing.

| Before | After |
|-------|------|
|![screencapture-codebar-io-admin-2021-10-18-18_58_00](https://user-images.githubusercontent.com/2683270/137775408-a91e77f8-7e55-4e8f-b604-9b06b68d4182.png)|![screencapture-localhost-3000-admin-2021-10-18-18_57_44](https://user-images.githubusercontent.com/2683270/137775541-eba2c487-b2e3-4003-8a37-c037c29bffe7.png)|