### PR TITLE
Wider job component

### DIFF
--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -13,7 +13,7 @@
         %small #{link_to('Click here', new_member_job_path)} if you would like to post a new job.
   - if @jobs.any?
     .row
-      .col.col-md-8.col-lg-6
+      .col.col-md-8
         %ul.jobs.list-unstyled.ml-0.mb-0
           - @jobs.each do |job|
             = render partial: 'job', locals: { job: job }


### PR DESCRIPTION
I'm not a fan of the 50% width of jobs on this page, I think it looks a little odd so I've removed the larger grid-6 media query.

| Before | After |
|-------|------
|![screencapture-codebar-io-jobs-2021-11-08-13_09_42](https://user-images.githubusercontent.com/2683270/140739887-a2083c78-dcd3-4371-b8df-190d62d1774a.png)|![screencapture-codebar-io-jobs-2021-11-08-13_10_06](https://user-images.githubusercontent.com/2683270/140739883-6ff60001-263a-4f62-bada-aa601627c9db.png)|
