### PR TITLE
Fix student feedback form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    ffi (1.12.2)
+    ffi (1.15.4)
     font-awesome-rails (4.7.0.7)
       railties (>= 3.2, < 7)
     foreman (0.87.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -45,6 +45,23 @@ $(function(){
 
   $('body').removeClass('no-js');
 
+  // Chosen hides inputs and selects, which becomes problematic when they are
+  // required: browser validation doesn't get shown to the user.
+  // This fix places "the original input behind the Chosen input, matching the
+  // height and width so that the warning appears in the correct position."
+  // https://github.com/harvesthq/chosen/issues/515#issuecomment-474588057
+  $('select').on('chosen:ready', function () {
+    var height = $(this).next('.chosen-container').height();
+    var width = $(this).next('.chosen-container').width();
+
+    $(this).css({
+      position: 'absolute',
+      height: height,
+      width: width,
+      opacity: 0
+    }).show();
+  });
+
   $('select').chosen(function(){
     allow_single_deselect: true
     no_results_text: 'No results matched'

--- a/app/views/feedback/show.html.haml
+++ b/app/views/feedback/show.html.haml
@@ -35,9 +35,8 @@
             = f.button :button, 'Submit feedback', class: 'btn btn-primary'
 
 :javascript
-  $('.rating').starRating({
-    minus: false
-    });
-    $('input[name="commit"]').click(function(){
+  $('.rating').starRating({ minus: false });
+
+  $('button[type="submit"]').on('click', function () {
     $('#feedback_rating').val($('.rating').data('val'))
   });

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,7 +22,7 @@ Planner::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
   let(:member1) { Fabricate(:member) }
   let(:address) { Fabricate(:address) }
   let(:admin) { Fabricate(:chapter_organiser) }
-  let(:avatar) { Rack::Test::UploadedFile.new(Rails.root.join('app', 'assets', 'images', 'logo.png'), 'image/jpeg') }
+  let(:avatar) { Rack::Test::UploadedFile.new(Rails.root.join('app', 'assets', 'images', 'logo.png'), 'image/png') }
   let(:sponsor) { Fabricate(:sponsor) }
 
   describe 'POST #create' do

--- a/spec/fabricators/sponsor_fabricator.rb
+++ b/spec/fabricators/sponsor_fabricator.rb
@@ -8,7 +8,7 @@
 Fabricator(:sponsor) do
   name { Faker::Name.name }
   website { "http://#{Faker::Internet.domain_name}" }
-  avatar { Rack::Test::UploadedFile.new(Rails.root.join('app', 'assets', 'images', 'sponsors', sponsor_image), 'image/jpeg') }
+  avatar { Rack::Test::UploadedFile.new(Rails.root.join('app', 'assets', 'images', 'sponsors', sponsor_image), 'image/png') }
   address
 end
 

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -59,16 +59,15 @@ RSpec.feature 'member feedback', type: :feature do
   end
 
   context 'Submitting a feedback request' do
-    scenario 'I can see success page with message and link to homepage when valid data is given' do
+    scenario 'I can see success page with message and link to homepage when valid data is given', js: true do
       visit feedback_path(valid_token)
 
-      find(:xpath, "//input[@id='feedback_rating']", visible: false).set '4'
-      select(coach.full_name, from: 'feedback_coach_id')
-      select(@tutorial.title, from: 'feedback_tutorial_id')
-
+      within('.rating') { all('li').at(3).click }
+      select_from_chosen(coach.full_name, from: 'feedback_coach_id')
+      select_from_chosen(@tutorial.title, from: 'feedback_tutorial_id')
       click_button('Submit feedback')
 
-      expect(current_url).to eq(root_url)
+      expect(current_path).to eq(root_path)
 
       expect(page).to have_content(feedback_submited_message)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.include LoginHelpers
   config.include JobrefHelpers
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include SelectFromChosen, type: :feature
   config.use_transactional_fixtures = false
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'

--- a/spec/support/select_from_chosen.rb
+++ b/spec/support/select_from_chosen.rb
@@ -1,0 +1,24 @@
+# I started with:
+# https://coderwall.com/p/wdq81q/capybara-select-chosen-field-for-rspec-testing
+#
+# However, it was not working fully, possibly because of situations where the
+# list needs to scroll to find the match.
+#
+# I ended up putting a few suggestions together from:
+# https://gist.github.com/thijsc/1391107/2d979de6ecaec4edbea086da907c65102f3d0f7a
+module SelectFromChosen
+  def select_from_chosen(item_text, options)
+    # Find the native <select>
+    field = find_field(options[:from], :visible => false)
+
+    # Open the Chosen dialog
+    find("##{field[:id]}_chosen").click
+
+    # On the search input, type the string we're looking for and press Enter
+    within field.sibling('.chosen-container') do
+      input = find("input").native
+      input.send_keys(item_text)
+      input.send_key(:return)
+    end
+  end
+end


### PR DESCRIPTION
This pull request fixes #1665, but I must write _what exactly_ does it fix.

@khamiltonuk reported that a student could not submit feedback about a coach, with the culprit pointing out to the coach field being required. Upon closer inspection, this field turned out to be optional, so there must be something else preventing us from submitting…

Going to the corresponding page and trying to submit something totally empty did not work, as expected… but there was no errors, no browser messages highlighting that field X or Y had to be filled in. Looking at it a bit closer took me to https://github.com/harvesthq/chosen/issues/515, the `<select>`s we use on that page are being replaced with Chosen, and while doing that the original _required_ fields are being hidden. When they are hidden, they cannot show the required tooltips browsers do, so the first fix this PR has it to make them “visible” (i.e. hidden behind Chosen but you can see the required tooltips).

After taking care of this, the submit was still not working. Peeking under the hood, I noticed the start rating script we have gets setup (displaying seemingly interactive stars) but the actual selected star was not being converted into a number and set on the hidden input, thus the data reaching the controller was empty — in other words, invalid. Tweaking a bit the JavaScript we had fixed this, we were now submitting feedback! Huzzah!

But… surely we had a test for this. That test was passing, but the feature was kind of broken. Why is that? Well, the test we had was, in summary, testing the page _without_ JavaScript, which would offer the user a very different experience: no stars to select, no search-included “select” powered by Chosen. I had to adapt the test to be ran in a JavaScript supported environment and introduce some lines of code that would allow us to pick items from a Chosen-powered “select”.

Having done all of this, I finally ran into a small wall. Capybara was erring because a sponsor image was not found. I must admit I gave up on properly fixing this ‘cause it looked like magic to me. The image _was_ there (i.e. the file system) but I could not access it on the browser — even with a direct link. After a lot of digging, I could only make this go away basically by telling Capybara not to break our tests if images are missing. If someone has a better fix for this, I’d love to know about it! 🙇‍♂️ 

Update: on the last commit I tried to bump Ruby’s version to see if GitHub Actions stopped complaining about not being able to setup a database. From other runs on other PRs, that seems to be a common issue.