### PR TITLE
Hide rsvp buttons in past events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ActiveRecord::Base
   include Listable
   include Invitable
+  include DateTimeConcerns
 
   attr_accessor :begins_at
 
@@ -96,6 +97,10 @@ class Event < ActiveRecord::Base
   end
 
   private
+
+  def time_zone
+    'London'
+  end
 
   def duplicated_sponsors
     @duplicated_sponsors ||= fetch_duplicated_sponsors

--- a/app/views/events/_event_actions.html.haml
+++ b/app/views/events/_event_actions.html.haml
@@ -3,15 +3,18 @@
     Go to external booking site
 - else
   - if @event.invitable
-    - if logged_in?
-      - unless @event.coaches_only?
-        = link_to event_student_rsvp_path(@event), class: 'btn btn-primary mr-2' do
-          = t('events.attend_as_student')
-      - unless @event.students_only?
-        = link_to event_coach_rsvp_path(@event), class: 'btn btn-primary' do
-          = t('events.attend_as_coach')
+    - if @event.past?
+      %p.badge.bg-primary This event has already occurred.
     - else
-      = link_to 'Sign up', new_member_path, class: 'btn btn-primary mr-2'
-      = link_to 'Log in', login_path, class: 'btn btn-primary'
+      - if logged_in?
+        - unless @event.coaches_only?
+          = link_to event_student_rsvp_path(@event), class: 'btn btn-primary mr-2' do
+            = t('events.attend_as_student')
+        - unless @event.students_only?
+          = link_to event_coach_rsvp_path(@event), class: 'btn btn-primary' do
+            = t('events.attend_as_coach')
+      - else
+        = link_to 'Sign up', new_member_path, class: 'btn btn-primary mr-2'
+        = link_to 'Log in', login_path, class: 'btn btn-primary'
   - else
     %p.badge.bg-primary= t('events.not_open_for_rsvp')

--- a/spec/features/view_event_spec.rb
+++ b/spec/features/view_event_spec.rb
@@ -55,6 +55,20 @@ RSpec.feature 'viewing an event', type: :feature do
           expect(page).to have_content('Your spot has not yet been confirmed. We will verify your attendance after you complete the questionnaire.')
         end
       end
+      
+      context 'can not RSVP to an event' do
+        it 'that is now in the past' do
+          expect(current_path).to eq(event_path(closed_event))
+
+          travel_into_the_future = Time.zone.now + 3.days
+          allow(Time).to receive(:now).and_return(travel_into_the_future)
+          visit event_path(closed_event)
+          
+          expect(page).to have_content('This event has already occurred.')
+          expect(page).not_to have_button('Attend as a coach')
+          expect(page).not_to have_button('Attend as a student')
+        end
+      end
     end
   end
 
@@ -89,6 +103,20 @@ RSpec.feature 'viewing an event', type: :feature do
 
           expect(page).to have_content("Your spot has been confirmed for #{open_event.name}! We look forward to seeing you there")
           expect(page).not_to have_content('We will verify your attendance after you complete the questionnaire!')
+        end
+      end
+
+      context 'can not RSVP to an event' do
+        it 'that is now in the past' do
+          expect(current_path).to eq(event_path(open_event))
+
+          travel_into_the_future = Time.zone.now + 3.days
+          allow(Time).to receive(:now).and_return(travel_into_the_future)
+          visit event_path(open_event)
+
+          expect(page).to have_content('This event has already occurred.')
+          expect(page).not_to have_button('Attend as a coach')
+          expect(page).not_to have_button('Attend as a student')
         end
       end
 


### PR DESCRIPTION
Closes #1703 

This PR resolves the issue 1703 which mentions users can RSVP to past "Events".