### PR TITLE
Migrate admin feedback page to Bootstrap 5 classes

### DIFF
--- a/app/views/admin/feedback/index.html.haml
+++ b/app/views/admin/feedback/index.html.haml
@@ -1,41 +1,34 @@
-%section#admin#banner
+.container-fluid.pt-3
   - if @feedback.any?
     .row
-      .medium-6.columns.text-left
+      .col
         = page_entries_info(@feedback, model: 'feedback')
-        %br
-        %br
-    .row
-      .large-12.columns
-        - @feedback.each do |feedback|
-          .row
-            .large-2.columns
-              %h5= I18n.l(feedback.created_at, format: :date)
-            .large-3.columns
-              %h5.subheader
-                = feedback.tutorial.title
-            - if feedback.coach.present?
-              .large-1.columns
-                = image_tag(feedback.coach.avatar(50), class: 'th radius', title: feedback.coach.full_name, alt: feedback.coach.full_name)
-              .large-2.columns
-                = feedback.coach.full_name
-            .large-2.columns
-              - (0...feedback.rating).each do |rating|
-                %i.fa.fa-star
-          - if feedback.request.present?
-            .row
-              .large-12.columns
-                %h5 How did you find the workshop?
-                %p= feedback.request
-          - if feedback.suggestions.present?
-            .row
-              .large-12.columns
-                %h5 Suggestions
-                %p= feedback.suggestions
-          %hr
-    .row
-      .medium-12.columns.text-right
+
+    .row.mb-4
+      - @feedback.each do |feedback|
+        .col-12
+          .card.mt-4
+            .card-header.d-md-flex.justify-content-md-between
+              .d-block= I18n.l(feedback.created_at, format: :date)
+              .d-block= feedback.tutorial.title
+              .d-block
+                = image_tag(feedback.coach.avatar(24), class: 'rounded-circle', title: feedback.coach.full_name, alt: feedback.coach.full_name)
+                %small= feedback.coach.full_name
+              .d-block
+                - (0...feedback.rating).each do |rating|
+                  %i.fa.fa-star
+            .card-body
+              - if feedback.request.present?
+                %h5.card-title How did you find the workshop?
+                %p.card-text= feedback.request
+              - if feedback.suggestions.present?
+                %h5.card-title Suggestions
+                %p.card-text= feedback.suggestions
+
+    .row.mb-4
+      .col.text-right
         = will_paginate(@feedback)
-        %br
+
   - elsif @chapter.present?
-    No feedback has been submitted for #{@chapter.name}'s workshops yet.
+    .row
+      %p No feedback has been submitted for #{@chapter.name} workshops yet.

--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -27,6 +27,6 @@ RSpec.feature 'Chapter workshop feedback', type: :feature do
     visit root_path
     click_on "#{chapter.name} feedback"
 
-    expect(page).to have_content("No feedback has been submitted for #{chapter.name}'s workshops yet.")
+    expect(page).to have_content("No feedback has been submitted for #{chapter.name} workshops yet.")
   end
 end


### PR DESCRIPTION
### Description
This PR migrates the admin feedback page to Bootstrap 5 classes.

### Status
Ready for Review

### Screenshots
| Before | After |
| --- | --- |
| <img width="1281" alt="Screenshot 2022-03-04 at 10 01 51 pm" src="https://user-images.githubusercontent.com/5873816/156870545-84008df9-91ab-4a49-a4ac-3d2630d67aae.png"> | <img width="1280" alt="Screenshot 2022-03-04 at 10 26 33 pm" src="https://user-images.githubusercontent.com/5873816/156871297-dc928dcd-2125-4628-a01a-e8668260a639.png"> |