### PR TITLE
Migrate admin contacts page to Bootstrap 5 classes

### DIFF
--- a/app/views/admin/contacts/index.html.haml
+++ b/app/views/admin/contacts/index.html.haml
@@ -1,12 +1,14 @@
-%section#admin#banner
-  .row
-    .large-12.columns
-      %ul.breadcrumbs
-        %li= link_to 'Sponsors', admin_sponsors_path
-        %li.current Contacts
-  .row
-    .medium-12.columns
-      %table.hover
+.container-fluid.pt-3
+  .row.mb-3
+    .col
+      %nav{'aria-label': 'breadcrumb'}
+        %ol.breadcrumb.ml-0
+          %li.breadcrumb-item= link_to t('admin.shared.sponsors'), admin_sponsors_path, class: 'border-0'
+          %li.breadcrumb-item.active Contacts
+
+  .row.mb-4
+    .col
+      %table.table.table-striped.table-hover
         %thead
           %tr
             %th Sponsor
@@ -17,12 +19,12 @@
           - @contacts.each do |contact|
             %tr
               %td
-                =link_to contact.sponsor.name, admin_sponsor_path(contact.sponsor)
+                = link_to contact.sponsor.name, admin_sponsor_path(contact.sponsor), class: 'border-0'
               %td
                 #{contact.name} #{contact.surname}
               %td
                 = contact.email
-              %td.text-center
+              %td
                 - if contact.mailing_list_consent
                   %i.fa.fa-check.success
                 - else


### PR DESCRIPTION
### Description
This PR migrates the admin contacts page to Bootstrap 5 classes.

### Status
Ready for Review

### Screenshots
| Before | After |
| --- | --- |
| ![Screenshot 2022-03-09 at 21-34-53 codebar](https://user-images.githubusercontent.com/5873816/157596364-bfd35d1b-7bb5-4ac3-88a7-d3fa01c10c00.png) | ![Screenshot 2022-03-09 at 21-33-59 codebar](https://user-images.githubusercontent.com/5873816/157596283-9aeec246-54f1-4c6a-8315-4c5659373af7.png) |