### PR TITLE
Remove mentions of food given remote setting

### DIFF
--- a/app/views/member_mailer/welcome_coach.html.haml
+++ b/app/views/member_mailer/welcome_coach.html.haml
@@ -29,7 +29,7 @@
   You will be notified at least three hours before the event if you receive a place.
 
 %p
-  Our workshops start with around 30 minutes of socialising and food, before we assign
+  Our workshops start with around 30 minutes of socialising, before we assign
   you to coach one or two students. They'll either be working on
   = link_to "one of our tutorials", "http://tutorials.codebar.io/"
   or looking for help with their own projects. Don't worry if you're not an expert on


### PR DESCRIPTION
Small change, but I actually had a coach reaching out to me about this email oddity. Given the current remote setting, might as well remove this… And whenever we move to IRL gatherings, I don’t think this mention will be missed.