### PR TITLE
Move festival banner into a reusable partial

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -10,18 +10,6 @@
     .col-md-8
       %p.lead.mb-0= raw t('homepage.explanation')
 
-.container-fluid.py-4.festival-banner
-  .row.justify-content-md-center
-    .col-lg-8
-      .row
-        .col-md-4.mb-4.mb-md-0
-          = link_to image_tag('festival/festival-logo-pink.png', style: 'max-width: 180px;', alt: 'codebar Festival logo'), 'https://festival.codebar.io/', class: 'border-0'
-          %p.text-white.mb-0
-            %strong 11 - 13th March 2022
-        .col-md
-          %p.text-white.mb-2 Following our successful festival in 2021 we are very excited to celebrate our community and provide even more opportunities in codebar Festival 2022.
-          %p.text-white.mb-0 Join us for 3 days of talks, workshops, demos, and panel discussions on CODING, CAREER, or WELLBEING. New for this year is the JOB FAIR, chat with people from Compare The Market, Amazon.com, Global, IDBS and Immersive Labs. You're in control, create your own schedule. It’s 100% virtual and completely free. #{link_to 'RSVP here', 'https://festival.codebar.io', class: 'link-light border-0 text-decoration-underline'}.
-
 .container-fluid.py-4.py-lg-5
   .row
     .col-md-4.mb-4.mb-md-0

--- a/app/views/shared/_festival_banner.html.haml
+++ b/app/views/shared/_festival_banner.html.haml
@@ -1,0 +1,11 @@
+.container-fluid.py-4.festival-banner
+  .row.justify-content-md-center
+    .col-lg-8
+      .row
+        .col-md-4.mb-4.mb-md-0
+          = link_to image_tag('festival/festival-logo-pink.png', style: 'max-width: 180px;', alt: 'codebar Festival logo'), 'https://festival.codebar.io/', class: 'border-0'
+          %p.text-white.mb-0
+            %strong 11 - 13th March 2022
+        .col-md
+          %p.text-white.mb-2 Following our successful festival in 2021 we are very excited to celebrate our community and provide even more opportunities in codebar Festival 2022.
+          %p.text-white.mb-0 Join us for 3 days of talks, workshops, demos, and panel discussions on CODING, CAREER, or WELLBEING. New for this year is the JOB FAIR, chat with people from Compare The Market, Amazon.com, Global, IDBS and Immersive Labs. You're in control, create your own schedule. It’s 100% virtual and completely free. #{link_to 'RSVP here', 'https://festival.codebar.io', class: 'link-light border-0 text-decoration-underline'}.


### PR DESCRIPTION
### Description
This PR moves the festival banner into a reusable partial so we can remove it from the homepage for now and reuse it next year.

### Related Github issues
Fixes #1719 
