### PR TITLE
Migrate admin edit announcements page to Bootstrap 5, add Edit buttons to announcements index page

### DIFF
--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -1,8 +1,11 @@
-#container
-  .row
-    .large-12.columns
+.container-fluid
+  .row.mb-4
+    .col
+      %h1 Edit announcement
+  .row.mb-4
+    .col
       = simple_form_for [:admin, @announcement] do |f|
         = f.association :groups, label_method: :to_s
         = f.input :message
         = f.input :expires_at, as: :string
-        = f.submit :update, class: 'button tiny'
+        = f.button :button, :update, class: 'btn btn-primary'

--- a/app/views/admin/announcements/index.html.haml
+++ b/app/views/admin/announcements/index.html.haml
@@ -1,33 +1,33 @@
 .container-fluid
-  .row.mb-3
+  .row.mb-4
     .col
       %h1 Announcements
-  .row
+  .row.border-bottom.border-primary
     .col
-      .row.border-bottom.border-primary
-        .col-3
-          %p.mb-2 Created by
-        .col-3
-          %p.mb-2 Message
-        .col-3
-          %p.mb-2 Groups
-        .col-3
-          %p.mb-2 Expires at
-      - @announcements.each do |announcement|
-        .row.mt-3
-          .col-3
-            .row
-              .col-2
-                = image_tag(announcement.created_by.avatar(24), alt: announcement.created_by.full_name)
-              .col-10
-                %p= announcement.created_by.full_name
-          .col-3
-            = dot_markdown(announcement.message)
-          .col-3
-            %ul
-              - announcement.groups.each do |group|
-                %li
-                  %p.mb-2= group.to_s
-          .col-3
-            - if announcement.expires_at.present?
-              %p=l(announcement.expires_at, format: :date)
+      %p.mb-2 Created by
+    .col-4
+      %p.mb-2 Message
+    .col
+      %p.mb-2 Groups
+    .col
+      %p.mb-2 Expires at
+    .col
+      %p.mb-2 Edit
+  - @announcements.each do |announcement|
+    .row.mt-3
+      .col
+        .d-flex.align-items-start
+          = image_tag(announcement.created_by.avatar(25), alt: announcement.created_by.full_name)
+          %p.ml-2.mb-0= announcement.created_by.full_name
+      .col-4
+        = dot_markdown(announcement.message)
+      .col
+        %ul
+          - announcement.groups.each do |group|
+            %li
+              %p.mb-2= group.to_s
+      .col
+        - if announcement.expires_at.present?
+          %p= l(announcement.expires_at, format: :date)
+      .col
+        = link_to 'Edit', edit_admin_announcement_path(announcement), class: 'border-0'

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -1,11 +1,11 @@
 .container-fluid
-  .row
+  .row.mb-4
     .col
-      %h1 New Announcement
+      %h1 New announcement
   .row.mb-4
     .col
       = simple_form_for [:admin, @announcement] do |f|
         = f.association :groups, label_method: :to_s
         = f.input :message
         = f.input :expires_at, as: :string
-        = f.submit :create, class: 'btn btn-primary'
+        = f.button :button, :create, class: 'btn btn-primary'


### PR DESCRIPTION
### Description
As above ☝🏻 

### Status
Ready for Review

### Related Github issue
None

### Screenshots
| Edit announcement before | Edit announcement after |
| --- | --- |
| ![Screenshot 2022-04-04 at 20-10-52 codebar](https://user-images.githubusercontent.com/5873816/161671486-177a5962-b91b-40df-881a-f2f22ccb1d9b.png) | ![Screenshot 2022-04-04 at 20-10-19 codebar](https://user-images.githubusercontent.com/5873816/161671518-858d21eb-7399-4703-8133-a3550129ce04.png) |

Announcement index page
![Screenshot 2022-04-04 at 20-10-35 codebar](https://user-images.githubusercontent.com/5873816/161671586-af8b4c3f-5a02-4253-bdb6-60b1122d04b6.png)