### PR TITLE
Migrate admin workshop page waiting list section to Bootstrap 5 classes

### DIFF
--- a/app/views/admin/workshop/_waiting_list.html.haml
+++ b/app/views/admin/workshop/_waiting_list.html.haml
@@ -1,33 +1,35 @@
 - if waiting_list.list.any?
-  .row
-    .large-12.columns
-      %strong Waiting List
-  .row
-    %table.attendances.large-12.columns
+  .mt-4
+    %strong Waiting list
+
+    %table.table.table-borderless.mt-3
+      %colgroup
+        %col
+        %col
+        %col{style: 'width: 40%;'}
+        %col
       %tbody
         - waiting_list.list.each do |list|
           - invitation = list.invitation
-          %tr.row
-            %td.small-1.columns
-              = link_to admin_workshop_invitation_path(@workshop, invitation, attending: true), class: 'waiting_list', method: :put, remote: true, title: 'Add to attendees' do
+          %tr
+            %td
+              = link_to admin_workshop_invitation_path(@workshop, invitation, attending: true), class: 'waiting_list border-0', method: :put, remote: true, title: 'Add to attendees' do
                 %i.far.fa-plus-square
-            %td.small-1.columns
-              = link_to admin_workshop_invitation_path(@workshop, invitation, attending: false), class: 'waiting_list_remove',
-              method: :put, remote: true, title: 'Remove from waitlist' do
+            %td
+              = link_to admin_workshop_invitation_path(@workshop, invitation, attending: false), class: 'waiting_list_remove border-0', method: :put, remote: true, title: 'Remove from waitlist' do
                 %i.far.fa-minus-square
-            %td.small-5.columns
+            %td
               - if MemberPresenter.new(invitation.member).newbie?
-                %span.has-tip{ 'data-tooltip': '', 'aria-haspopup': 'true',  title: 'New attendee.' }
-                  %i.fas.fa-paw-alt
-              = link_to admin_member_path(invitation.member) do
+                %span{'data-bs-toggle': 'tooltip', 'data-bs-placement': 'bottom', title: 'New attendee'}
+                  %i.fas.fa-paw
+              = link_to admin_member_path(invitation.member), class: 'border-0' do
                 - if invitation.member.full_name.blank?
                   = invitation.member.email
                 - else
                   = invitation.member.full_name
-            %td.small-5.columns
+            %td
               - if invitation.tutorial?
                 %small Tutorial: #{invitation.tutorial}
                 %br
               - if invitation.note?
-                %small=invitation.note
-                %br
+                %small Note: #{invitation.note}


### PR DESCRIPTION
### Description
This PR migrates the admin workshop page waiting list section to Bootstrap 5 classes.

Depends on #1725 for the new tooltip to work.

### Status
Ready for Review

### Screenshots
| Before | After |
| --- | --- |
| ![Screenshot 2022-04-06 at 19-26-31 codebar](https://user-images.githubusercontent.com/5873816/162108430-aa8ff1d6-dbd0-4ef9-a3ce-fd7e91a5bd94.png) | ![Screenshot 2022-04-06 at 19-22-49 codebar](https://user-images.githubusercontent.com/5873816/162108473-99b417c0-ac5b-439e-b5c9-db09fe0b5366.png) |