### PR TITLE
Delete the shared _title partial

### DIFF
--- a/app/views/shared/_title.html.haml
+++ b/app/views/shared/_title.html.haml
@@ -1,6 +1,0 @@
-%section.hero.opaque
-  .row
-    .medium-offset-1.medium-7.columns
-      %h2= title
-      - if date
-        %span.date= date

--- a/app/views/subscriptions/index.html.haml
+++ b/app/views/subscriptions/index.html.haml
@@ -1,37 +1,41 @@
-%section
-  = render partial: 'shared/title', locals: { title: 'Subscriptions', date: nil }
-
-.row.mt-4
-  .col.col-lg-9
-    %h3= t('subscriptions.mailing_list.title')
-    %p.lead= t('subscriptions.mailing_list.summary')
-    - if @member.subscribed_to_newsletter?
-      = simple_form_for @mailing_list, url: mailing_lists_path, method: :delete do |f|
-        = f.button :button, t('subscriptions.mailing_list.unsubscribe'), class: 'btn btn-success btn-lg'
-    - else
-      = simple_form_for @mailing_list, url: mailing_lists_path do |f|
-        = f.button :button, t('subscriptions.mailing_list.subscribe'), class: 'btn btn-success btn-lg'
-%hr
-
-.row
-  .col.col.col-lg-9
-    %p.lead= t('subscriptions.summary')
-
-- @groups.group_by(&:chapter).each do |chapter, groups|
-  .row.mb-4.border-bottom
+.container-fluid.stripe.reverse
+  .row
     .col
-      %h4= chapter.name
-  - groups.sort_by(&:name).each do |group|
-    .row.mb-3
+      %h1 Subscriptions
+
+.container-fluid
+  .row.mb-4
+    .col.col-lg-8
+      .card
+        .card-body
+          %h3= t('subscriptions.mailing_list.title')
+          %p= t('subscriptions.mailing_list.summary')
+          - if @member.subscribed_to_newsletter?
+            = simple_form_for @mailing_list, url: mailing_lists_path, method: :delete do |f|
+              = f.button :button, t('subscriptions.mailing_list.unsubscribe'), class: 'btn btn-success btn-lg mb-0'
+          - else
+            = simple_form_for @mailing_list, url: mailing_lists_path do |f|
+              = f.button :button, t('subscriptions.mailing_list.subscribe'), class: 'btn btn-success btn-lg mb-0'
+
+  .row.mb-4
+    .col.col.col-lg-8
+      %p.lead= t('subscriptions.summary')
+
+  - @groups.group_by(&:chapter).each do |chapter, groups|
+    .row.mb-4.border-bottom
       .col
-        %p= group.name
-      .col.col-md-4.col-lg-3
-        - if belongs_to_group?(group)
-          = simple_form_for :subscription, method: :delete, html: { class: 'w-100' } do |f|
-            = f.input :subscription_id, as: :hidden, input_html: { value: nil }
-            = f.input :group_id, as: :hidden, input_html: { value: group.id }
-            = f.button :button, 'Subscribed', class: 'btn btn-success btn-lg w-100', id: "#{chapter.name.downcase}-#{group.name.downcase}"
-        - else
-          = simple_form_for :subscription, html: { class: 'w-100' } do |f|
-            = f.input :group_id, as: :hidden, input_html: { value: group.id }
-            = f.button :button, 'Subscribe', class: 'btn btn-primary btn-lg w-100', id: "#{chapter.name.downcase}-#{group.name.downcase}"
+        %h4= chapter.name
+    - groups.sort_by(&:name).each do |group|
+      .row.mb-3
+        .col
+          %p= group.name
+        .col.col-md-4.col-lg-3
+          - if belongs_to_group?(group)
+            = simple_form_for :subscription, method: :delete, html: { class: 'w-100' } do |f|
+              = f.input :subscription_id, as: :hidden, input_html: { value: nil }
+              = f.input :group_id, as: :hidden, input_html: { value: group.id }
+              = f.button :button, 'Subscribed', class: 'btn btn-success btn-lg w-100', id: "#{chapter.name.downcase}-#{group.name.downcase}"
+          - else
+            = simple_form_for :subscription, html: { class: 'w-100' } do |f|
+              = f.input :group_id, as: :hidden, input_html: { value: group.id }
+              = f.button :button, 'Subscribe', class: 'btn btn-primary btn-lg w-100', id: "#{chapter.name.downcase}-#{group.name.downcase}"


### PR DESCRIPTION
### Description
This PR deletes the old shared _title partial as it was only used in one place (on the Subscriptions page) and looked a bit outdated.

Might be worth looking into creating a new title partial to standardize on how we present page titles but this can wait until we finished migrating the site to Bootstrap.

Depends on #1737 which is the only other place we use title but that view is about to be deleted.

### Status
Ready for Review

### Screenshots
| Subscription page before | Subscription page after |
| --- | --- |
| ![Screenshot 2022-04-11 at 19-49-12 codebar](https://user-images.githubusercontent.com/5873816/162869509-e7f9434d-ffd0-4276-85d6-b0d96df74a88.png) | ![Screenshot 2022-04-11 at 19-48-55 codebar](https://user-images.githubusercontent.com/5873816/162869558-cfa01e45-4054-4cb2-bb68-e5bb8204d74f.png) |