### PR TITLE
[Bugfix] Updates waitlist form on workshop invitation page to not require the presence of a tutorial for coaches

### DIFF
--- a/app/controllers/waiting_lists_controller.rb
+++ b/app/controllers/waiting_lists_controller.rb
@@ -7,8 +7,13 @@ class WaitingListsController < ApplicationController
     return back_with_message(@invitation.errors.full_messages) unless @invitation.valid?(:waitinglist)
 
     @invitation.save && WaitingList.add(@invitation, auto_rsvp)
-    message = auto_rsvp ? 'You have been added to the waiting list' :
+
+    message = if auto_rsvp
+      'You have been added to the waiting list'
+    else
       'We will send you an email if any spots become available'
+    end
+
     back_with_message(message)
   end
 

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -8,7 +8,7 @@ class WorkshopInvitation < ActiveRecord::Base
   validates :member_id, uniqueness: { scope: %i[workshop_id role] }
   validates :role, inclusion: { in: %w[Student Coach], allow_nil: true }
   validates :tutorial, presence: true, if: :student_attending?
-  validates :tutorial, presence: true, on: :waitinglist
+  validates :tutorial, presence: true, on: :waitinglist, if: :student_attending?
 
   scope :year, ->(year) { joins(:workshop).where('EXTRACT(year FROM workshops.date_and_time) = ?', year) }
   scope :attended, -> { where(attended: true) }

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe WorkshopInvitation, type: :model do
+  subject(:workshop_invitation) { Fabricate(:workshop_invitation) }
   it_behaves_like InvitationConcerns, :workshop_invitation, :workshop
 
   context 'defaults' do
@@ -13,7 +14,11 @@ RSpec.describe WorkshopInvitation, type: :model do
     it { is_expected.to validate_uniqueness_of(:member_id).scoped_to(:workshop_id, :role) }
     it { is_expected.to validate_inclusion_of(:role).in_array(%w[Student Coach]) }
 
-    it { is_expected.to validate_presence_of(:tutorial).on(:waitinglist) }
+    context 'if Student invitation' do
+      before { allow(subject).to receive(:student_attending?).and_return(true) }
+      it { is_expected.to validate_presence_of(:tutorial) }
+      it { is_expected.to validate_presence_of(:tutorial).on(:waitinglist) }
+    end
   end
 
   context 'scopes' do


### PR DESCRIPTION
### Problem
Two days ago a coach tried to join the waitlist for a workshop via the Join waiting list button on the workshop invitation page but couldn't because the model requires the presence of a tutorial which is not relevant for coaches.

The bug as reported by the coach:
![image](https://user-images.githubusercontent.com/5873816/164114794-8d836e17-dbec-41ce-bfcd-1e57229be66b.png)

### Solution
Updated the code to only check for the presence of a tutorial if a student tries to join the student waiting list. I also cheekily fixed a Rubocop offence in `app/controllers/waiting_lists_controller.rb` while I was there.

### Status
Ready for Review