### PR TITLE
Record admin RSVPs authors

### DIFF
--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -1,4 +1,5 @@
 class WorkshopInvitation < ActiveRecord::Base
+  include Auditor::Model
   include InvitationConcerns
 
   belongs_to :workshop
@@ -38,5 +39,13 @@ class WorkshopInvitation < ActiveRecord::Base
 
   def student_attending?
     for_student? && attending.present?
+  end
+
+  def admin_set_attending
+    return if activities.empty?
+
+    last_owner = activities.last.owner
+
+    return last_owner.full_name if last_owner.id != member_id
   end
 end

--- a/app/presenters/invitation_presenter.rb
+++ b/app/presenters/invitation_presenter.rb
@@ -10,4 +10,12 @@ class InvitationPresenter < BasePresenter
   def attendance_status
     model.attending ? 'Attending' : 'RSVP'
   end
+
+  def automated_rsvp_message
+    if model.admin_set_attending
+      "Added by #{model.admin_set_attending}"
+    else
+      'Waiting list'
+    end
+  end
 end

--- a/app/services/auditor.rb
+++ b/app/services/auditor.rb
@@ -11,8 +11,11 @@ module Auditor
 
     def log(&block)
       changes = model.changes
-      yield block if block
+      result = yield block if block
+
       create(changes)
+
+      result
     end
 
     def log_with_note(note)

--- a/app/views/admin/workshop/_attendances.html.haml
+++ b/app/views/admin/workshop/_attendances.html.haml
@@ -42,7 +42,7 @@
                 %i.fas.fa-history
                 =l(invitation.rsvp_time)
             - if invitation.automated_rsvp?
-              %span{'data-bs-toggle': 'tooltip', 'data-bs-placement': 'bottom', title: 'Waiting list or admin addition'}
+              %span{'data-bs-toggle': 'tooltip', 'data-bs-placement': 'bottom', title: invitation.automated_rsvp_message}
                 %p.mb-1.small
                   %i.fas.fa-magic
           - if invitation.reminded_at.present?

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Admin::InvitationsController, type: :controller do
       expect(flash[:notice]).to match("You have added")
     end
 
+    it "Records change author when updating an invitation" do
+      expect(invitation.activities.length).to eq(0)
+
+      put :update, id: invitation.token, workshop_id: workshop.id, attending: "true"
+
+      expect(invitation.activities.length).to eq(1)
+    end
+
     it "Warns the user about failed updates" do
       # Trigger an error when trying to update the `attending` attribute
       invitation.update_attribute(:tutorial, nil)

--- a/spec/presenters/invitation_presenter_spec.rb
+++ b/spec/presenters/invitation_presenter_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe InvitationPresenter do
+  let(:admin) { Fabricate(:chapter_organiser) }
   let(:invitation) { Fabricate(:student_workshop_invitation) }
   let(:invitation_presenter) { InvitationPresenter.new(invitation) }
 
@@ -17,6 +18,34 @@ RSpec.describe InvitationPresenter do
 
     it 'returns RSVP when not attending' do
       expect(invitation_presenter.attendance_status).to eq('RSVP')
+    end
+  end
+
+  context '#automated_rsvp_message' do
+    it 'returns name of admin that set attending when manually edited' do
+      audit = Auditor::Audit.new(invitation, :attending, admin)
+      audit.log do
+        invitation.update(
+          attending: true,
+          automated_rsvp: true,
+          rsvp_time: Time.zone.now
+        )
+      end
+
+      expect(invitation_presenter.automated_rsvp_message).to eq("Added by #{invitation.admin_set_attending}")
+    end
+
+    it 'returns waitlist message when user editied invitation' do
+      audit = Auditor::Audit.new(invitation, :attending, invitation.member)
+      audit.log do
+        invitation.update(
+          attending: true,
+          automated_rsvp: true,
+          rsvp_time: Time.zone.now
+        )
+      end
+
+      expect(invitation_presenter.automated_rsvp_message).to eq('Waiting list')
     end
   end
 end


### PR DESCRIPTION
This change will allow us to keep track of admin RSVPs and who triggers them. Tests are still missing, I’ll add them later.