### PR TITLE
Stop emailing students & coaches without TOC accepted

### DIFF
--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -29,8 +29,6 @@ class InvitationManager
 
   def invite_students_to_event(event, chapter)
     chapter_students(chapter).each do |student|
-      next unless student.accepted_toc_at
-
       invitation = Invitation.new(event: event, member: student, role: 'Student')
       EventInvitationMailer.invite_student(event, student, invitation).deliver_now if invitation.save
     end
@@ -38,8 +36,6 @@ class InvitationManager
 
   def invite_coaches_to_event(event, chapter)
     chapter_coaches(chapter).each do |coach|
-      next unless coach.accepted_toc_at
-
       invitation = Invitation.new(event: event, member: coach, role: 'Coach')
       EventInvitationMailer.invite_coach(event, coach, invitation).deliver_now if invitation.save
     end

--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -29,6 +29,8 @@ class InvitationManager
 
   def invite_students_to_event(event, chapter)
     chapter_students(chapter).each do |student|
+      next unless student.accepted_toc_at
+
       invitation = Invitation.new(event: event, member: student, role: 'Student')
       EventInvitationMailer.invite_student(event, student, invitation).deliver_now if invitation.save
     end
@@ -36,6 +38,8 @@ class InvitationManager
 
   def invite_coaches_to_event(event, chapter)
     chapter_coaches(chapter).each do |coach|
+      next unless coach.accepted_toc_at
+
       invitation = Invitation.new(event: event, member: coach, role: 'Coach')
       EventInvitationMailer.invite_coach(event, coach, invitation).deliver_now if invitation.save
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -20,6 +20,7 @@ class Member < ApplicationRecord
   validates :email, uniqueness: true
   validates :about_you, length: { maximum: 255 }
 
+  scope :accepted_toc, -> { where.not(accepted_toc_at: nil) }
   scope :order_by_email, -> { order(:email) }
   scope :subscribers, -> { joins(:subscriptions).order('created_at desc').uniq }
   scope :not_banned, lambda {
@@ -32,7 +33,9 @@ class Member < ApplicationRecord
                                 .where('meeting_invitations.meeting_id = ? and meeting_invitations.attending = ?',
                                        meeting.id, true)
                             }
-  scope :in_group, ->(members) { not_banned.joins(:groups).where(groups: { id: members.select(:id) }) }
+  scope :in_group, lambda { |members|
+    not_banned.accepted_toc.joins(:groups).where(groups: { id: members.select(:id) })
+  }
 
   scope :with_skill, ->(skill_name) { tagged_with(skill_name) }
 

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -66,6 +66,52 @@ RSpec.describe InvitationManager, type: :model do
 
       manager.send_event_emails(event, chapter)
     end
+
+    it 'emails only students that accepted toc' do
+      event = Fabricate(:event, chapters: [chapter], audience: 'Students')
+
+      first_student, *other_students = students
+      first_student.update(accepted_toc_at: nil)
+
+      expect(Invitation).to_not(
+        receive(:new).
+        with(event: event, member: first_student, role: 'Student').
+        and_call_original
+      )
+
+      other_students.each do |other_student|
+        expect(Invitation).to(
+          receive(:new).
+          with(event: event, member: other_student, role: 'Student').
+          and_call_original
+        )
+      end
+
+      manager.send_event_emails(event, chapter)
+    end
+
+    it 'emails only coaches that accepted toc' do
+      event = Fabricate(:event, chapters: [chapter], audience: 'Coaches')
+
+      first_coach, *other_coaches = coaches
+      first_coach.update(accepted_toc_at: nil)
+
+      expect(Invitation).to_not(
+        receive(:new).
+        with(event: event, member: first_coach, role: 'Coach').
+        and_call_original
+      )
+
+      other_coaches.each do |other_coach|
+        expect(Invitation).to(
+          receive(:new).
+          with(event: event, member: other_coach, role: 'Coach').
+          and_call_original
+        )
+      end
+
+      manager.send_event_emails(event, chapter)
+    end
   end
 
   describe '#send_monthly_attendance_reminder_emails', wip: true do


### PR DESCRIPTION
After talking with Kim about this a few weeks ago, we realised it doesn’t make much sense to email members that have not accepted our terms about new events. We see that as not having come back to codebar in a while, thus making more sense to save our resources.