### PR TITLE
Remove previous newsletters link

### DIFF
--- a/app/views/shared/_newsletter.html.haml
+++ b/app/views/shared/_newsletter.html.haml
@@ -31,4 +31,3 @@
             %input{ type: 'text', name: 'b_b4652d85b385945c79f2ffa2e_3798974cb3', tabindex: '-1', value: '' }
           .d-flex.justify-content-between.align-items-center
             %input.btn.btn-primary#mc-embedded-subscribe{ type: 'submit', value: 'Subscribe', name: 'subscribe' }
-            %a{ href: 'https://us8.campaign-archive.com/home/?u=b4652d85b385945c79f2ffa2e&id=3798974cb3' } View previous newsletters.


### PR DESCRIPTION
I don't think we should have this link so I am removing it

| Before | After |
|-------|------|
|<img width="948" alt="Screenshot 2022-05-30 at 17 42 11" src="https://user-images.githubusercontent.com/2683270/171025609-730d9840-8cba-4a6e-a616-7c015f4ae25d.png">|<img width="926" alt="Screenshot 2022-05-30 at 17 41 02" src="https://user-images.githubusercontent.com/2683270/171025564-ba9351d4-216e-4784-8586-e3be92e04cc2.png">|

