### PR TITLE
chore(1797): Invite everyone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,4 @@ TAGS
 
 # Ignore local uploads
 public/uploads/
-
 vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ TAGS
 
 # Ignore local uploads
 public/uploads/
+
+vendor/bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - spec/**/*
     - config/**/*
     - bin/**/*
+    - vendor/bundle/**/*
 
 require:
   - rubocop
@@ -17,7 +18,7 @@ require:
 Layout/LineLength:
   Max: 120
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Layout/EndOfLine:
   EnforcedStyle: lf
@@ -39,11 +40,11 @@ Rails/Date:
   Enabled: true
 
 Metrics/BlockLength:
-  ExcludedMethods: ['describe', 'context', 'draw', 'namespace']
+  ExcludedMethods: ["describe", "context", "draw", "namespace"]
 
 Performance:
   Exclude:
-    - '**/test/**/*'
+    - "**/test/**/*"
 
 Rails:
   Enabled: true
@@ -51,7 +52,7 @@ Rails:
 Rails/OutputSafety:
   Enabled: true
   Exclude:
-    - 'app/presenters/job_presenter.rb'
+    - "app/presenters/job_presenter.rb"
 
 Bundler/OrderedGems:
   Enabled: false
@@ -114,13 +115,13 @@ Layout/SpaceAroundOperators:
   Enabled: true
 
 Layout/SpaceBeforeComma:
-    Enabled: true
+  Enabled: true
 
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
 Layout/SpaceBeforeFirstArg:
-    Enabled: true
+  Enabled: true
 
 Layout/SpaceInsideBlockBraces:
   Enabled: true
@@ -159,7 +160,7 @@ Lint/UriEscapeUnescape:
 Metrics/MethodLength:
   Max: 10
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Style/AndOr:
   Enabled: true
@@ -167,15 +168,15 @@ Style/AndOr:
 Style/BlockComments:
   Enabled: true
   Exclude:
-    - 'spec/spec_helper.rb'
+    - "spec/spec_helper.rb"
 
 Style/CaseEquality:
   Enabled: false
 
 Style/CollectionMethods:
   PreferredMethods:
-    inject: 'inject'
-    reduce: 'inject'
+    inject: "inject"
+    reduce: "inject"
 
 Style/ColonMethodCall:
   Enabled: true
@@ -192,7 +193,7 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   Enabled: true
   Exclude:
-    - 'config/*.rb'
+    - "config/*.rb"
 
 Style/GuardClause:
   Enabled: false
@@ -253,12 +254,12 @@ Rails/Validation:
 Rails/SkipsModelValidations:
   Enabled: true
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 Rails/FilePath:
   Enabled: true
   Exclude:
-    - 'spec/rails_helper.rb'
+    - "spec/rails_helper.rb"
 
 RSpec/MultipleExpectations:
   Max: 2
@@ -269,7 +270,7 @@ RSpec/ExampleLength:
 RSpec/SubjectStub:
   Enabled: true
   Exclude:
-    - 'spec/models/job_spec.rb'
+    - "spec/models/job_spec.rb"
 
 RSpec/NestedGroups:
   Max: 5

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -22,7 +22,7 @@ class EventInvitationMailer < ActionMailer::Base
     @host_address = AddressPresenter.new(@event.venue.address)
     @everyone_is_invited = !event.audience
 
-    mail(mail_args(member, @everyone_is_invited ? "Coach Invitation: #{@event.name}" : "Invitation: #{@event.name}"),
+    mail(mail_args(member, @everyone_is_invited ? "Invitation: #{@event.name}" : "Coach Invitation: #{@event.name}"),
          &:html)
   end
 

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -20,9 +20,10 @@ class EventInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
     @host_address = AddressPresenter.new(@event.venue.address)
-    @everyone_is_invited = event.audience.empty?
+    @everyone_is_invited = !event.audience
 
-    mail(mail_args(member, @everyone_is_invited ? "Coach Invitation: #{@event.name}" : "Coach Invitation: #{@event.name}"), &:html)
+    mail(mail_args(member, @everyone_is_invited ? "Coach Invitation: #{@event.name}" : "Invitation: #{@event.name}"),
+         &:html)
   end
 
   def attending(event, member, invitation)

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -20,10 +20,9 @@ class EventInvitationMailer < ActionMailer::Base
     @member = member
     @invitation = invitation
     @host_address = AddressPresenter.new(@event.venue.address)
+    @everyone_is_invited = event.audience.empty?
 
-    subject = "Coach Invitation: #{@event.name}"
-
-    mail(mail_args(member, subject), &:html)
+    mail(mail_args(member, @everyone_is_invited ? "Coach Invitation: #{@event.name}" : "Coach Invitation: #{@event.name}"), &:html)
   end
 
   def attending(event, member, invitation)

--- a/app/views/event_invitation_mailer/invite_coach.html.haml
+++ b/app/views/event_invitation_mailer/invite_coach.html.haml
@@ -1,7 +1,7 @@
-= render partial: 'shared_mailers/header', locals: { title: 'Coach Event Invitation' }
+= render partial: 'shared_mailers/header', locals: { title: @everyone_is_invited ? 'Event Invitation' : 'Coach Event Invitation' }
 %body{ bgcolor: '#FFFFFF' }
 
-  = render partial: 'shared_mailers/body_header', locals: { title: 'Coach Event Invitation' }
+  = render partial: 'shared_mailers/body_header', locals: { title: @everyone_is_invited ? 'Event Invitation' : 'Coach Event Invitation' }
 
   %table{ class: 'body-wrap'}
     %tr

--- a/db/migrate/20220821112614_audience_array_field.rb
+++ b/db/migrate/20220821112614_audience_array_field.rb
@@ -1,6 +1,0 @@
-class AudienceArrayField < ActiveRecord::Migration
-  def change
-    change_column :events, :audience, :string, array: true, using: "(string_to_array(audience, ','))"
-  end
-
-end

--- a/db/migrate/20220821112614_audience_array_field.rb
+++ b/db/migrate/20220821112614_audience_array_field.rb
@@ -1,0 +1,6 @@
+class AudienceArrayField < ActiveRecord::Migration
+  def change
+    change_column :events, :audience, :string, array: true, using: "(string_to_array(audience, ','))"
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220821112614) do
+ActiveRecord::Schema.define(version: 20201120012812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -234,7 +234,7 @@ ActiveRecord::Schema.define(version: 20220821112614) do
     t.string   "external_url"
     t.boolean  "confirmation_required", default: false
     t.boolean  "surveys_required",      default: false
-    t.string   "audience",                                           array: true
+    t.string   "audience",
     t.boolean  "remote",                default: false, null: false
     t.string   "timezone"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,9 +234,7 @@ ActiveRecord::Schema.define(version: 20201120012812) do
     t.string   "external_url"
     t.boolean  "confirmation_required", default: false
     t.boolean  "surveys_required",      default: false
-    t.string   "audience",
-    t.boolean  "remote",                default: false, null: false
-    t.string   "timezone"
+    t.string   "audience"
   end
 
   add_index "events", ["slug"], name: "index_events_on_slug", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201120012812) do
+ActiveRecord::Schema.define(version: 20220821112614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,7 +130,7 @@ ActiveRecord::Schema.define(version: 20201120012812) do
     t.string   "surname"
     t.string   "email"
     t.boolean  "mailing_list_consent", default: false
-    t.string   "token", null: false
+    t.string   "token",                                null: false
   end
 
   add_index "contacts", ["email", "sponsor_id"], name: "index_contacts_on_email_and_sponsor_id", unique: true, using: :btree
@@ -234,7 +234,9 @@ ActiveRecord::Schema.define(version: 20201120012812) do
     t.string   "external_url"
     t.boolean  "confirmation_required", default: false
     t.boolean  "surveys_required",      default: false
-    t.string   "audience"
+    t.string   "audience",                                           array: true
+    t.boolean  "remote",                default: false, null: false
+    t.string   "timezone"
   end
 
   add_index "events", ["slug"], name: "index_events_on_slug", unique: true, using: :btree

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe EventInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }
+  let(:coach_event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event', audience: 'Coaches') }
   let(:member) { Fabricate(:member) }
   let(:invitation) { Fabricate(:invitation, event: event, member: member) }
 
@@ -14,12 +15,22 @@ RSpec.describe EventInvitationMailer, type: :mailer do
     expect(email.body.encoded).to match('hello@codebar.io')
   end
 
-  it '#invite_coach' do
-    email_subject = "Coach Invitation: #{event.name}"
-    EventInvitationMailer.invite_coach(event, member, invitation).deliver_now
+  describe '#invite_coach' do
+    it 'sends a generic invitation if the event has no audiencce' do
+      email_subject = "Invitation: #{event.name}"
+      EventInvitationMailer.invite_coach(event, member, invitation).deliver_now
 
-    expect(email.subject).to eq(email_subject)
-    expect(email.body.encoded).to match('hello@codebar.io')
+      expect(email.subject).to eq(email_subject)
+      expect(email.body.encoded).to match('hello@codebar.io')
+    end
+
+    it 'sends a coach invitation of the event is for coaches' do
+      email_subject = "Coach Invitation: #{event.name}"
+      EventInvitationMailer.invite_coach(coach_event, member, invitation).deliver_now
+
+      expect(email.subject).to eq(email_subject)
+      expect(email.body.encoded).to match('hello@codebar.io')
+    end
   end
 
   it '#attending' do


### PR DESCRIPTION
fixes #1797

now, when a specific audience is not selected, the invitation emails no longer mention coaches and students.