### PR TITLE
explicity wraps the button to a new row on the events page dropdown

### DIFF
--- a/app/views/admin/events/_invitation_management.html.haml
+++ b/app/views/admin/events/_invitation_management.html.haml
@@ -16,6 +16,7 @@
                 { class: 'chosen-select', required: true,
                 data: { placeholder: t('messages.invitations.select_a_member_to_rsvp') } }
       = f.hidden_field :event_id, value: @event.id
+  .row.mb-4
     .col-auto
       = f.button :button, 'Add', class: 'btn btn-sm btn-primary mb-0 mr-2'
       %span{ "data-tooltip" => true, "aria-haspopup" => "true", class: "has-tip", title: t('admin.workshop.manage_rsvps.text') }


### PR DESCRIPTION
Closes #1813 

#1813 is caused by a name that's too long appearing in the drop-down. I don't think we can prevent the drop-down extending for long text so I think the best option is to explicitly put the button on a new line.

### Screenshot

![image](https://user-images.githubusercontent.com/6391616/192492733-02c2d3ca-9938-4dd2-bba6-6e3de44971e4.png)


### With Long Name

![image](https://user-images.githubusercontent.com/6391616/192492875-639bdd70-8973-46bd-b8f0-772296b8febe.png)
