### PR TITLE
adds future workshop checks before displaying badges about attendance

### DIFF
--- a/app/views/workshops/_actions.html.haml
+++ b/app/views/workshops/_actions.html.haml
@@ -4,7 +4,7 @@
   - if @workshop.past? and !logged_in?
     %p= t('workshops.sign_up_to_be_invited')
   - else
-    - if logged_in?
+    - if logged_in? and @workshop.future?
       - if @workshop.attendee?(current_user)
         %p.badge.bg-success= t('workshops.already_attending')
       - elsif @workshop.waitlisted?(current_user)


### PR DESCRIPTION
Closes #1812 

This PR adds a check to ensure the workshop is in the future before displaying badges about attendance. If the workshop has already happened the badges are not required