### PR TITLE
Don’t raise an exception on SIGTERM

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,6 +6,7 @@ preload_app!
 rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
+raise_exception_on_sigterm false
 
 on_worker_boot do
   # worker specific setup


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/385232/196027851-916760c8-881d-40c5-8e7a-1a77d48ec549.png)

Looking at our Rollbar quota, the large majority of the errors we get there come from, I believe, the recurring Heroku restart that happens. I see no reason to report these to Rollbar, since they are expected and, at least while using Heroku, necessary.

Luckily, looks like [Puma has an option for this][0], so it makes sense to me to turn it on (or rather off, since we’re setting it to `false`). [Found it][1] while doing some research on this subject, since I’ve had a feeling I’ve seen it before.

[0]: https://www.rubydoc.info/gems/puma/Puma%2FDSL:raise_exception_on_sigterm
[1]: https://github.com/puma/puma/issues/1438