### PR TITLE
Add more context to background jobs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: rake jobs:work
+worker: bundle exec rake jobs:workoff --trace


### PR DESCRIPTION
For some reason, these background jobs seem to break frequently. Heroku logs are not telling us much, so hopfully with this commit:
- we’ll get more information thanks to the `--trace` option
- we’ll stop the worker when there is no works to do, instead of keeping it running