### PR TITLE
Add checkbox to admin new announcement form that, when checked sends announcement to every group

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -11,6 +11,11 @@ class Admin::AnnouncementsController < Admin::ApplicationController
 
   def create
     @announcement = Announcement.new(announcement_params.merge!(created_by: current_user))
+    if announcement_params[:all_groups]
+      group_ids = Group.joins(:chapter).where(chapters: { active: true }).pluck(:id)
+      @announcement.group_ids = group_ids
+    end
+
     return redirect_to admin_announcements_path, notice: 'Announcement successfully created' if @announcement.save
 
     flash['notice'] = 'Please make sure you fill in all mandatory fields'
@@ -31,6 +36,6 @@ class Admin::AnnouncementsController < Admin::ApplicationController
   end
 
   def announcement_params
-    params.require(:announcement).permit(:message, :expires_at, group_ids: [])
+    params.require(:announcement).permit(:all_groups, :message, :expires_at, group_ids: [])
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -6,5 +6,7 @@ class Announcement < ActiveRecord::Base
 
   scope :active, -> { where('expires_at > ?', Date.current) }
 
+  attr_accessor :all_groups
+
   validates :message, presence: true
 end

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -6,7 +6,8 @@
   .row
     .col.col-md-10.col-lg-8
       = simple_form_for [:admin, @announcement] do |f|
-        = f.association :groups, label_method: :to_s
+        = f.association :groups, label: 'Select groups'
+        = f.input :all_groups, as: :boolean, checked_value: true, unchecked_value: false, label: 'Send to all groups'
         = f.input :message, input_html: { rows: 3 }
         = f.input :expires_at, as: :string
         .text-right

--- a/spec/features/admin/announcements_spec.rb
+++ b/spec/features/admin/announcements_spec.rb
@@ -52,5 +52,29 @@ RSpec.feature 'Announcements', type: :feature do
       expect(page).to have_content(announcement.message)
       expect(page).to have_content(old_announcement.message)
     end
+
+    scenario 'can successfully send a new announcement to every group' do
+      visit new_admin_announcement_path
+      fill_in 'Message', with: 'An announcement to every group'
+      check 'Send to all groups'
+      click_on 'create'
+
+      expect(page).to have_content('An announcement to every group')
+      expect(page).to have_content("Coaches #{chapter.name}")
+      expect(page).to have_content("Students #{chapter.name}")
+      expect(page.current_path).to eq(admin_announcements_path)
+    end
+
+    scenario 'can successfully send a new announcement to selected groups' do
+      visit new_admin_announcement_path
+      fill_in 'Message', with: 'An announcement to selected groups'
+      select "Coaches", from: 'Select group'
+      click_on 'create'
+
+      expect(page).to have_content('An announcement to selected groups')
+      expect(page).to have_content("Coaches #{chapter.name}")
+      expect(page).to_not have_content("Students #{chapter.name}")
+      expect(page.current_path).to eq(admin_announcements_path)
+    end
   end
 end


### PR DESCRIPTION
Closes #1791 

### Description
This PR adds a checkbox to the admin new announcement form labeled 'Send to all groups'. When the checkbox is checked, the announcement is sent to every group.

@KimberleyCook just a note that I only added this checkbox to the new announcement page. I figured when editing an announcement you could remove/add groups via the 'Select groups' dropdown as necessary.

### Status
Ready for Review

### Screenshots
<img width="1440" alt="Screenshot 2022-11-02 at 2 36 16 pm" src="https://user-images.githubusercontent.com/5873816/199607198-71e2fc36-bae9-4fd6-a14e-3714601cdb69.png">