### PR TITLE
Update EventCalendar service to only include address if event has one

### DIFF
--- a/lib/services/event_calendar.rb
+++ b/lib/services/event_calendar.rb
@@ -13,13 +13,13 @@ class EventCalendar
   private
 
   def setup_event
-    address = AddressPresenter.new(event.venue.address)
+    address = AddressPresenter.new(event.venue.address) if event.venue.present?
     calendar.event do |e|
       e.organizer = event.email.to_s
       e.dtstart = event.date_and_time
       e.dtend = event.ends_at
       e.summary = event.name
-      e.location = address.to_s
+      e.location = address&.to_s
       e.ip_class = 'PRIVATE'
     end
   end


### PR DESCRIPTION
### Description
We recently introduced remote events in #1798 but forgot to update the `EventCalendar` service to only include the address in the invitation if the event has one.

### Status
Ready for Review