### PR TITLE
Add admin testimonials index view

### DIFF
--- a/app/controllers/admin/testimonials_controller.rb
+++ b/app/controllers/admin/testimonials_controller.rb
@@ -1,0 +1,7 @@
+class Admin::TestimonialsController < SuperAdmin::ApplicationController
+  def index
+    @testimonials = Testimonial.includes(:member).all
+
+    authorize @testimonials
+  end
+end

--- a/app/policies/testimonial_policy.rb
+++ b/app/policies/testimonial_policy.rb
@@ -1,0 +1,5 @@
+class TestimonialPolicy < ApplicationPolicy
+  def index?
+    user.has_role?(:admin)
+  end
+end

--- a/app/views/admin/testimonials/index.html.haml
+++ b/app/views/admin/testimonials/index.html.haml
@@ -1,0 +1,25 @@
+.container.py-4.py-lg-5
+  .row.mb-4
+    .col
+      %h1 Testimonials
+
+  .row
+    .col
+      %table.table.table-striped.table-hover
+        %thead
+          %tr
+            %th
+              Name
+            %th
+              Text
+            %th
+              Status
+            %th
+              Actions
+        %tbody
+          - @testimonials.each do |testimonial|
+            %tr
+              %td= testimonial.member.full_name
+              %td= testimonial.text
+              %td
+              %td

--- a/app/views/layouts/_admin_menu.html.haml
+++ b/app/views/layouts/_admin_menu.html.haml
@@ -27,6 +27,9 @@
 %li
   = link_to new_admin_group_path, class: 'dropdown-item' do
     New group
+%li
+  = link_to admin_testimonials_path, class: 'dropdown-item' do
+    Testimonials
 
 - if current_user.has_role?(:organiser, :any)
   %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,8 @@ Planner::Application.routes.draw do
       resource :invitations, only: [:update]
       resources :invitations, only: [:update]
     end
+
+    resources :testimonials, only: %i[index]
   end
 
   get   '/login', to: 'auth_services#new'

--- a/spec/features/admin/managing_testimonials_spec.rb
+++ b/spec/features/admin/managing_testimonials_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.feature 'Managing testimonials', type: :feature do
+  let(:member) { Fabricate(:member) }
+
+  scenario 'non admin cannot manage testimonials' do
+    login(member)
+
+    visit admin_testimonials_path
+    expect(current_url).to eq(root_url)
+    expect(page).to have_content("You can't be here")
+  end
+
+  context 'an admin member' do
+    before do
+      login_as_admin(member)
+    end
+
+    scenario 'can view a list of testimonials' do
+      testimonial = Fabricate(:testimonial)
+
+      visit admin_testimonials_path
+
+      expect(page).to have_content('Testimonials')
+      expect(page).to have_content(testimonial.text)
+    end
+  end
+end


### PR DESCRIPTION
### Description
This is the first step in allowing members to leave testimonials aka #1438. This PR adds an admin index view where admins eventually will be able to manage testimonials.

### Status
Ready for Review

### Related Github issue
#1438

### Screenshots
<img width="1439" alt="Screenshot 2022-11-15 at 10 31 29 pm" src="https://user-images.githubusercontent.com/5873816/202101934-a42d5056-df37-43bc-aea3-d63b2d2569c0.png">