### PR TITLE
Add banner to homepage for impact report

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,5 +1,8 @@
 - title t('homepage.title')
 
+.alert.alert-dark.mb-0.text-center
+  We’re beyond proud to launch our <strong>first-ever</strong> Impact Report, which you can read here - <a href="https://impact-report-22.codebar.io/" class="text-dark" target="_blank"">impact-report-22.codebar.io</a>
+
 .homepage-hero.d-flex.align-items-center
   .container.d-flex
     .col-md-5.offset-md-1.p-3.text

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -11,6 +11,7 @@
 
       .col-sm-12.col-md-6.col-lg-3
         %ul.list-unstyled.ml-0
+          %li= link_to 'Impact Report 2022', "https://impact-report-22.codebar.io/"
           %li= link_to t("navigation.code_of_conduct"), code_of_conduct_path
           %li= link_to t("navigation.breach_code_of_conduct"), breach_code_of_conduct_path
           %li= link_to t("navigation.coach_guide"), teaching_guide_path


### PR DESCRIPTION
Add a banner to the homepage for the Impact Report and a link in the footer.

<img width="1434" alt="Screenshot 2022-11-17 at 18 46 23" src="https://user-images.githubusercontent.com/2683270/202519659-5a7a77ee-065a-4350-9647-8df321511c7a.png">
