### PR TITLE
Add local variables to Rollbar stacktraces

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -66,4 +66,9 @@ Rollbar.configure do |config|
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+
+  # https://docs.rollbar.com/docs/ruby#section-enabling-local-variables-in-stack-traces
+  config.send_extra_frame_data = :app
+  config.locals = { :enabled => true }
+  config.backtrace_cleaner = ActiveSupport::BacktraceCleaner.new
 end


### PR DESCRIPTION
Documentation: https://docs.rollbar.com/docs/ruby#section-enabling-local-variables-in-stack-traces

This should give us more context on Rollbar, adding the values of local variables in order for us to debug issues more efficiently. 