### PR TITLE
Temporarily hide the manual RSVP dropdown on the admin event page

### DIFF
--- a/app/views/admin/events/_invitation_management.html.haml
+++ b/app/views/admin/events/_invitation_management.html.haml
@@ -7,20 +7,19 @@
           %br
           <strong>#{@attending_students.count}</strong> are attending as students and <strong>#{@attending_coaches.count}</strong> as coaches.
 
-= simple_form_for :invitation, url: admin_invitation_path, method: :put do |f|
-  .row.mb-4
-    .col-auto
-      = f.select :id,
-                @event.invitations.not_accepted.all.map { |u| [ "#{u.member.full_name} (#{u.role})", u.token] },
-                { include_blank: true },
-                { class: 'chosen-select', required: true,
-                data: { placeholder: t('messages.invitations.select_a_member_to_rsvp') } }
-      = f.hidden_field :event_id, value: @event.id
-  .row.mb-4
-    .col-auto
-      = f.button :button, 'Add', class: 'btn btn-sm btn-primary mb-0 mr-2'
-      %span{ "data-tooltip" => true, "aria-haspopup" => "true", class: "has-tip", title: t('admin.workshop.manage_rsvps.text') }
-        %i.fas.fa-info-circle
+-# = simple_form_for :invitation, url: admin_invitation_path, method: :put do |f|
+-#   .row.mb-4
+-#     .col-auto
+-#       = f.select :id,
+-#                 @event.invitations.not_accepted.all.map { |u| [ "#{u.member.full_name} (#{u.role})", u.token] },
+-#                 { include_blank: true },
+-#                 { class: 'chosen-select', required: true,
+-#                 data: { placeholder: t('messages.invitations.select_a_member_to_rsvp') } }
+-#       = f.hidden_field :event_id, value: @event.id
+-#     .col-auto
+-#       = f.button :button, 'Add', class: 'btn btn-sm btn-primary mb-0 mr-2'
+-#       %span{ "data-tooltip" => true, "aria-haspopup" => "true", class: "has-tip", title: t('admin.workshop.manage_rsvps.text') }
+-#         %i.fas.fa-info-circle
 
 .row
   .col-12.col-md-6


### PR DESCRIPTION
### Description
This PR temporarily hides the manual RSVP dropdown on the admin event page that prevents the page from loading if every chapter has been invited to an event (too many invitations!).

### Status
Ready for Review