### PR TITLE
Fixes rb#461

### DIFF
--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -1,6 +1,6 @@
 class AuthServicesController < ApplicationController
   def new
-    referer_path = URI(request.referer).path
+    referer_path = URI(request.referer).path if request.referer
     if Rails.application.routes.recognize_path(referer_path)[:controller].in?(%w[workshops events meetings])
       session[:referer_path] = referer_path
     end

--- a/spec/controllers/auth_services_controller_spec.rb
+++ b/spec/controllers/auth_services_controller_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe AuthServicesController, type: :controller do
+  describe "GET #new" do
+    it "redirects when referer is missing" do
+      expected_referer_path = nil
+      request.env["HTTP_REFERER"] = expected_referer_path
+
+      get :new
+      expect(response).to redirect_to("/auth/github")
+      expect(session[:referer_path]).to eq(expected_referer_path)
+    end
+
+    it "redirects when referer is present" do
+      expected_referer_path = "workshops/42"
+      request.env["HTTP_REFERER"] = expected_referer_path
+
+      get :new
+      expect(response).to redirect_to("/auth/github")
+      expect(session[:referer_path]).to eq(expected_referer_path)
+    end
+  end
+end


### PR DESCRIPTION
Rollbar was complaining when we hit this endpoint without a referer. `referer_path = URI(request.referer).path` line was blowing up whenever `request.referer` was not present.