### PR TITLE
Mark no attendance as secondary

### DIFF
--- a/app/views/admin/events/_event.html.haml
+++ b/app/views/admin/events/_event.html.haml
@@ -2,12 +2,13 @@
   .card.mb-4
     - if event.date_and_time.past?
       .attendance
-        - if (invitation.is_a?(WorkshopInvitation) && invitation.attended?)
-          .attended.p-1.text-white.bg-success
-            Attended
-        - elsif (invitation.is_a?(WorkshopInvitation) && !invitation.attended?)
-          .not-attended.p-1.text-white.bg-danger
-            Not attended
+        - if invitation.is_a? WorkshopInvitation
+          - if invitation.attended?
+            .attended.p-1.text-white.bg-success
+              Attended
+          - else
+            .not-attended.p-1.text-white.bg-danger
+              Not attended
         - else
           .no-attendance.p-1.text-white.bg-secondary
             No attendance data

--- a/app/views/admin/events/_event.html.haml
+++ b/app/views/admin/events/_event.html.haml
@@ -3,13 +3,13 @@
     - if event.date_and_time.past?
       .attendance
         - if (invitation.is_a?(WorkshopInvitation) && invitation.attended?)
-          .attended.p-1.bg-success
+          .attended.p-1.text-white.bg-success
             Attended
         - elsif (invitation.is_a?(WorkshopInvitation) && !invitation.attended?)
-          .not-attended.p-1.bg-danger
+          .not-attended.p-1.text-white.bg-danger
             Not attended
         - else
-          .no-attendance.p-1.bg-secondary.text-white
+          .no-attendance.p-1.text-white.bg-secondary
             No attendance data
     .card-body
       .d-md-flex.justify-content-md-between

--- a/app/views/admin/events/_event.html.haml
+++ b/app/views/admin/events/_event.html.haml
@@ -9,7 +9,7 @@
           .not-attended.p-1.bg-danger
             Not attended
         - else
-          .no-attendance.p-1.bg-danger
+          .no-attendance.p-1.bg-secondary.text-white
             No attendance data
     .card-body
       .d-md-flex.justify-content-md-between


### PR DESCRIPTION
- Changes the background of _No attendance info_ from red to grey, so we can more easily distinguish it from the actual _no shows_
- Changes the text to all attendances (_show, no show, no attendance info_) to white, so it’s easier to read
- Simplifies the template logic a bit, so it’s easier to read and understand

| before | after |
|-|-|
| ![codebar-01-before](https://github.com/codebar/planner/assets/385232/77187395-0b84-42af-b477-b0fc3bbe4054) | ![codebar-02-after](https://github.com/codebar/planner/assets/385232/8354e9c9-0678-458c-92e2-d5f321e45477) |


