### PR TITLE
Raise 404 when event is not found

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,7 +26,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    event = Event.find_by(slug: params[:id])
+    event = Event.find_by!(slug: params[:id])
 
     @event = EventPresenter.new(event)
     @host_address = AddressPresenter.new(@event.venue.address) if @event.venue.present?

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -6,7 +6,7 @@
         %br
         %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
     .col-12.col-md-9
-      %p.lead= @event.description.html_safe
+      %p.lead= sanitize(@event.description)
 
   .row
     .col


### PR DESCRIPTION
fixes rb#464

We were trying to call a method on the `venue` of an event that was never found.