### PR TITLE
Ignore subscription if not found

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -21,12 +21,15 @@ class SubscriptionsController < ApplicationController
   end
 
   def destroy
-    @subscription = current_user.subscriptions.find_by(group_id: group_id)
-    @subscription.destroy
+    # Don't error if subscription is not found
+    subscription = current_user.subscriptions.find_by(group_id: group_id)
+    subscription&.destroy
 
+    # Instead, rely on the group's existence (rather than the subscription)
+    group = Group.find(group_id)
     flash[:notice] = I18n.t('subscriptions.messages.group.unsubscribe',
-                            chapter: @subscription.group.chapter.city,
-                            role: @subscription.group.name)
+                            chapter: group.chapter.city,
+                            role: group.name)
 
     redirect_to :back
   end


### PR DESCRIPTION
If a user is trying to unsubscribe from a non-existing subscription (i.e. no longer a student/coach), just say yes and move on. No need to record that on Rollbar. Rely on the group to show the success toast.

Fixes: https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/474