### PR TITLE
Login before accepting TOC

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,6 +61,13 @@ class ApplicationController < ActionController::Base
 
   def accept_terms
     store_path
+
+    unless logged_in?
+      # https://guides.rubyonrails.org/layouts_and_rendering.html#avoiding-double-render-errors
+      redirect_to redirect_path
+      return
+    end
+
     redirect_to terms_and_conditions_path if current_user.accepted_toc_at.blank?
   end
 

--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -7,6 +7,8 @@ class Member::DetailsController < ApplicationController
 
   def edit
     accept_terms
+    # https://apidock.com/rails/ActionController/Metal/performed%3F
+    return if performed?
 
     flash[notice] = I18n.t('notifications.signing_up')
     @member.newsletter ||= true

--- a/spec/controllers/details_controller_spec.rb
+++ b/spec/controllers/details_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe Member::DetailsController, type: :controller do
+  describe "GET edit" do
+    context "When a user is not logged in" do
+      it "redirects to GitHub authentication" do
+        get :edit
+        expect(response).to redirect_to("/auth/github")
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a user is not logged in, instead of erring if someone is trying to access a member edit page, redirect them to the login page (through GitHub). Fixes [rb#465](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/465).