### PR TITLE
Fix: explicitly set CarrierWave.config.cache_storage

### DIFF
--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,4 +1,6 @@
 CarrierWave.configure do |config|
+  config.cache_storage = :file
+
   if Rails.env.development?
     config.storage = :file
   elsif Rails.env.production?


### PR DESCRIPTION
CarrierWave had been updated so that we need to explicitly specify config.cache_storage, see https://github.com/carrierwaveuploader/carrierwave/commit/629afecbaeccd2300e4660b78ee36bd95dd845c5