### PR TITLE
Add missing .btn class to buttons on member/new page

### DIFF
--- a/app/views/members/new.html.haml
+++ b/app/views/members/new.html.haml
@@ -18,9 +18,9 @@
         %p.lead
           = t('members.new.students.github')
         .d-flex.flex-column.align-items-start
-          = link_to registration_path(member_type: 'student'), class: 'btn-lg btn-primary mb-4 text-decoration-none' do
+          = link_to registration_path(member_type: 'student'), class: 'btn btn-lg btn-primary mb-4 text-decoration-none' do
             = t('members.sign_up_as_student')
             %i.fab.fa-github
-          = link_to registration_path(member_type: 'coach'), class: 'btn-lg btn-primary text-decoration-none' do
+          = link_to registration_path(member_type: 'coach'), class: 'btn btn-lg btn-primary text-decoration-none' do
             = t('members.sign_up_as_coach')
             %i.fab.fa-github


### PR DESCRIPTION
### Description
The two buttons on the member/new page were missing the required .btn class. Looks like previously Bootstrap inferred buttonness from .btn-primary etc but latest Bootstrap requires the .btn class.

### Status
Ready for Review

### Screenshots
| Before | After |
| --- | --- |
| <img width="1470" alt="Screenshot 2023-08-04 at 12 16 53 am" src="https://github.com/codebar/planner/assets/5873816/61f7b880-d2f8-408d-b0a9-9eada788fff5"> | <img width="1470" alt="Screenshot 2023-08-04 at 12 16 32 am" src="https://github.com/codebar/planner/assets/5873816/81a01939-0ebe-46a0-8c27-d63135fbc96f"> |