### PR TITLE
Apple Silicon support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2
+FROM --platform=linux/amd64 ruby:3.2.2
 
 # Default node version on apt is old. This makes sure a recent version is installed
 # This step also runs apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN set -ex; \
 WORKDIR /planner
 
 COPY Gemfile Gemfile.lock ./
-RUN bundle install --jobs 4
+RUN gem install bundler:2.4.17 && bundle install --jobs 4
 
 COPY . ./

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The current Dockerfile and docker-compose were closely copied from [the Docker g
 
 **Note:** If you are using Windows, you can run `bin/dbuild` using Git Bash.
 
+**Note:** If you are using a Mac with an Apple Silicon processer (M1, M2, etc) you will need to enable the following option in Docker's settings:
+> Use Rosetta for x86/amd64 emulation on Apple Silicon
+
 ### 4. Run the tests
 
 Run `bin/drake` to run all the tests and make sure everything works.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.4'
 services:
   db:
     image: postgres
+    platform: "linux/amd64"
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.4'
 services:
   db:
     image: postgres
@@ -7,6 +7,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password
   web:
+    platform: "linux/amd64"
     env_file:
       - docker-compose.env
     build: .


### PR DESCRIPTION
Building the application using Docker on Apple Silicon (M1, M2, etc) fails with the following error in the step where it attempts to install Google Chrome:

```
7.332 + apt-get install -y --force-yes google-chrome-stable --no-install-recommends
7.341 Reading package lists...
7.723 Building dependency tree...
7.805 Reading state information...
7.864 W: --force-yes is deprecated, use one of the options starting with --allow instead.
7.864 E: Unable to locate package google-chrome-stable
------
failed to solve: process "/bin/sh -c set -ex;     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -     && wget -q -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -     && sh -c 'echo \"deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main\" >> /etc/apt/sources.list.d/google.list'     && apt-get update     && apt-get install -y --force-yes google-chrome-stable --no-install-recommends     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

By default, Docker will use images that match the host architecture (ie. `linux/arm64/v8` on Apple Silicon). The above `apt` repo does not have an ARM version of Google Chrome.

This PR addresses the problem by making it explicit that Docker should always use the `linux/amd64` versions of images.

It also addresses another Apple Silicon-related error message and a bundler-related warning. See the individual commit messages for more details.

---

Note that the main goal of this PR is to get _building_ of the project to complete via Docker.