### PR TITLE
gShow today’s workshop(s) as upcoming

### DIFF
--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -23,7 +23,7 @@ class Admin::ChaptersController < Admin::ApplicationController
   def show
     authorize(@chapter)
 
-    @workshops = @chapter.workshops.upcoming
+    @workshops = @chapter.workshops.today_and_upcoming
     @sponsors = @chapter.sponsors.uniq
     @groups = @chapter.groups
     @subscribers = @chapter.subscriptions.last(20).reverse

--- a/app/models/concerns/listable.rb
+++ b/app/models/concerns/listable.rb
@@ -4,6 +4,7 @@ module Listable
   extend ActiveSupport::Concern
 
   included do
+    scope :today_and_upcoming, -> { where('date_and_time >= ?', Time.zone.today).order(date_and_time: :asc) }
     scope :upcoming, -> { where('date_and_time >= ?', Time.zone.now).order(date_and_time: :asc) }
     scope :past, -> { where('date_and_time < ?', Time.zone.now).order(:date_and_time) }
     scope :recent, lambda {

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -4,6 +4,19 @@ RSpec.describe Listable, type: :model do
   subject(:workshop) { Fabricate(:workshop) }
 
   context 'scopes' do
+    context '#today_and_upcoming' do
+      it 'returns a list of all today and upcoming workshops' do
+        Fabricate.times(5, :past_workshop)
+        future_workshops = Fabricate.times(3, :workshop)
+
+        # Make sure one is not technically upcoming but is happening now
+        future_workshops.last.date_and_time = 1.hour.ago
+        future_workshops.last.save
+
+        expect(Workshop.today_and_upcoming).to match_array(future_workshops)
+      end
+    end
+
     context '#upcoming' do
       it 'returns a list of all upcoming workshops' do
         Fabricate.times(5, :past_workshop)


### PR DESCRIPTION
As an admin, something that is constantly annoying to me is losing quick access to the workshop I’m organising today because it is past 6.30pm and it no longer shows up in the “Upcoming workshops” section.

Adding a new scope that includes today’s workshops as well, so that organisers have access to the workshop at hands while running it.

![image](https://github.com/codebar/planner/assets/385232/7c442ca2-997c-4916-a7d3-1709c6ea9daa)
