### PR TITLE
Fix two rogue messages on tests

### DIFF
--- a/spec/fabricators/sponsor_fabricator.rb
+++ b/spec/fabricators/sponsor_fabricator.rb
@@ -15,6 +15,7 @@ end
 Fabricator(:sponsor_full, from: :sponsor) do
   description { Faker::Lorem.word }
   level { 'gold' }
+  accessibility_info { 'Accessible parking spaces' }
 end
 
 Fabricator(:sponsor_with_member_contacts, from: :sponsor) do

--- a/spec/lib/tasks/delete_member_rake_spec.rb
+++ b/spec/lib/tasks/delete_member_rake_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'rake member:delete', type: :task do
   end
 
   it 'when no email is provided' do
-    expect { task.invoke }.to raise_error(SystemExit, "You have to provide an email address. Usage: rake member:delete'[email@address.com]'")
+    regexed_msg = Regexp.quote("You have to provide an email address. Usage: rake member:delete'[email@address.com]'")
+    expect { task.invoke }.to output(/#{regexed_msg}\s*/).to_stderr
+      .and raise_error(SystemExit)
   end
 
   it 'anonymises member information' do


### PR DESCRIPTION
These two messages would appear on some tests, on the console. With this commit those messages are still caught but don’t show up on the console anymore (in the middle of RSpec’s dots).

The messages were:
- You have to provide an email address. Usage: rake member:delete'[email@address.com]'
- Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.

Technically, the second one is not a message we display on the code, but rather an RSpec warning telling us one of our variables was nil. Adding content to the constructor was the solution.