### PR TITLE
Fix failure to upload sponsor logos on Ruby 3.2.2 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'acts-as-taggable-on'
 gem 'carrierwave'
-gem 'carrierwave-ftp', require: 'carrierwave/storage/sftp'
+gem 'carrierwave-ftp', github: 'luan/carrierwave-ftp', ref: '5481c13', require: 'carrierwave/storage/sftp'
 gem 'cocoon'
 gem 'delayed_job'
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/luan/carrierwave-ftp.git
+  revision: 5481c1335fd3285d2057c7056e8a4662daa68dd4
+  ref: 5481c13
+  specs:
+    carrierwave-ftp (0.4.1)
+      carrierwave (>= 0.6.2)
+      double-bag-ftps (~> 0.1.4)
+      net-sftp (~> 4.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -100,10 +110,6 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
-    carrierwave-ftp (0.4.1)
-      carrierwave (>= 0.6.2)
-      double-bag-ftps (= 0.1.3)
-      net-sftp (~> 2.1.2)
     chosen-rails (1.10.0)
       coffee-rails (>= 3.2)
       railties (>= 3.0)
@@ -140,7 +146,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    double-bag-ftps (0.1.3)
+    double-bag-ftps (0.1.4)
     erubi (1.12.0)
     execjs (2.8.1)
     fabrication (2.30.0)
@@ -221,8 +227,8 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
-    net-sftp (2.1.2)
-      net-ssh (>= 2.6.5)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.3.3)
       net-protocol
     net-ssh (7.2.0)
@@ -472,7 +478,7 @@ DEPENDENCIES
   bullet
   capybara (>= 3.26)
   carrierwave
-  carrierwave-ftp
+  carrierwave-ftp!
   chosen-rails
   cocoon
   commonmarker


### PR DESCRIPTION
This unreleased commit is the only one that hhas support for Ruby 3.2 and above.

Resolves #1920 