### PR TITLE
Replace deprecated script and install Node directly from nodesource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM ruby:3.2.2
 
 # Default node version on apt is old. This makes sure a recent version is installed
-# This step also runs apt-get update
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+# Instructions for installing node from nodesource can be found here:
+# https://github.com/nodesource/distributions
+RUN set -ex; \
+    apt-get update \
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update 
 RUN apt-get install -y --force-yes build-essential libpq-dev nodejs
 
 # Install latest chrome dev package


### PR DESCRIPTION
Installing Node from nodesource scripts has been very recently deprecated (and sleeps the build for 60s). This replaces the script with installing the signed debian repo directly using the instructions provided [here](https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions).

Fixes https://github.com/codebar/planner/issues/1926