### PR TITLE
Rename clashing method name to fix pagination

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,7 +1,7 @@
 module EmailHelper
   private
 
-  def full_url_for(path)
+  def email_full_url_for(path)
     "#{@host}#{path}"
   end
 end

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -44,7 +44,7 @@ class EventInvitationMailer < ApplicationMailer
   private
 
   helper do
-    def full_url_for(path)
+    def email_full_url_for(path)
       "#{@host}#{path}"
     end
   end

--- a/app/mailers/feedback_request_mailer.rb
+++ b/app/mailers/feedback_request_mailer.rb
@@ -14,7 +14,7 @@ class FeedbackRequestMailer < ApplicationMailer
   end
 
   helper do
-    def full_url_for(path)
+    def email_full_url_for(path)
       "#{@host}#{path}"
     end
   end

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -48,7 +48,7 @@ class MeetingInvitationMailer < ApplicationMailer
   private
 
   helper do
-    def full_url_for(path)
+    def email_full_url_for(path)
       "#{@host}#{path}"
     end
   end

--- a/app/views/contact_mailer/subscription_notification.html.haml
+++ b/app/views/contact_mailer/subscription_notification.html.haml
@@ -3,4 +3,4 @@ Hi #{@contact.name},
 %p
   You have been subscribed to codebar's sponsors mailing list. To opt-out follow the link below:
   %br
-  =link_to 'Update subscription preferences', full_url_for(contact_preferences_url(token: @contact.token)), class: 'btn'
+  =link_to 'Update subscription preferences', email_full_url_for(contact_preferences_url(token: @contact.token)), class: 'btn'

--- a/app/views/event_invitation_mailer/attending.html.haml
+++ b/app/views/event_invitation_mailer/attending.html.haml
@@ -27,7 +27,7 @@
                 %h4
                   #{@event.name}
                   %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(event_invitation_url(@event.id, @invitation.token)), class: 'btn'
+                = link_to 'Update your attendance', email_full_url_for(event_invitation_url(@event.id, @invitation.token)), class: 'btn'
 
         .content
           %table

--- a/app/views/event_invitation_mailer/invite_coach.html.haml
+++ b/app/views/event_invitation_mailer/invite_coach.html.haml
@@ -25,7 +25,7 @@
                 %h4
                   #{@event.name}
                   %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
+                = link_to 'View invitation and RSVP', email_full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
 
         - if @event.venue.present?
           .content

--- a/app/views/event_invitation_mailer/invite_student.html.haml
+++ b/app/views/event_invitation_mailer/invite_student.html.haml
@@ -25,7 +25,7 @@
                 %h4
                   #{@event.name}
                   %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
+                = link_to 'View invitation and RSVP', email_full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
 
         - if @event.venue.present?
           .content

--- a/app/views/feedback_request_mailer/request_feedback.html.haml
+++ b/app/views/feedback_request_mailer/request_feedback.html.haml
@@ -29,7 +29,7 @@
             %tr
               %td
                 %p
-                  =link_to "Submit feedback", full_url_for(feedback_url(@feedback_request.token)), class: 'btn'
+                  =link_to "Submit feedback", email_full_url_for(feedback_url(@feedback_request.token)), class: 'btn'
 
         .content
           = render partial: 'shared_mailers/social', locals: { workshop: @workshop }

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -17,7 +17,7 @@
         <div style="color: #111111; font-size: 15px; font-weight: 300; margin-top: 60px;">Despo</div>
         <div style="color: #111111; font-size: 16px; font-weight: 600; margin-top: 5px;"><a href="http://codebar.io" style="color: #663095; text-decoration: none;">codebar</a></div>
 
-        <p style="color: #6d6a6a; font-size: 13px; font-weight: 600; margin-top: 90px;">If you dont want to receive these emails <%= link_to "unsubscribe", full_url_for(unsubscribe_url(member_token(@member))), style: "color: #a369d5; text-decoration: underline" %></p>
+        <p style="color: #6d6a6a; font-size: 13px; font-weight: 600; margin-top: 90px;">If you dont want to receive these emails <%= link_to "unsubscribe", email_full_url_for(unsubscribe_url(member_token(@member))), style: "color: #a369d5; text-decoration: underline" %></p>
       </div>
 
       <div style="width: 100%; height: 40px; background-color: #f6f4f8;"></div>

--- a/app/views/shared_mailers/_footer.html.haml
+++ b/app/views/shared_mailers/_footer.html.haml
@@ -7,6 +7,6 @@
           %tr
             %td{ align: "center" }
               %p
-                %a{ href: full_url_for(unsubscribe_url(member_token(@member))) }
+                %a{ href: email_full_url_for(unsubscribe_url(member_token(@member))) }
                   %unsubscribe Unsubscribe
     %td

--- a/app/views/virtual_workshop_invitation_mailer/attending.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending.html.haml
@@ -34,7 +34,7 @@
               %td
                 %h4
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update or cancel your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table

--- a/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update or cancel your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -35,7 +35,7 @@
                   %br
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', email_full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?
                   %h4 Sponsored by

--- a/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
@@ -15,7 +15,7 @@
                 %p.lead
                   We’d love to have you at our next #{@workshop.chapter.name} virtual workshop.
                 %p
-                  As part of our workshops, you’ll get to work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or receive guidance on your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', full_url_for(coaches_url)} who help out as coaches.
+                  As part of our workshops, you’ll get to work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or receive guidance on your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', email_full_url_for(coaches_url)} who help out as coaches.
                 %p You will also get the opportunity to interact with other people interested in coding and collaborate with them.
                 %p Please note: We do not accept any RSVPs over email.
 
@@ -27,7 +27,7 @@
               %td{ width: '60%', style: 'vertical-align: top; padding-right: 20px;' }
                 %h4
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', email_full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?
                   %h4 Sponsored by

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -21,7 +21,7 @@
                   so you should keep the slot available and check your email during the afternoon on the day of the workshop.
                 %p
                   Alternatively, if you know you can no longer make it, please
-                  = link_to 'remove yourself from the waiting list', full_url_for(invitation_url(@invitation))
+                  = link_to 'remove yourself from the waiting list', email_full_url_for(invitation_url(@invitation))
                   so someone else can take part in the workshop.
 
         .content
@@ -30,7 +30,7 @@
               %td
                 %h4
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update or cancel your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -36,7 +36,7 @@
                 %h4
                   Workshop
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -31,7 +31,7 @@
                 %h4
                   Workshop
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -37,7 +37,7 @@
                   Workshop
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', email_full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4
                   Venue

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -15,7 +15,7 @@
                 %p.lead
                   We’d love to have you at our next #{@workshop.chapter.name} workshop. RSVP now to secure a spot, some light bites and time with a dedicated coach.
                 %p
-                  As part of our workshop, you'll get to work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or receive guidance on your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', full_url_for(coaches_url)} who help out as coaches.
+                  As part of our workshop, you'll get to work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or receive guidance on your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', email_full_url_for(coaches_url)} who help out as coaches.
                 %p You will also get the opportunity to meet other people interested in coding and collaborate with them.
                 %p We’re looking forward to having you with us. See you there!
                 %p Please note: We do not accept any RSVPs over email.
@@ -30,7 +30,7 @@
                   Workshop
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', email_full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4
                   Venue

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -23,7 +23,7 @@
                 %h4
                   Workshop
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -21,7 +21,7 @@
                   so you should keep your laptop with you and check your email during the afternoon on the day of the workshop.
                 %p
                   Alternatively, if you know you can no longer make it, you should
-                  = link_to 'remove yourself from the waiting list', full_url_for(invitation_url(@invitation))
+                  = link_to 'remove yourself from the waiting list', email_full_url_for(invitation_url(@invitation))
                   so someone else can come to the workshop.
 
         .content
@@ -32,7 +32,7 @@
                   Workshop
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', email_full_url_for(invitation_url(@invitation)), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4
                   Venue

--- a/spec/features/admin/feedback_spec.rb
+++ b/spec/features/admin/feedback_spec.rb
@@ -14,6 +14,16 @@ RSpec.feature 'Viewing feedback', type: :feature do
       visit admin_feedback_index_path
       feedbacks.each { |feedback| expect(page).to have_content(feedback.request) }
     end
+
+    it 'has access to the second page of feedback' do
+      feedbacks = Fabricate.times(50, :feedback)
+
+      visit admin_feedback_index_path
+      
+      # Check if the page has a link with the text '2' that leads to the second page of feedback
+      second_page_path = Rails.application.routes.url_for(controller: 'admin/feedback', action: 'index', only_path: true, page: 2)
+      expect(page).to have_link('2', href: second_page_path)
+    end
   end
 
   context 'an organiser' do


### PR DESCRIPTION
Fixes https://github.com/codebar/planner/issues/1928

Pagination wasn't working as the page urls were being generation via the `full_url_for` mathod in the email helper. This renames the method so it doesn't clash.

Added a test to check a pagination link is generated correctly.

DISCLAIMER: the renaming was done by an auto search and replace. I've looked through the code and the changes make sense to me, but I'm not a Rails expert and I'm not very familiar with the codebase.

If there's a different way you want me to fix this, or tips on any further testing I can do, let me know.