### PR TITLE
Introduce Timecop for more stable time testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :test do
   gem 'shoulda-matchers', '~> 4.5'
   gem 'simplecov',      require: false
   gem 'simplecov-lcov', require: false
+  gem 'timecop', '~> 0.9.8'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,6 +451,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.2.2)
     tilt (2.2.0)
+    timecop (0.9.8)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -553,6 +554,7 @@ DEPENDENCIES
   stimulus-rails
   stripe
   terser
+  timecop (~> 0.9.8)
   turbo-rails
   tzinfo-data
   web-console (>= 4.1.0)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "timecop"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -74,4 +75,7 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = false # raise an error if n+1 query occurs
   end
+
+  # https://github.com/travisjeffery/timecop#timecopsafe_mode
+  Timecop.safe_mode = true
 end

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe Listable, type: :model do
   context 'scopes' do
     context '#today_and_upcoming' do
       it 'returns a list of all today and upcoming workshops' do
-        Fabricate.times(5, :past_workshop)
-        future_workshops = Fabricate.times(3, :workshop)
+        Timecop.travel(Time.now.utc) do
+          Fabricate.times(5, :past_workshop)
+          future_workshops = Fabricate.times(3, :workshop)
 
-        # Make sure one is not technically upcoming but is happening now
-        future_workshops.last.date_and_time = 1.hour.ago
-        future_workshops.last.save
+          # Make sure one is not technically upcoming but is happening now
+          future_workshops.last.date_and_time = 1.hour.ago
+          future_workshops.last.save
 
-        expect(Workshop.today_and_upcoming).to match_array(future_workshops)
+          expect(Workshop.today_and_upcoming).to match_array(future_workshops)
+        end
       end
     end
 


### PR DESCRIPTION
It was brought to my attention that the test I introduced a few days ago was failing on her timezone. Timecop should solve this.