### PR TITLE
Fix broken Donate button redirect

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,5 +1,5 @@
 class DonationsController < ApplicationController
   def new
-    redirect_to I18n.t('services.donations')
+    redirect_to I18n.t('services.donations'), allow_other_host: true
   end
 end


### PR DESCRIPTION
### Description
The Donate button redirect was broken when we upgraded to Rails 7. This PR fixes the redirect.

### Status
Ready for Review