### PR TITLE
Add current Sponsor logo to the sponsor edit page

### DIFF
--- a/app/views/admin/sponsors/_form.html.haml
+++ b/app/views/admin/sponsors/_form.html.haml
@@ -8,6 +8,8 @@
       - if current_user.has_role?(:admin)
         = f.input :level, collection: Sponsor.levels.keys, label_method: :humanize
       = f.input :avatar, as: :file, required: !@sponsor.avatar?
+      - if @sponsor.avatar?
+        = image_tag(@sponsor.avatar.url, alt: "#{@sponsor.name} logo", class: 'small-image mw-100 mb-4', 'data-test': 'sponsor-logo')
       = f.hidden_field :image_cache
 
       #contacts.card.bg-light.border-info.mb-4.mb-md-0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -755,7 +755,6 @@ en:
         remote: Only check if the role is fully remote only
         salary: Annual pay before tax, without commas or decimal points
       sponsor:
-        avatar: The avatar is displayed in sponsors and on the event pages.
         accessibility_info: Is the office on the second floor? Is there a lift? How can someone with a handicap get there.
         contacts:
           mailing_list_consent: Adds contact to sponsors mailing list and triggers email enabling contact to self opt-out.

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -63,6 +63,9 @@ RSpec.feature 'Managing sponsors', type: :feature do
         sponsor = Fabricate(:sponsor)
 
         visit edit_admin_sponsor_path(sponsor)
+        puts page.body
+
+        expect(page.find('.small-image')['alt']).to match("#{sponsor.name} logo")
 
         fill_in 'Accessibility information', with: 'This venue is fully accessible to wheelchair users.'
         fill_in 'Description', with: 'This sponsor has great WiFi.'
@@ -73,6 +76,15 @@ RSpec.feature 'Managing sponsors', type: :feature do
         expect(page).to have_content 'This venue is fully accessible to wheelchair users.'
         expect(page).to have_content 'This sponsor has great WiFi.'
         expect(page).to have_content 'Office is located on the third floor.'
+      end
+    end
+    context 'with existing avatar' do
+      it 'shows the current avatar on the edit page' do
+        sponsor = Fabricate(:sponsor)
+
+        visit edit_admin_sponsor_path(sponsor)
+
+        expect(page.find('*[data-test=sponsor-logo]')['alt']).to match("#{sponsor.name} logo")
       end
     end
   end


### PR DESCRIPTION
### Description
This PR adds the current logo to the Sponsor form if a logo has already been uploaded for a Sponsor.

### Related Github ticket
#1840

### Status
Ready for Review

### Screenshots
![Screen Shot 2023-10-23 at 17 53 42](https://github.com/codebar/planner/assets/5873816/5188de1b-f24b-409f-9ee4-31bbf2e44279)