### PR TITLE
Update New announcement form to ensure group names are properly displayed in the Select groups dropdown

### DIFF
--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -6,7 +6,7 @@
   .row
     .col.col-md-10.col-lg-8
       = simple_form_for [:admin, @announcement] do |f|
-        = f.association :groups, label_method: :to_s
+        = f.association :groups, label_method: :to_s, label: 'Select groups'
         = f.input :message, input_html: { rows: 3 },
           hint: raw(t('admin.shared.markdown_hint', link: link_to(t('admin.shared.markdown'), 'https://commonmark.org/help/')))
         = f.input :expires_at, as: :string

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -6,7 +6,7 @@
   .row
     .col.col-md-10.col-lg-8
       = simple_form_for [:admin, @announcement] do |f|
-        = f.association :groups, label: 'Select groups'
+        = f.association :groups, label_method: :to_s, label: 'Select groups'
         = f.input :all_groups, as: :boolean, checked_value: true, unchecked_value: false, label: 'Send to all groups'
         = f.input :message, input_html: { rows: 3 },
           hint: raw(t('admin.shared.markdown_hint', link: link_to(t('admin.shared.markdown'), 'https://commonmark.org/help/')))

--- a/spec/features/admin/announcements_spec.rb
+++ b/spec/features/admin/announcements_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Announcements', type: :feature do
     scenario 'can successfully send a new announcement to selected groups' do
       visit new_admin_announcement_path
       fill_in 'Message', with: 'An announcement to selected groups'
-      select "Coaches", from: 'Select group'
+      select "Coaches #{chapter.name}", from: 'Select group'
       click_on 'announcement[create]'
 
       expect(page).to have_content('An announcement to selected groups')


### PR DESCRIPTION
### Description
We noticed that in the New announcement form the Select groups dropdown would only display groups by their name (e.g. Student or Coach) without the city name attached, so it was impossible to tell what groups we were assigning announcements to. This PR updates the form field to display the group name in the following format `"#{name} #{chapter.name}"`

### Status
Ready for Review

### Screenshots
| Before | After |
| --- | --- |
| <img width="1470" alt="Screenshot 2023-10-31 at 2 54 01 pm" src="https://github.com/codebar/planner/assets/5873816/cc99ff0f-1125-4e38-bec3-05636808bf4c"> | <img width="1470" alt="Screenshot 2023-10-31 at 2 41 17 pm" src="https://github.com/codebar/planner/assets/5873816/fde2875d-65f9-4cd5-ba28-13c033192eb3"> |