### PR TITLE
Add controls to homepage Testimonials carousel

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -6,6 +6,7 @@
  */
 
 $enable-negative-margins: true;
+$carousel-control-width: 3rem;
 
 // scss-docs-start import-stack
 // Configuration

--- a/app/views/members/_testimonials.html.haml
+++ b/app/views/members/_testimonials.html.haml
@@ -1,11 +1,20 @@
-.carousel.slider{ 'data-bs-ride': 'carousel' }
+.carousel.carousel-dark.slide#testimonials-carousel{ 'data-bs-ride': 'carousel' }
+  .carousel-indicators
+    - @testimonials.length.times do |n|
+      %button{type: 'button', 'data-bs-target': '#testimonials-carousel', 'data-bs-slide-to': n, class: ('active' if n === 0), 'aria-current': 'true', 'aria-label': "Slide #{n + 1}"}
   .carousel-inner
     - @testimonials.each_with_index do |testimonial, index|
-      .carousel-item{ class: ('active' if index === 0) }
-        %figure.bg-white.rounded.p-4.mb-0
+      .carousel-item.p-5.bg-white.rounded{ class: ('active' if index === 0) }
+        %figure.p-3.mb-0
           %blockquote.blockquote
             %p= testimonial.text
-          %figcaption.blockquote-footer.mt-0.mb-0
+          %figcaption.blockquote-footer.my-0
             = image_tag(testimonial.member.avatar(25), class: 'rounded-circle', alt: testimonial.member.name)
             %cite.mb-0{ title: testimonial.member.full_name }
               = testimonial.member.full_name
+  %button.carousel-control-prev.bg-white{type: 'button', 'data-bs-target': '#testimonials-carousel', 'data-bs-slide': 'prev'}
+    %span.carousel-control-prev-icon{'aria-hidden': 'true'}
+    %span.visually-hidden Previous
+  %button.carousel-control-next.bg-white{type: 'button', 'data-bs-target': '#testimonials-carousel', 'data-bs-slide': 'next'}
+    %span.carousel-control-next-icon{'aria-hidden': 'true'}
+    %span.visually-hidden Next


### PR DESCRIPTION
### Description
This PR adds controls to the homepage Testimonials carousel to increase the accessibility of the section. I've added all the built in controls that Bootstrap provides. Since the carousel autoplays we should also add a play/pause button, this is not provided by Bootstrap and will have to be custom built (but we can make use of methods provided by BS).

### Status
Ready for Review

### Screenshots
| Before | After |
| --- | --- |
| <img width="1469" alt="Screenshot 2023-11-08 at 5 26 59 pm" src="https://github.com/codebar/planner/assets/5873816/3a762c16-269e-4cf5-8beb-1901bb6e97c5"> | <img width="1470" alt="Screenshot 2023-11-08 at 5 19 50 pm" src="https://github.com/codebar/planner/assets/5873816/07d85b2b-1969-442d-984b-158f801700ce"> |