### PR TITLE
Fix Rollbar warning #521 - ActionController::RoutingError: No route matches [GET] "/images/logo-square.png"

### DIFF
--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -6,7 +6,7 @@
 %meta{ property: 'og:locale', content: 'en_GB' }
 %meta{ property: 'og:site_name', content: 'codebar' }
 %meta{ name: 'keywords', content: 'codebar, programming, diversity, html, css, javascript, ruby, python' }
-%meta{ property: 'og:image', content: 'https://codebar.io/images/logo-square.png' }
+%meta{ property: 'og:image', content: image_url('logo-square.png') }
 %meta{ property: 'og:url', content: "https://codebar.io#{url_for(nil)}" }
 %meta{ property: 'og:title', content: 'codebar' }
 %meta{ property: 'og:description', content: 'Making tech more diverse and welcoming by bringing people together and helping teach programming skills.' }


### PR DESCRIPTION
### Description
When we upgraded to Rails 7 we moved some assets around and the logo-square.png asset was deleted from public/images, but we forgot to update the reference to this image in that location in the app/views/layouts/_meta.html.haml file. The og:image meta tag is still looking for this image in that location. Update the og:image tag to serve the image from the asset pipeline instead. This fix should get rid of a warning in Rollbar with a large amount of occurrences.

### Status
Ready for Review

### Related Rollbar error/warning
https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/521