### PR TITLE
Fix Rollbar waring #521: missing Twitter summary image

### DIFF
--- a/app/views/virtual_workshops/_meta_tags.html.haml
+++ b/app/views/virtual_workshops/_meta_tags.html.haml
@@ -3,14 +3,14 @@
   - twitter_description = "codebar #{workshop.chapter.name} virtual  workshop on #{humanize_date(workshop.date_and_time, with_time: true)}"
   - slack_description = "codebar #{workshop.chapter.name} virtual workshop"
   %meta{ property: 'twitter:card', content: 'summary' }
-  %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
+  %meta{ property: 'twitter:image', content: image_url('twitter-summary-card-image.png') }
   %meta{ property: 'twitter:site', content: '@codebar' }
   %meta{ property: 'twitter:title', content: title }
   %meta{ property: 'twitter:description', content: twitter_description }
   %meta{ property: 'twitter:image:alt', content: 'codebar logo' }
   %meta{ property: 'og:title', content: title }
   %meta{ property: 'og:description', content: slack_description }
-  %meta{ property: 'og:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
+  %meta{ property: 'og:image', content: image_url('twitter-summary-card-image.png') }
   %meta{ name: 'twitter:label1', value: "Where"}
   %meta{ name: 'twitter:data1', value: "online" }
   %meta{ name: 'twitter:label2', value: "When"}

--- a/app/views/workshops/_meta_tags.html.haml
+++ b/app/views/workshops/_meta_tags.html.haml
@@ -3,14 +3,14 @@
   - twitter_description = "codebar #{workshop.chapter.name} workshop at #{workshop.host.name} on #{humanize_date(workshop.date_and_time, with_time: true)}"
   - slack_description = "codebar #{workshop.chapter.name}"
   %meta{ property: 'twitter:card', content: 'summary' }
-  %meta{ property: 'twitter:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
+  %meta{ property: 'twitter:image', content: image_url('twitter-summary-card-image.png') }
   %meta{ property: 'twitter:site', content: '@codebar' }
   %meta{ property: 'twitter:title', content: title }
   %meta{ property: 'twitter:description', content: twitter_description }
   %meta{ property: 'twitter:image:alt', content: 'codebar logo' }
   %meta{ property: 'og:title', content: title }
   %meta{ property: 'og:description', content: slack_description }
-  %meta{ property: 'og:image', content: 'https://codebar.io/images/twitter-summary-card-image.png' }
+  %meta{ property: 'og:image', content: image_url('twitter-summary-card-image.png') }
   %meta{ name: 'twitter:label1', value: "Where"}
   %meta{ name: 'twitter:data1', value: "#{workshop.host.name}, #{@host_address}" }
   %meta{ name: 'twitter:label2', value: "When"}


### PR DESCRIPTION
### Description
When we upgraded to Rails 7 we moved some assets around. The twitter-summary-card-image.png image was deleted from public/images and moved into assets/images/ but we forgot to update the references to the image. Update the asset path everywhere this image is used to point to the assets folder.

### Status
Ready for Review

### Related Rollbar error/warning
https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/521