### PR TITLE
Fix Rollbar warning #529: ActionController::RoutingError: uninitialized constant Member::JobsController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,13 +25,6 @@ Rails.application.routes.draw do
     resource :details, only: %i[edit update]
   end
 
-  namespace :member, path: 'my' do
-    resources :jobs, except: [:destroy] do
-      post 'submit'
-      get 'pending', on: :collection
-    end
-  end
-
   resource :members do
     get :autocomplete_skill_name, on: :collection
   end
@@ -163,4 +156,7 @@ Rails.application.routes.draw do
   get 'breach-code-of-conduct' => 'pages#show', id: 'breach-code-of-conduct'
 
   get ':id' => 'chapter#show', as: :chapter
+
+  # Redirects
+  get '/my/jobs/new', to: redirect('https://jobs.codebar.io/my/jobs/new')
 end


### PR DESCRIPTION
### Description
For some reason we are still getting intermittent hits to https://codebar.io/my/jobs/new, but the controller and action no longer exists (jobs functionality was moved into it's own app). Set up a redirect in routes.tb to redirect `/my/jobs/new` to `https://jobs.codebar.io/my/jobs/new`. Also remove remaining Job related code from routes.rb.

### Status
Ready for Review

### Related Rollbar error/warning
https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/529