### PR TITLE
Ignore unknown routes from Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -32,6 +32,10 @@ Rollbar.configure do |config|
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 
+  # This particular exception is blowing up our Rollbar plan limit
+  # and it doesn't provide useful information so let's ignore it.
+  config.exception_level_filters.merge!(ActionController::RoutingError.name => 'ignore')
+
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)
   # config.use_async = true


### PR DESCRIPTION
This particular error keeps eating up our Rollbar usage limit. It’s not a particularly useful message, so let’s ignore it.