### PR TITLE
Update links to be specific to codebar

### DIFF
--- a/app/views/shared/_donation_platforms.html.haml
+++ b/app/views/shared/_donation_platforms.html.haml
@@ -19,7 +19,7 @@
         .bg-dark.rounded-top
           = image_tag("give-as-you-live.png", alt: "Give as you Live logo", class: "mw-100 rounded-top")
       .card-body
-        %h3.h6= link_to(t("donation_platforms.give_as_you_live.title"), "https://www.giveasyoulive.com/")
+        %h3.h6= link_to(t("donation_platforms.give_as_you_live.title"), "https://www.giveasyoulive.com/join/codebar?utm_source=charitytoolkit&utm_content=233896&utm_medium=post&utm_campaign=CTGenericCampaign")
         %p.card-text= t("donation_platforms.give_as_you_live.text")
   .d-flex.col-sm-12.col-md-6.col-lg-3
     .card.mt-3.mt-lg-0.shadow
@@ -35,7 +35,7 @@
         .bg-dark.rounded-top
           = image_tag("GitHub_Logo_White.png", alt: "Github Sponsors logo", class: "mw-100")
       .card-body
-        %h3.h6= link_to(t("donation_platforms.github_sponsors.title"), "https://github.com/sponsors")
+        %h3.h6= link_to(t("donation_platforms.github_sponsors.title"), "https://github.com/sponsors/codebar")
         %p.card-text= t("donation_platforms.github_sponsors.text")
 
 - if local_assigns[:with_button]


### PR DESCRIPTION
I've updated the Give As you Live and GitHub sponsors links to be specific to codebar