### PR TITLE
Fix showing duplicate sponsors

### DIFF
--- a/app/models/sponsors_search.rb
+++ b/app/models/sponsors_search.rb
@@ -26,6 +26,6 @@ class SponsorsSearch
   end
 
   def by_chapter
-    @sponsors = sponsors.joins(:workshops).where('workshops.chapter_id' => chapter) if chapter.present?
+    @sponsors = sponsors.joins(:workshops).where('workshops.chapter_id' => chapter).group('sponsors.id') if chapter.present?
   end
 end


### PR DESCRIPTION
This is a fix for https://github.com/codebar/planner/issues/1839

When filtering by chapter, the page was displaying a sponsor row for every workshop, like this:

<img width="786" alt="image" src="https://github.com/codebar/planner/assets/1482649/2f3d9517-7f32-4376-97ad-239a5b8d97ae">

This PR fixes the display so that it only shows the chapter once, like this:

<img width="783" alt="image" src="https://github.com/codebar/planner/assets/1482649/f753c476-1dbe-407a-8ce6-b22a23eaab4d">
