### PR TITLE
ISSUE-1981: Switch webdrivers to selenium-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,6 @@ FROM ruby:3.2.2
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y --force-yes build-essential libpq-dev nodejs
 
-# Install latest chrome dev package
-RUN set -ex; \
-    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && wget -q -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y --force-yes google-chrome-stable --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /planner
 
 COPY Gemfile Gemfile.lock ./

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'selenium-webdriver'
-  gem 'webdrivers'
   gem 'database_cleaner'
   gem 'shoulda-matchers', '~> 6.2'
   gem 'simplecov',      require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.15.0)
       execjs (~> 2)
+    base64 (0.2.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -422,7 +423,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.21.1)
+      base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -480,11 +482,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -570,7 +568,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console (>= 4.1.0)
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p137

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,3 @@
-require 'webdrivers'
-
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 


### PR DESCRIPTION
Hi all.

Changes in the PR:
1. Remove Chrome installation (it didn't work anyway). So in Docker we will use _some_ chrome's version.
2. Upgrade `selenium-webdrivers`.

I think I could use [Chrome for testing](https://googlechromelabs.github.io/chrome-for-testing/) last stable version (125th at the moment) but I think it's enough to use Chrome builtin docker image.