### PR TITLE
Fix Rollbar error #569 undefined method name for nil:NilClass in admin sponsor page

### DIFF
--- a/app/views/public_activity/sponsor/_admin_contact_subscribe.html.haml
+++ b/app/views/public_activity/sponsor/_admin_contact_subscribe.html.haml
@@ -1,1 +1,2 @@
-%li #{link_to(activity.owner.full_name, admin_member_path(activity.owner))} subscribed #{activity.recipient.name} #{activity.recipient.surname} with email #{activity.parameters[:note]} to the Sponsor newsletter
+- if activity.recipient.present?
+  %li #{link_to(activity.owner.full_name, admin_member_path(activity.owner))} subscribed #{activity&.recipient.name} #{activity&.recipient.surname} with email #{activity.parameters[:note]} to the Sponsor newsletter

--- a/app/views/public_activity/sponsor/_admin_contact_unsubscribe.html.haml
+++ b/app/views/public_activity/sponsor/_admin_contact_unsubscribe.html.haml
@@ -1,1 +1,2 @@
-%li #{link_to(activity.owner.full_name, admin_member_path(activity.owner))} unsubscribed #{activity.recipient.name} #{activity.recipient.surname} with email #{activity.parameters[:note]} from the Sponsor newsletter
+- if activity.recipient.present?
+  %li #{link_to(activity.owner.full_name, admin_member_path(activity.owner))} unsubscribed #{activity.recipient.name} #{activity.recipient.surname} with email #{activity.parameters[:note]} from the Sponsor newsletter

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -155,6 +155,34 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
         end
       end
     end
+
+    context 'activities' do
+      scenario 'when there are activities' do
+        contact = sponsor.contacts.first
+        audit = Auditor::Audit.new(sponsor, 'sponsor.admin_contact_subscribe', manager, contact)
+        audit.log_with_note(contact.email)
+
+        visit admin_sponsor_path(sponsor)
+
+        within '#activities' do
+          expect(page).to have_content("#{manager.full_name} subscribed #{contact.name} #{contact.surname} with email #{contact.email} to the Sponsor newsletter")
+        end
+      end
+
+      scenario 'when an activity is associated with a deleted contact' do
+        contact = sponsor.contacts.first
+        audit = Auditor::Audit.new(sponsor, 'sponsor.admin_contact_subscribe', manager, contact)
+        audit.log_with_note(contact.email)
+
+        contact.delete
+
+        visit admin_sponsor_path(sponsor)
+
+        within '#activities' do
+          expect(page).to_not have_content("#{manager.full_name} subscribed #{contact.name} #{contact.surname} with email #{contact.email} to the Sponsor newsletter")
+        end
+      end
+    end
   end
 
   context 'Editing a sponsor' do


### PR DESCRIPTION
### Description
This PR addresses the undefined method name for nil:NilClass error in the admin sponsor page.

### Status
Ready for Review

### Related Rollbar error
https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/569

### Screenshots
N/A