### PR TITLE
Handle student & coach event emailing as separate

### DIFF
--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -33,6 +33,7 @@ class InvitationManager
       EventInvitationMailer.invite_student(event, student, invitation).deliver_now if invitation.save
     end
   end
+  handle_asynchronously :invite_students_to_event
 
   def invite_coaches_to_event(event, chapter)
     chapter_coaches(chapter).each do |coach|
@@ -40,6 +41,7 @@ class InvitationManager
       EventInvitationMailer.invite_coach(event, coach, invitation).deliver_now if invitation.save
     end
   end
+  handle_asynchronously :invite_coaches_to_event
 
   def chapter_students(chapter)
     Member.in_group(chapter.groups.students)


### PR DESCRIPTION
Send them both in the background, separately. This should help with the timeouts we have sometimes on Heroku, I hope.