### PR TITLE
Fix link to sponsor #2512 

### DIFF
--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -16,7 +16,7 @@
       .bg-light.p-3.mb-4
         %dl.row
           %dt= t('.website')
-          %dd= link_to @sponsor.website
+          %dd= link_to @sponsor.website, @sponsor.website, target: '_blank'
 
           %dt= t('.address')
           - if @sponsor.address.present?

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
     scenario 'displays all sponsor details' do
       expect(page).to have_content(sponsor.name)
       expect(page).to have_content(sponsor.description)
-      expect(page).to have_link(sponsor.website)
+      expect(page).to have_link(sponsor.website, href: sponsor.website)
       expect(page).to have_content(sponsor.level)
       expect(page).to have_content(ContactPresenter.new(sponsor.contacts.first).full_name)
 


### PR DESCRIPTION
Fixes link to sponsor website from admin area, resolves #2512 by using name as param in link_to, alternatively I could set only_path: false. Also opens external link in new tab