### PR TITLE
Redirect to login when editing member logged out

### DIFF
--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -4,6 +4,7 @@ class Member::DetailsController < ApplicationController
 
   before_action :set_member
   before_action :suppress_notices
+  before_action :is_logged_in?, only: %i[edit]
 
   def edit
     accept_terms


### PR DESCRIPTION
Unauthenticated users now trying to open https://codebar.io/member/details/edit will be redirected to the main page with a messages telling them to log in. Closes rb#525.

| before | after |
|:-:|:-:|
| ![Screenshot 2025-01-25 at 10 29 02](https://github.com/user-attachments/assets/49125876-8389-4e44-a06b-b1a212f6c65e) | ![Screenshot 2025-01-25 at 10 33 18](https://github.com/user-attachments/assets/af28420f-f349-4cf7-9279-751292c87cc7) |



