### PR TITLE
CI: ruby/setup-ruby reads .ruby-version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,11 +24,8 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        # .ruby-version provides the Ruby version implicitly.
         bundler-cache: true
-      env:
-        BUNDLE_JOBS: 4
-        BUNDLE_RETRY: 3
 
     - name: Setup test database
       env:


### PR DESCRIPTION
This PR relies on ruby/setup-ruby to pick good defaults for installing packages.

And, we don't want to write the version number more than once (in the .ruby-version file).