### PR TITLE
Remove need for sponsor avatar

### DIFF
--- a/app/views/admin/sponsors/_form.html.haml
+++ b/app/views/admin/sponsors/_form.html.haml
@@ -7,7 +7,7 @@
         hint: raw(t('admin.shared.markdown_hint', link: link_to(t('admin.shared.markdown'), 'https://commonmark.org/help/')))
       - if current_user.has_role?(:admin)
         = f.input :level, collection: Sponsor.levels.keys, label_method: :humanize
-      = f.input :avatar, as: :file, required: !@sponsor.avatar?
+      = f.input :avatar, as: :file
       - if @sponsor.avatar?
         = image_tag(@sponsor.avatar.url, alt: "#{@sponsor.name} logo", class: 'small-image mw-100 mb-4', 'data-test': 'sponsor-logo')
       = f.hidden_field :image_cache


### PR DESCRIPTION
This will remove the need for an avatar for sponsors. This should be a temporary change, but will allow admins to continue creating new sponsors