### PR TITLE
fix: add link to chapter page from pills

### DIFF
--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -4,7 +4,7 @@
       .order-md-2
         - if event.chapter
           %span.badge.bg-primary.mb-3.mb-md-0
-            = event.chapter.name
+            = link_to event.chapter.name, event.chapter.slug, class: 'text-light text-decoration-none' 
         - if @user
           - if @user.attending?(event.__getobj__)
             %span.badge.bg-success.mb-3.mb-md-0

--- a/app/views/meetings/_meeting.html.haml
+++ b/app/views/meetings/_meeting.html.haml
@@ -4,7 +4,7 @@
       .order-md-2
         - if meeting.chapter
           %span.badge.bg-primary.mb-3.mb-md-0
-            = meeting.chapter.name
+            = link_to meeting.chapter.name, meeting.chapter.slug, class: 'text-light text-decoration-none'
         - if @user
           - if @user.attending?(meeting)
             %span.badge.bg-success.mb-3.mb-md-0


### PR DESCRIPTION
It has often been a frustation for me, that I couldn't navigate to a specific chapter page from an event or meeting. This scratches that itch.

<img width="992" height="450" alt="image" src="https://github.com/user-attachments/assets/0fdcc0cb-3e2f-405d-bab6-7e94cf329d58" />

#### How to verify

1. Check out this branch
2. Navigate to http://0.0.0.0:3000/events
3. Click on the pill in event (see screenshot above)
4. Observe that you're navigating to http://0.0.0.0:3000/brighton, which shows all the events for the chapter