### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
In some PRs there are missing newlines at end of files, because we have inconsistent editor settings. This fixes that