### PR TITLE
RSpec: use .rspec configuration file to centralize spec_helper usage

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/spec/controllers/admin/member_notes_controller_spec.rb
+++ b/spec/controllers/admin/member_notes_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Admin::MemberNotesController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:chapter_organiser) }

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Admin::SponsorsController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:member1) { Fabricate(:member) }

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Admin::WorkshopsController, type: :controller do
   let!(:workshop) { Fabricate(:workshop) }
   let(:admin) { Fabricate(:member) }

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MembersController, type: :controller do
   describe "GET unsubscribe/#token" do
     it "redirects to the subscription path when token is valid" do

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Accepting a workshop invitation', type: :feature do
   context '#workshop' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Accepting Terms and Conditions', type: :feature do
   context 'When a user signs up to codebar' do
     before do

--- a/spec/features/admin/accessing_portal_spec.rb
+++ b/spec/features/admin/accessing_portal_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'admin portal', type: :feature do
   scenario 'non admin cannot access the admin portal' do
     member = Fabricate(:member)

--- a/spec/features/admin/announcements_spec.rb
+++ b/spec/features/admin/announcements_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Announcements', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_groups) }

--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Chapter workshop feedback', type: :feature do
   it 'is only available to chapter organisers' do
     member = Fabricate(:member)

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Chapters', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Event creation', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_groups) }

--- a/spec/features/admin/feedback_spec.rb
+++ b/spec/features/admin/feedback_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Viewing feedback', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/filtering_sponsors_list_spec.rb
+++ b/spec/features/admin/filtering_sponsors_list_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Admin filtering sponsors list', type: :feature do
   let(:manager) { Fabricate(:member) }
 

--- a/spec/features/admin/groups_spec.rb
+++ b/spec/features/admin/groups_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'admin groups', type: :feature do
   context '#creating a new group' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing events', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter_with_groups) }

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing sponsors', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'managing workshop attendances', type: :feature do
   context 'an admin' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/admin/managing_meeting_invitations_spec.rb
+++ b/spec/features/admin/managing_meeting_invitations_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing meeting invitations', type: :feature do
   let(:admin) { Fabricate(:member) }
   let(:meeting) { Fabricate(:meeting) }

--- a/spec/features/admin/managing_organisers_spec.rb
+++ b/spec/features/admin/managing_organisers_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing organisers', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter) }

--- a/spec/features/admin/managing_testimonials_spec.rb
+++ b/spec/features/admin/managing_testimonials_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing testimonials', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing meetings', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'Admin managing members', type: :feature do
   let(:member) { Fabricate(:student) }
   let(:admin) { Fabricate(:chapter_organiser) }

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Admin::Sponsors', type: :feature do
   let(:manager) { Fabricate(:member) }
 

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'An admin managing workshops', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'viewing a Chapter', type: :feature do
   context 'non active chapters' do
     let(:inactive_chapter) { Fabricate(:chapter, active: false) }

--- a/spec/features/coach_accepting_invitation_spec.rb
+++ b/spec/features/coach_accepting_invitation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'a Coach can', type: :feature do
   context '#workshop' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/internationalization_spec.rb
+++ b/spec/features/internationalization_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Internationalization', type: :feature do
   after(:each) do
     I18n.locale = :en

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'when visiting the coaches page', type: :feature do
   scenario 'I can see the most active coaches' do
     coach = Fabricate(:attended_coach).member

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'events_controller'
 
 RSpec.feature 'event listing', type: :feature do

--- a/spec/features/manage_contact_preferences_spec.rb
+++ b/spec/features/manage_contact_preferences_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing contact preferences', type: :feature do
 
   context 'A sponsor contact can manage their contact preferences' do

--- a/spec/features/managing_workshop_attendance_spec.rb
+++ b/spec/features/managing_workshop_attendance_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 RSpec.feature 'Managing workshop attendance', type: :feature do
   let(:coach) { Fabricate(:coach) }
   let(:student) { Fabricate(:student) }

--- a/spec/features/member/login_spec.rb
+++ b/spec/features/member/login_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Member logging in', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'member feedback', type: :feature do
   let(:feedback_request) { Fabricate(:feedback_request) }
   let(:valid_token) { feedback_request.token }

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'A new student signs up', type: :feature do
   before do
     mock_github_auth

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Member portal', type: :feature do
   subject { page }
 

--- a/spec/features/sponsors_spec.rb
+++ b/spec/features/sponsors_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Sponsors', type: :feature do
   context 'Listing' do
     scenario 'can see a listing of all non expired job posts' do

--- a/spec/features/subscribing_to_emails_spec.rb
+++ b/spec/features/subscribing_to_emails_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Managing subscriptions', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:group) { Fabricate(:group) }

--- a/spec/features/subscribing_to_newsletter_spec.rb
+++ b/spec/features/subscribing_to_newsletter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'Subscribing to the newsletter', type: :feature do
   before do
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(

--- a/spec/features/view_event_spec.rb
+++ b/spec/features/view_event_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'viewing an event', type: :feature do
   let(:closed_event) { Fabricate(:event, confirmation_required: true, surveys_required: true) }
   let(:open_event) { Fabricate(:event, confirmation_required: false, surveys_required: false) }

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'viewing a meeting', type: :feature do
   let!(:meeting) { Fabricate(:meeting) }
 

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 RSpec.feature 'Viewing a workshop invitation', type: :feature, wip: true do
   let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop) }
 

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 RSpec.feature 'Viewing a workshop page', type: :feature do
   context 'visitor' do
     before do

--- a/spec/features/viewing_pages_spec.rb
+++ b/spec/features/viewing_pages_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'A visitor to the website', type: :feature do
   scenario 'can access and view the cookie policy' do
     visit root_path

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.feature 'when visiting the homepage', type: :feature do
   let!(:next_workshop) { Fabricate(:workshop) }
   let!(:events) { Fabricate.times(8, :event) }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#contact_email' do
     it "returns the workshop chapter's email" do

--- a/spec/lib/services/flodesk_spec.rb
+++ b/spec/lib/services/flodesk_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'json'
 require 'services/flodesk'
 

--- a/spec/lib/services/mailing_list_spec.rb
+++ b/spec/lib/services/mailing_list_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'json'
 require 'services/mailing_list'
 

--- a/spec/lib/tasks/delete_member_rake_spec.rb
+++ b/spec/lib/tasks/delete_member_rake_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'rake member:delete', type: :task do
   let!(:member) { Fabricate.create(:member) }
   before do

--- a/spec/lib/tasks/feedback_rake_spec.rb
+++ b/spec/lib/tasks/feedback_rake_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'rake feedback:request', type: :task do
   context 'when most recent workshop has attendances' do
     let(:workshop) { Fabricate(:workshop, date_and_time: 23.hours.ago) }

--- a/spec/lib/tasks/mailing_list_rake_spec.rb
+++ b/spec/lib/tasks/mailing_list_rake_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'rake mailing_list:subscribe_active_members', type: :task do
   it "preloads the Rails environment" do
     expect(task.prerequisites).to include "environment"

--- a/spec/lib/tasks/reminders_meeting_rake_spec.rb
+++ b/spec/lib/tasks/reminders_meeting_rake_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'rake reminders:meeting', type: :task do
   it "preloads the Rails environment" do
     expect(task.prerequisites).to include "environment"

--- a/spec/lib/tasks/reminders_workshop_rake_spec.rb
+++ b/spec/lib/tasks/reminders_workshop_rake_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'rake reminders:workshop', type: :task do
   let!(:workshop) { Fabricate(:workshop, date_and_time: Time.zone.now + 29.hours) }
 

--- a/spec/lib/verifier_spec.rb
+++ b/spec/lib/verifier_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'verifier'
 
 RSpec.describe Verifier do

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe EventInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe FeedbackRequestMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MeetingInvitationMailer, type: :mailer do
   let(:meeting) { Fabricate(:meeting) }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MemberMailer, type: :mailer do
   let(:member) { Fabricate(:member) }
 

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe VirtualWorkshopInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop) }

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe WorkshopInvitationMailer, type: :mailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Address, type: :model do
   subject(:address) { Fabricate.build(:address) }
 end

--- a/spec/models/attendance_warning_spec.rb
+++ b/spec/models/attendance_warning_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe AttendanceWarning, type: :model do
   describe '#create' do
     let(:member) { Fabricate(:member) }

--- a/spec/models/ban_spec.rb
+++ b/spec/models/ban_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Ban, type: :model do
   context 'validates' do
     it { is_expected.to validate_presence_of(:expires_at) }

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Chapter, type: :model do
   it { should validate_presence_of(:city) }
   it { should validate_length_of(:description).is_at_most(280) }

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Listable, type: :model do
   subject(:workshop) { Fabricate(:workshop) }
 

--- a/spec/models/concerns/permissions_spec.rb
+++ b/spec/models/concerns/permissions_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Permissions, type: :model do
   subject(:member) { Fabricate(:member) }
 

--- a/spec/models/eligibility_inquiry_spec.rb
+++ b/spec/models/eligibility_inquiry_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe EligibilityInquiry, type: :model do
   describe '#create' do
     let(:member) { Fabricate(:member) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Event, type: :model do
   subject(:event) { Fabricate(:event) }
   include_examples "Invitable", :invitation, :event

--- a/spec/models/feedback_request_spec.rb
+++ b/spec/models/feedback_request_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe FeedbackRequest, type: :model do
   subject { Fabricate(:feedback_request) }
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Feedback, type: :model do
   subject(:feedback) { Fabricate.build(:feedback) }
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Group, type: :model do
   subject(:group) { Fabricate.build(:group) }
 

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe InvitationManager, type: :model do
   subject(:manager) { InvitationManager.new }
 

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Invitation, type: :model do
   it_behaves_like InvitationConcerns, :invitation, :event
 

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MeetingInvitation, type: :model do
   it_behaves_like InvitationConcerns, :meeting_invitation, :meeting
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Meeting, type: :model do
   include_examples "Invitable", :meeting_invitation, :meeting
   include_examples DateTimeConcerns, :meeting

--- a/spec/models/meeting_talk_spec.rb
+++ b/spec/models/meeting_talk_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MeetingTalk, type: :model do
   context 'validations' do
     subject { MeetingTalk.new }

--- a/spec/models/member_note_spec.rb
+++ b/spec/models/member_note_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MemberNote, type: :model do
   context 'Mandatory attributes' do
     it 'Requires a note' do

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Member, type: :model do
   let(:member) { Fabricate(:member) }
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Role, type: :model do
   context 'scopes' do
     let(:student_role) { Fabricate(:student_role) }

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Sponsor, type: :model do
   subject(:sponsor) { Fabricate.build(:sponsor) }
 

--- a/spec/models/sponsors_search_spec.rb
+++ b/spec/models/sponsors_search_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe SponsorsSearch, type: :model do
   let(:search_params) { { name: Faker::Name.name, chapter: Faker::Name.name } }
 

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Tutorial, type: :model do
   subject(:tutorial) { Fabricate.build(:tutorial) }
 

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe WaitingList, type: :model do
   let(:workshop) { Fabricate(:workshop) }
 

--- a/spec/models/workshop_calendar_spec.rb
+++ b/spec/models/workshop_calendar_spec.rb
@@ -1,5 +1,4 @@
-require 'spec_helper'
-describe WorkshopCalendar do
+RSpec.describe WorkshopCalendar do
   let(:invitation_url) { Faker::Internet.url }
   let(:calendar) { WorkshopCalendar.new(workshop, invitation_url).calendar }
 

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe WorkshopInvitation, type: :model do
   subject(:workshop_invitation) { Fabricate(:workshop_invitation) }
   it_behaves_like InvitationConcerns, :workshop_invitation, :workshop

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Workshop, type: :model do
   subject(:workshop) { Fabricate(:workshop) }
   include_examples "Invitable", :workshop_invitation, :workshop

--- a/spec/models/workshop_sponsor_spec.rb
+++ b/spec/models/workshop_sponsor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe WorkshopSponsor, type: :model do
   context 'validates' do
     it 'sponsor_id for uniqueness' do

--- a/spec/presenters/address_presenter_spec.rb
+++ b/spec/presenters/address_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe AddressPresenter do
   let(:address) { Fabricate.build(:address) }
   let(:presenter) { AddressPresenter.new(address) }

--- a/spec/presenters/chapter_presenter_spec.rb
+++ b/spec/presenters/chapter_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe ChapterPresenter do
   let(:chapter) { Fabricate(:chapter_without_organisers) }
   let(:presenter) { ChapterPresenter.new(chapter) }

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe ContactPresenter do
   let(:contact_presenter) { ContactPresenter.new(contact) }
   let(:contact) { Fabricate(:contact) }

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe EventPresenter do
   let(:workshop) { Fabricate(:workshop) }
   let(:event) { described_class.new(workshop) }

--- a/spec/presenters/invitation_presenter_spec.rb
+++ b/spec/presenters/invitation_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe InvitationPresenter do
   let(:invitation) { Fabricate(:student_workshop_invitation) }
   let(:invitation_presenter) { InvitationPresenter.new(invitation) }

--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MeetingPresenter do
   let(:meeting) { Fabricate(:meeting) }
   let(:event) { MeetingPresenter.new(meeting) }

--- a/spec/presenters/member_presenter_spec.rb
+++ b/spec/presenters/member_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe MemberPresenter do
   let(:member) { Fabricate(:member, skill_list: 'java, ruby') }
   let(:member_presenter) { MemberPresenter.new(member) }

--- a/spec/presenters/sponsor_presenter_spec.rb
+++ b/spec/presenters/sponsor_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe SponsorPresenter do
   let(:sponsor_presenter) { SponsorPresenter.new(sponsor) }
   let(:sponsor) { Fabricate(:sponsor, contacts: contacts) }

--- a/spec/presenters/virtual_workshop_presenter_spec.rb
+++ b/spec/presenters/virtual_workshop_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe VirtualWorkshopPresenter do
   def double_workshop(attending_coaches:, attending_students:)
     double(:workshop, coach_spaces: 3, student_spaces: 5, chapter: chapter,

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe WorkshopPresenter do
   let(:chapter) { Fabricate(:chapter) }
   let(:host) { Fabricate(:sponsor, seats: 5, number_of_coaches: 15) }

--- a/spec/services/auditor_spec.rb
+++ b/spec/services/auditor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'Auditor::Audit' do
   let(:sponsor) { Fabricate.build(:sponsor) }
   let(:member) { Fabricate(:member) }


### PR DESCRIPTION
This PR begins using the pre-existing `.rspec` configuration file more.

See https://rspec.info/documentation/3.13/rspec-core/#store-command-line-options-rspec and other RSpec docs for more on the file.