### PR TITLE
fix: failing integration tests

### DIFF
--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -50,8 +50,18 @@ RSpec.feature 'managing workshop attendances', type: :feature do
       expect(page).to have_content('1 are attending as students')
       expect(page).to_not have_selector('i.fa-magic')
 
-      find('span', text: 'Select a member to RSVP').click
-      find("li", text: "#{other_invitation.member.full_name} (#{other_invitation.role})").click
+      dropdown_text = 'Select a member to RSVP'
+      dropdown = find('span', text: dropdown_text, visible: true)
+      if dropdown.visible?
+        begin
+          dropdown.click
+        rescue Selenium::WebDriver::Error::ElementClickInterceptedError
+          puts "Dropdown is visible but cannot be clicked."
+        end
+      end
+
+      find('span', text: dropdown_text).click
+      find('li', text: "#{other_invitation.member.full_name} (#{other_invitation.role})", visible: true).click
 
       expect(page).to have_content('2 are attending as students')
 

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -61,13 +61,12 @@ RSpec.feature 'member feedback', type: :feature do
   context 'Submitting a feedback request' do
     scenario 'I can see success page with message and link to homepage when valid data is given', js: true do
       visit feedback_path(valid_token)
-
       within('.rating') { all('li').at(3).click }
       select_from_chosen(coach.full_name, from: 'feedback_coach_id')
       select_from_chosen(@tutorial.title, from: 'feedback_tutorial_id')
       click_button('Submit feedback')
 
-      expect(current_path).to eq(root_path)
+      expect(page).to have_current_path(root_path)
 
       expect(page).to have_content(feedback_submited_message)
     end


### PR DESCRIPTION
The failing test in `member_feedback_spec.rb` was due to the test not waiting for the url to change.  This was fixed by using `have_current_path` to wait for the url to change.  

The test in `manage_workshop_attendances_spec.rb` was failing because the RSVP member dropdown was appearing in front of the h4 title 'Students' and as a result the dropdown was not being clicked.  This was fixed by checking the dropdown is visible before clicking.  If the element click error is raised a custom message is logged.