### PR TITLE
chore: improve slow tests

### DIFF
--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -7,8 +7,8 @@ RSpec.feature 'Chapter workshop feedback', type: :feature do
     workshop = Fabricate(:workshop, chapter: chapter)
     other_workshop = Fabricate(:workshop)
 
-    feedbacks = Fabricate.times(3, :feedback, workshop: workshop)
-    other_feedbacks = Fabricate.times(3, :feedback, workshop: other_workshop)
+    feedbacks = Fabricate.times(1, :feedback, workshop: workshop)
+    other_feedbacks = Fabricate.times(1, :feedback, workshop: other_workshop)
 
     login_as_organiser(member, chapter)
 

--- a/spec/features/admin/feedback_spec.rb
+++ b/spec/features/admin/feedback_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Viewing feedback', type: :feature do
     end
 
     it 'can access the feedback page' do
-      feedbacks = Fabricate.times(10, :feedback)
+      feedbacks = Fabricate.times(2, :feedback)
 
       visit admin_feedback_index_path
       feedbacks.each { |feedback| expect(page).to have_content(feedback.request) }


### PR DESCRIPTION
The below tests are slow due to the feedback test data creation.  I reduced the amount of feedback created to reduce to slowness.  In test `planner/spec/features/admin/feedback_spec.rb:11` 10 pieces of feedback are generated with `Fabricate`.  To me 10 seems excessive so I have reduced this to 2 to speed the test up.  In the other test 3 pieces of feedback and 3 pieces of other_feedback were being created and I have reduced this to 1 in each (total of 2).  

The slow tests:
`planner/spec/features/admin/feedback_spec.rb:11`
'can access the feedback page'
locally the test run time went from 27.41s to 6.45s

`planner/spec/features/admin/chapter/feedback_spec.rb:4`
'is only available to chapter organisers' 
locally the test run time went from 25.19s to 13.27s