### PR TITLE
chore set belongs_to_required_by_default to true in config

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,3 @@
 class Address < ApplicationRecord
-  belongs_to :sponsor
+  belongs_to :sponsor, optional: true
 end

--- a/app/models/attendance_warning.rb
+++ b/app/models/attendance_warning.rb
@@ -1,6 +1,6 @@
 class AttendanceWarning < ApplicationRecord
   belongs_to :member
-  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id', inverse_of: false
+  belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id', inverse_of: false, optional: true
 
   scope :last_six_months, -> { where(created_at: 6.months.ago...Time.zone.now) }
 

--- a/app/models/auth_service.rb
+++ b/app/models/auth_service.rb
@@ -1,4 +1,4 @@
 class AuthService < ApplicationRecord
-  belongs_to :member
+  belongs_to :member, optional: true
   validates :uid, uniqueness: { constraint: :provider }
 end

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -1,5 +1,5 @@
 class Ban < ApplicationRecord
-  belongs_to :member
+  belongs_to :member, optional: true
   belongs_to :added_by, class_name: 'Member'
 
   validates :expires_at, :reason, :note, :added_by, presence: true

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,6 @@
 require 'services/mailing_list'
 class Contact < ApplicationRecord
-  belongs_to :sponsor
+  belongs_to :sponsor, optional: true
 
   validates :name, :surname, :email, presence: true
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,7 +8,7 @@ class Event < ApplicationRecord
 
   resourcify :permissions, role_cname: 'Permission', role_table_name: :permission
 
-  belongs_to :venue, class_name: 'Sponsor'
+  belongs_to :venue, class_name: 'Sponsor', optional: true
   has_many :sponsorships
   has_many :sponsors, -> { where('sponsorships.level' => nil) }, through: :sponsorships, source: :sponsor
   has_many :bronze_sponsors, -> { where('sponsorships.level' => 'bronze') }, through: :sponsorships, source: :sponsor

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,7 +1,7 @@
 class Feedback < ApplicationRecord
   belongs_to :tutorial
   belongs_to :coach, class_name: 'Member'
-  belongs_to :workshop
+  belongs_to :workshop, optional: true
   has_one :chapter, through: :workshop
 
   validates :rating, inclusion: { in: 1..5, message: "can't be blank" }

--- a/app/models/feedback_request.rb
+++ b/app/models/feedback_request.rb
@@ -1,6 +1,6 @@
 class FeedbackRequest < ApplicationRecord
   belongs_to :member
-  belongs_to :workshop
+  belongs_to :workshop, optional: true
 
   validates :member_id, presence: true, uniqueness: { scope: [:workshop] }
   validates :workshop, presence: true

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,7 +3,7 @@ class Invitation < ApplicationRecord
 
   belongs_to :event
   belongs_to :member
-  belongs_to :verified_by, class_name: 'Member'
+  belongs_to :verified_by, class_name: 'Member', optional: true
 
   validates :event, :member, presence: true
   validates :member_id, uniqueness: { scope: %i[event_id role] }

--- a/app/models/meeting_talk.rb
+++ b/app/models/meeting_talk.rb
@@ -1,6 +1,6 @@
 class MeetingTalk < ApplicationRecord
-  belongs_to :speaker, class_name: 'Member'
-  belongs_to :meeting
+  belongs_to :speaker, class_name: 'Member', optional: true
+  belongs_to :meeting, optional: true
 
   validates :title, :abstract, :speaker, :meeting, presence: true
 

--- a/app/models/member_note.rb
+++ b/app/models/member_note.rb
@@ -1,6 +1,6 @@
 class MemberNote < ApplicationRecord
-  belongs_to :member
-  belongs_to :author, class_name: 'Member'
+  belongs_to :member, optional: true
+  belongs_to :author, class_name: 'Member', optional: true
 
   validates :member, :author, :note, presence: true
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,6 +1,6 @@
 class Permission < ApplicationRecord
   has_and_belongs_to_many :members, join_table: :members_permissions
-  belongs_to :resource, polymorphic: true
+  belongs_to :resource, polymorphic: true, optional: true
 
   scopify
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  belongs_to :workshop
+  belongs_to :workshop, optional:  true
 
   validates :title, presence: true
   default_scope -> { order(:created_at) }

--- a/app/models/workshop_invitation.rb
+++ b/app/models/workshop_invitation.rb
@@ -3,7 +3,7 @@ class WorkshopInvitation < ApplicationRecord
 
   belongs_to :workshop
   belongs_to :member
-  belongs_to :overrider, foreign_key: :last_overridden_by_id, class_name: 'Member', inverse_of: false
+  belongs_to :overrider, foreign_key: :last_overridden_by_id, class_name: 'Member', inverse_of: false, optional: true
   has_one :waiting_list, foreign_key: :invitation_id
 
   validates :workshop, :member, presence: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,7 +59,7 @@ module Planner
 
     # TODO: sort this out properly at 
     # See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-belongs-to-required-by-default-option
-    config.active_record.belongs_to_required_by_default = false
+    config.active_record.belongs_to_required_by_default = true
   end
 end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,8 +57,6 @@ module Planner
     # More info at https://skylight.io/support/environments
     config.skylight.environments << 'development'
 
-    # TODO: sort this out properly at 
-    # See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-belongs-to-required-by-default-option
     config.active_record.belongs_to_required_by_default = true
   end
 end

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -64,7 +64,6 @@ RSpec.feature 'Event creation', type: :feature do
         check 'This is a virtual event'
         click_on 'Save'
 
-
         expect(page).to have_content('Event successfully created')
 
         expect(page).to have_content('A test virtual event')

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -64,6 +64,7 @@ RSpec.feature 'Event creation', type: :feature do
         check 'This is a virtual event'
         click_on 'Save'
 
+
         expect(page).to have_content('Event successfully created')
 
         expect(page).to have_content('A test virtual event')


### PR DESCRIPTION
this belongs_to setting in planner/config/application.rb has been set to true. 

config.active_record.belongs_to_required_by_default = true

there were many failing tests and after trying to build the associations with the fabricate test fixtures which was seemingly not possible I set some associations to optional to resolve the tests.  