### PR TITLE
Member search

### DIFF
--- a/app/controllers/admin/member_search_controller.rb
+++ b/app/controllers/admin/member_search_controller.rb
@@ -2,7 +2,7 @@ class Admin::MemberSearchController < Admin::ApplicationController
   def index
     member_params = params[:member_search] || {}
     name = member_params[:name]
-    members = name.blank? ? Member.none : Member.find_members(name).select(:id, :name, :surname, :pronouns)
+    members = name.blank? ? Member.none : Member.find_members_by_name(name).select(:id, :name, :surname, :pronouns)
     callback_url = member_params[:callback_url] || params[:callback_url] || results_admin_member_search_index_path
     if members.size == 1
       query = { member_pick: { members: [members.first.id] } }

--- a/app/controllers/admin/member_search_controller.rb
+++ b/app/controllers/admin/member_search_controller.rb
@@ -2,20 +2,20 @@ class Admin::MemberSearchController < Admin::ApplicationController
   def index
     member_params = params[:member_search] || {}
     name = member_params[:name]
-    @members = name.blank? ? Member.none : Member.find_members(name).select(:id, :name, :surname, :pronouns)
-    @callback_url = member_params[:callback_url] || params[:callback_url] || results_admin_member_search_index_path
-    if @members.size == 1
-      query = { member_pick: { members: [@members.first.id] } }
+    members = name.blank? ? Member.none : Member.find_members(name).select(:id, :name, :surname, :pronouns)
+    callback_url = member_params[:callback_url] || params[:callback_url] || results_admin_member_search_index_path
+    if members.size == 1
+      query = { member_pick: { members: [members.first.id] } }
       query_string = query.to_query
-      callback_url = "#{@callback_url}?#{query_string}"
+      callback_url = "#{callback_url}?#{query_string}"
       redirect_to callback_url and return
     end
 
-    render 'index', locals: { members: @members, callback_url: @callback_url }
+    render 'index', locals: { members: members, callback_url: callback_url }
   end
 
   def results
-    @members = Member.find(params[:member_pick][:members])
-    render 'show', members: @members
+    members = Member.find(params[:member_pick][:members])
+    render 'show', locals: { members: members }
   end
 end

--- a/app/controllers/admin/member_search_controller.rb
+++ b/app/controllers/admin/member_search_controller.rb
@@ -1,0 +1,21 @@
+class Admin::MemberSearchController < Admin::ApplicationController
+  def index
+    @params = params[:member_search] || {}
+    @name = @params[:name]
+    @members = @name.blank? ? Member.none : Member.find_members(@name).select(:id, :name, :surname, :pronouns)
+    @callback_url = @params[:callback] || results_admin_member_search_index_path
+    if (@members.size == 1) && @callback_url.present?
+      query = { member_pick: { members: [@members.pluck(:id)] } }
+      query_string = query.to_query
+      @callback_url = "#{@callback_url}?#{query_string}"
+      redirect_to @callback_url and return
+    end
+
+    render 'index', locals: { members: @members, callback: @callback_url }
+  end
+
+  def results
+    @members = Member.find(params[:member_pick][:members])
+    render 'show', locals: { members: @members }
+  end
+end

--- a/app/controllers/admin/member_search_controller.rb
+++ b/app/controllers/admin/member_search_controller.rb
@@ -1,21 +1,21 @@
 class Admin::MemberSearchController < Admin::ApplicationController
   def index
-    @params = params[:member_search] || {}
-    @name = @params[:name]
-    @members = @name.blank? ? Member.none : Member.find_members(@name).select(:id, :name, :surname, :pronouns)
-    @callback_url = @params[:callback] || results_admin_member_search_index_path
-    if (@members.size == 1) && @callback_url.present?
-      query = { member_pick: { members: [@members.pluck(:id)] } }
+    member_params = params[:member_search] || {}
+    name = member_params[:name]
+    @members = name.blank? ? Member.none : Member.find_members(name).select(:id, :name, :surname, :pronouns)
+    @callback_url = member_params[:callback_url] || params[:callback_url] || results_admin_member_search_index_path
+    if @members.size == 1
+      query = { member_pick: { members: [@members.first.id] } }
       query_string = query.to_query
-      @callback_url = "#{@callback_url}?#{query_string}"
-      redirect_to @callback_url and return
+      callback_url = "#{@callback_url}?#{query_string}"
+      redirect_to callback_url and return
     end
 
-    render 'index', locals: { members: @members, callback: @callback_url }
+    render 'index', locals: { members: @members, callback_url: @callback_url }
   end
 
   def results
     @members = Member.find(params[:member_pick][:members])
-    render 'show', locals: { members: @members }
+    render 'show', members: @members
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -119,7 +119,8 @@ class Member < ApplicationRecord
   end
 
   def self.find_members(name)
-    where("CONCAT(name, ' ', surname) ILIKE ?", "%#{name}%")
+    name.strip!
+    name.eql?('') ? self.none : where("CONCAT(name, ' ', surname) ILIKE ?", "%#{name}%")
   end
 
   private

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -118,6 +118,10 @@ class Member < ApplicationRecord
     member_notes.where('created_at > ?', notes_from_date)
   end
 
+  def self.find_members(name)
+    where('name ILIKE ?', "%#{name}%").or(where('surname ILIKE ?', "%#{name}%"))
+  end
+
   private
 
   def invitations_on(date)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -118,7 +118,7 @@ class Member < ApplicationRecord
     member_notes.where('created_at > ?', notes_from_date)
   end
 
-  def self.find_members(name)
+  def self.find_members_by_name(name)
     name.strip!
     name.eql?('') ? self.none : where("CONCAT(name, ' ', surname) ILIKE ?", "%#{name}%")
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -119,7 +119,7 @@ class Member < ApplicationRecord
   end
 
   def self.find_members(name)
-    where('name ILIKE ?', "%#{name}%").or(where('surname ILIKE ?', "%#{name}%"))
+    where("CONCAT(name, ' ', surname) ILIKE ?", "%#{name}%")
   end
 
   private

--- a/app/views/admin/member_search/_search_form.html.haml
+++ b/app/views/admin/member_search/_search_form.html.haml
@@ -1,0 +1,6 @@
+= simple_form_for :member_search, url: admin_member_search_index_path, method: :get, html: {multipart: true, novalidate: true } do |f|
+  .row 
+    .col-12.col-md-6
+      = f.input :name, label: 'Member Name', input_html: { placeholder: 'Enter member name' }
+      = f.button :submit, 'Search', class: 'btn btn-primary mt-3', name: nil
+      = f.hidden_field 'callback_url', value: callback_url

--- a/app/views/admin/member_search/index.html.haml
+++ b/app/views/admin/member_search/index.html.haml
@@ -20,4 +20,3 @@
                 = f.check_box :members, { multiple: true, checked: member.id }, member.id, nil
                 = f.label "members_#{member.id}", member.name_and_surname, class: 'form-check-label'
             = f.button :submit, 'Take me back', class: 'btn btn-primary mt-3', name: nil
-            

--- a/app/views/admin/member_search/index.html.haml
+++ b/app/views/admin/member_search/index.html.haml
@@ -1,0 +1,23 @@
+.container.py-4.py-lg-5
+  .row.mb-4
+    .col
+      %h1 Member search
+
+  .row
+    .col.col-md-10.col-lg-8
+      = render partial: 'search_form', locals: { callback_url: callback_url }
+
+  .row 
+    .col.col-md-10.col-lg-8
+      - if members.present?
+        %h2 Select Member 
+        = simple_form_for :member_pick, url: callback_url, method: :get do |f|
+          .row 
+            .col-12.col-md-6
+            = f.label :members, 'Member Name'
+            - members.each do |member|
+              .form-check
+                = f.check_box :members, { multiple: true, checked: member.id }, member.id, nil
+                = f.label "members_#{member.id}", member.name_and_surname, class: 'form-check-label'
+            = f.button :submit, 'Take me back', class: 'btn btn-primary mt-3', name: nil
+            

--- a/app/views/admin/member_search/show.html.haml
+++ b/app/views/admin/member_search/show.html.haml
@@ -7,6 +7,6 @@
       .col.col-md-10.col-lg-8
         %h2 Search Results
         %ul.list-group
-          - @members.each do |member|
+          - members.each do |member|
             %li.list-group-item
               = link_to member.name_and_surname, admin_member_path(member)

--- a/app/views/admin/member_search/show.html.haml
+++ b/app/views/admin/member_search/show.html.haml
@@ -1,0 +1,12 @@
+.container.py-4.py-lg-5
+  .row.mb-4
+    .col
+      %h1 Results 
+
+    .row
+      .col.col-md-10.col-lg-8
+        %h2 Search Results
+        %ul.list-group
+          - @members.each do |member|
+            %li.list-group-item
+              = link_to member.name_and_surname, admin_member_path(member)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,13 @@ Rails.application.routes.draw do
     end
 
     resources :testimonials, only: %i[index]
+
+    resources :member_search, path: 'member-search', only: [:index, :results] do
+      collection do
+        get 'index'
+        get 'results'
+      end
+    end
   end
 
   get   '/login', to: 'auth_services#new'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   db:
     image: postgres:17
+    ports:
+      - 5433:5432
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:

--- a/spec/controllers/admin/member_search_controller_spec.rb
+++ b/spec/controllers/admin/member_search_controller_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Admin::MemberSearchController, type: :controller do
+  let(:member) {Fabricate.build(:member)}
+
+  describe 'GET #index' do
+    context "when user is not logged in" do
+      before do
+        get :index
+      end
+      it "redirects to the home page" do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when user is an admin" do
+      let(:fake_relation) { instance_double('ActiveRecord::Relation') }
+      let(:fake_juliet) { instance_double('Member', id: 1, name: 'Juliet', surname: 'Montague') }
+
+      before do
+        login_as_admin(member)
+        get :index
+      end
+      it "shows user the search page" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      context "and when admin user searches for a single existing user" do
+        before do
+          allow(Member).to receive(:find_members).with('Juliet').and_return(fake_relation)
+          allow(fake_relation).to receive(:select).with(any_args).and_return([fake_juliet])
+          get :index, params: {member_search: {name: "Juliet", callback_url: root_path}}
+        end
+        it "redirects to the calling service" do
+          expect(response).to have_http_status(:found)
+
+          uri = URI.parse(response.location)
+          redirect_params = Rack::Utils.parse_nested_query(uri.query)
+
+          expect(redirect_params["member_pick"]["members"]).to eq(["1"])
+        end
+      end
+
+      context "and when an admin user searches and there are multiple results" do
+      let(:fake_romeo) { double('Member', id: 2, name: 'Romeo', surname: 'Capulet')}
+
+        before do
+          allow(Member).to receive(:find_members).with('e').and_return(fake_relation)
+          allow(fake_relation).to receive(:select).with(any_args).and_return([fake_juliet, fake_romeo])
+          get :index, params: {member_search: {name: 'e', callback_url: root_path}}
+        end
+        it "presents the found members on the index page" do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/member_search_controller_spec.rb
+++ b/spec/controllers/admin/member_search_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Admin::MemberSearchController, type: :controller do
 
       context "and when admin user searches for a single existing user" do
         before do
-          allow(Member).to receive(:find_members).with('Juliet').and_return(fake_relation)
+          allow(Member).to receive(:find_members_by_name).with('Juliet').and_return(fake_relation)
           allow(fake_relation).to receive(:select).with(any_args).and_return([fake_juliet])
           get :index, params: {member_search: {name: "Juliet", callback_url: root_path}}
         end
@@ -43,7 +43,7 @@ RSpec.describe Admin::MemberSearchController, type: :controller do
       let(:fake_romeo) { double('Member', id: 2, name: 'Romeo', surname: 'Capulet')}
 
         before do
-          allow(Member).to receive(:find_members).with('e').and_return(fake_relation)
+          allow(Member).to receive(:find_members_by_name).with('e').and_return(fake_relation)
           allow(fake_relation).to receive(:select).with(any_args).and_return([fake_juliet, fake_romeo])
           get :index, params: {member_search: {name: 'e', callback_url: root_path}}
         end

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Add a user to an existing workshop', type: :feature do
+RSpec.describe 'Add a user to an existing workshop', js: true, type: :feature do
   let(:member) {Fabricate(:member)}
 
   let(:juliet) {Fabricate(:member, name: 'Juliet',  surname: 'Capulet')}
@@ -10,7 +10,7 @@ RSpec.describe 'Add a user to an existing workshop', type: :feature do
    @start_page = "/admin/workshops/#{workshop.id}"
   end
 
-  scenario 'An admin searches and gets an exact match', js: true do
+  scenario 'An admin searches and gets an exact match' do
     visit @start_page
 
     params = {callback_url: @start_page.to_s}.to_query

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -1,4 +1,25 @@
-RSpec.feature 'Add a user to an existing workshop', type: :feature do
+RSpec.describe 'Add a user to an existing workshop', type: :feature do
+  let(:member) {Fabricate(:member)}
+
+  let(:juliet) {Fabricate(:member, name: 'Juliet',  surname: 'Capulet')}
+  let(:romeo) {Fabricate(:member, name: 'Romeo', surname: 'Montague')}
+  let(:workshop) {Fabricate(:workshop)}
+
+  before do
+   login_as_admin(member)
+   @start_page = "/admin/workshops/#{workshop.id}"
+  end
+
+  scenario 'An admin searches and gets an exact match', js: true do
+    visit @start_page
+
+    params = {callback: @start_page.to_s}.to_query
+    visit "/admin/member-search?#{params}"
+    fill_in 'Member Name', with: juliet.name
+    click_on 'Search'
+    expect(current_url).to include(@start_page)
+  end
+
   scenario 'An admin adds a member to a workshop' do
 
   end

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -1,0 +1,9 @@
+RSpec.feature 'Add a user to an existing workshop', type: :feature do
+  scenario 'An admin adds a member to a workshop' do
+
+  end
+
+  scenario 'An admin adds multiple members to a workshop' do
+
+  end
+end

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -13,18 +13,18 @@ RSpec.describe 'Add a user to an existing workshop', type: :feature do
   scenario 'An admin searches and gets an exact match', js: true do
     visit @start_page
 
-    params = {callback: @start_page.to_s}.to_query
+    params = {callback_url: @start_page.to_s}.to_query
     visit "/admin/member-search?#{params}"
-    fill_in 'Member Name', with: juliet.name
+    fill_in 'Member Name', with: juliet.name_and_surname
     click_on 'Search'
-    expect(current_url).to include(@start_page)
+    expect(page).to have_current_path(@start_page, ignore_query: true)
   end
 
-  scenario 'An admin adds a member to a workshop' do
-
-  end
-
-  scenario 'An admin adds multiple members to a workshop' do
-
-  end
+  # scenario 'An admin adds a member to a workshop' do
+  #   assert false
+  # end
+  #
+  # scenario 'An admin adds multiple members to a workshop' do
+  #   assert false
+  # end
 end

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -40,8 +40,4 @@ RSpec.describe 'Add a user to an existing workshop', js: true, type: :feature do
 
     expect(params[:member_pick][:members]).to eq([romeo.id.to_s])
   end
-  #
-  # scenario 'An admin adds multiple members to a workshop' do
-  #   assert false
-  # end
 end

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'Add a user to an existing workshop', js: true, type: :feature do
   let(:member) {Fabricate(:member)}
 
-  let(:juliet) {Fabricate(:member, name: 'Juliet',  surname: 'Capulet')}
-  let(:romeo) {Fabricate(:member, name: 'Romeo', surname: 'Montague')}
+  let!(:juliet) {Fabricate(:member, name: 'Juliet',  surname: 'Capulet')}
+  let!(:romeo) { Fabricate(:member, name: 'Romeo', surname: 'Montague') }
   let(:workshop) {Fabricate(:workshop)}
 
   before do
@@ -20,9 +20,26 @@ RSpec.describe 'Add a user to an existing workshop', js: true, type: :feature do
     expect(page).to have_current_path(@start_page, ignore_query: true)
   end
 
-  # scenario 'An admin adds a member to a workshop' do
-  #   assert false
-  # end
+  scenario 'An admin adds a member to a workshop' do
+    visit @start_page
+
+    params = {callback_url: @start_page.to_s}.to_query
+    visit "/admin/member-search?#{params}"
+    fill_in 'Member Name', with: 'e'
+    click_on 'Search'
+    expect(page).to have_current_path('/admin/member-search/index', ignore_query: true)
+
+    expect(page).to have_content('Romeo Montague')
+    expect(page).to have_unchecked_field('Romeo Montague')
+    check('Romeo Montague')
+    click_button'Take me back'
+
+    expect(page).to have_current_path(@start_page, ignore_query: true)
+    uri = URI.parse(page.current_url)
+    params = Rack::Utils.parse_nested_query(uri.query).with_indifferent_access
+
+    expect(params[:member_pick][:members]).to eq([romeo.id.to_s])
+  end
   #
   # scenario 'An admin adds multiple members to a workshop' do
   #   assert false

--- a/spec/features/admin/member_search_spec.rb
+++ b/spec/features/admin/member_search_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.feature 'admin member search', type: :feature do
+  scenario 'search returns single member to requesting service' do
+    Fabricate(:member, :name => 'Romeo', :surname => 'Montague')
+    Fabricate(:member, :name => 'Juliet', :surname => 'Capulet')
+    member = Fabricate(:member)
+    login_as_admin(member)
+    visit admin_member_search_index_path(callback: results_admin_member_search_index_path)
+
+    fill_in 'member_search_name', with: 'Julie'
+    click_button 'Search'
+
+    expect(page).to have_current_path(results_admin_member_search_index_path, ignore_query: true)
+
+    expect(page).to have_content('Juliet Capulet')
+  end
+
+
+end

--- a/spec/features/admin/member_search_spec.rb
+++ b/spec/features/admin/member_search_spec.rb
@@ -1,12 +1,10 @@
-require 'spec_helper'
-
 RSpec.feature 'admin member search', type: :feature do
   scenario 'search returns single member to requesting service' do
     Fabricate(:member, :name => 'Romeo', :surname => 'Montague')
     Fabricate(:member, :name => 'Juliet', :surname => 'Capulet')
     member = Fabricate(:member)
     login_as_admin(member)
-    visit admin_member_search_index_path(callback: results_admin_member_search_index_path)
+    visit admin_member_search_index_path(callback_url: results_admin_member_search_index_path)
 
     fill_in 'member_search_name', with: 'Julie'
     click_button 'Search'

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -137,4 +137,25 @@ RSpec.describe Member do
       expect(member.flag_to_organisers?).to be true
     end
   end
+
+  describe '#find_members' do
+    describe 'search by first name' do
+      it 'finds the member' do
+        expect(Member.find_members(member.name).first).to eq(member)
+      end
+    end
+
+    describe 'search by last name' do
+      it 'finds the member' do
+        expect(Member.find_members(member.surname).first).to eq(member)
+      end
+    end
+
+    describe 'search by full name' do
+      it 'finds the member' do
+        expect(Member.find_members("#{member.name} #{member.surname}").first).to eq(member)
+      end
+    end
+
+  end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -141,19 +141,19 @@ RSpec.describe Member do
   describe '#find_members' do
     describe 'search by first name' do
       it 'finds the member' do
-        expect(Member.find_members(member.name).first).to eq(member)
+        expect(Member.find_members_by_name(member.name).first).to eq(member)
       end
     end
 
     describe 'search by last name' do
       it 'finds the member' do
-        expect(Member.find_members(member.surname).first).to eq(member)
+        expect(Member.find_members_by_name(member.surname).first).to eq(member)
       end
     end
 
     describe 'search by full name' do
       it 'finds the member' do
-        expect(Member.find_members("#{member.name} #{member.surname}").first).to eq(member)
+        expect(Member.find_members_by_name("#{member.name} #{member.surname}").first).to eq(member)
       end
     end
 
@@ -161,7 +161,7 @@ RSpec.describe Member do
       it 'returns no members' do
         Fabricate(:member)
         expect(Member.all.size).to be > 0
-        expect(Member.find_members('').size).to eq(0)
+        expect(Member.find_members_by_name('').size).to eq(0)
       end
     end
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -157,5 +157,13 @@ RSpec.describe Member do
       end
     end
 
+    describe 'search bar is empty' do
+      it 'returns no members' do
+        Fabricate(:member)
+        expect(Member.all.size).to be > 0
+        expect(Member.find_members('').size).to eq(0)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This adds a controller and little view for doing member searches. Full implementation of this pattern will require calling services to add a `callback` param to the request to `MemberSearch`, which it will then `GET` once the Member(s) have been found.

If only one member is found from the search, I've chosen to assume that it's correct and we skip straight to redirecting to the calling service. That might be a faulty assumption.

I'm going to clear up the commit history, but it'll give you an early sense of how this is working. Screenshots!

<img width="1401" height="393" alt="Screenshot 2025-08-09 at 22 14 09" src="https://github.com/user-attachments/assets/f9b7bd00-8886-4091-83a8-fdc9e04a765e" />

<img width="896" height="705" alt="Screenshot 2025-08-09 at 22 14 29" src="https://github.com/user-attachments/assets/0857abce-46c4-45a4-b38d-40649c22d339" />

