### PR TITLE
Chore: reduce test suite run time by reducing test data fabrication

### DIFF
--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature 'Chapter workshop feedback', type: :feature do
     workshop = Fabricate(:workshop, chapter: chapter)
     other_workshop = Fabricate(:workshop)
 
-    feedbacks = Fabricate.times(3, :feedback, workshop: workshop)
-    other_feedbacks = Fabricate.times(3, :feedback, workshop: other_workshop)
+    feedbacks = Fabricate.times(1, :feedback, workshop: workshop)
+    other_feedbacks = Fabricate.times(1, :feedback, workshop: other_workshop)
 
     login_as_organiser(member, chapter)
 

--- a/spec/features/admin/feedback_spec.rb
+++ b/spec/features/admin/feedback_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Viewing feedback', type: :feature do
     end
 
     it 'can access the feedback page' do
-      feedbacks = Fabricate.times(10, :feedback)
+      feedbacks = Fabricate.times(2, :feedback)
 
       visit admin_feedback_index_path
       feedbacks.each { |feedback| expect(page).to have_content(feedback.request) }

--- a/spec/features/admin/filtering_sponsors_list_spec.rb
+++ b/spec/features/admin/filtering_sponsors_list_spec.rb
@@ -6,14 +6,14 @@ RSpec.feature 'Admin filtering sponsors list', type: :feature do
   end
 
   describe 'when visiting the sponsors page' do
-    let!(:sponsors) { Fabricate.times(4, :sponsor_with_contacts) }
+    let!(:sponsors) { Fabricate.times(2, :sponsor_with_contacts) }
 
     before(:each) do
       visit admin_sponsors_path
     end
 
     scenario 'all the sponsors are displayed' do
-      expect(page).to have_css('.sponsor', count: 4)
+      expect(page).to have_css('.sponsor', count: 2)
     end
 
     describe 'when filtering by name' do

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Managing meetings', type: :feature do
     let(:meeting) { Fabricate(:meeting) }
 
     scenario 'when format: :text' do
-      invitations = Fabricate.times(4, :attending_meeting_invitation, meeting: meeting)
+      invitations = Fabricate.times(2, :attending_meeting_invitation, meeting: meeting)
       visit attendees_emails_admin_meeting_path(meeting, format: :text)
 
       invitations.each do |invitation|

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
       Fabricate(:workshop_sponsor, sponsor: sponsor)
       # Multiple works with the same sponsor and chapter
       chapter = Fabricate(:chapter)
-      5.times do
+      2.times do
         Fabricate(:workshop_sponsor, sponsor: sponsor2, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter))
       end
 

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
 
   context '#views' do
     scenario 'list of all chapter workshops' do
-      workshops = Fabricate.times(5, :workshop, chapter: chapter)
+      workshops = Fabricate.times(2, :workshop, chapter: chapter)
       visit admin_chapter_workshops_path(chapter)
 
       workshops.each do |workshop|
@@ -189,7 +189,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
 
     scenario 'viewing a text file with all attendee emails' do
       workshop = Fabricate(:workshop)
-      attendees = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
+      attendees = Fabricate.times(2, :attending_workshop_invitation, workshop: workshop)
       attendees_emails = attendees.map(&:member).map(&:email)
       visit admin_workshop_attendees_emails_path(workshop, format: :text)
 
@@ -201,7 +201,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
     context 'attendee names list' do
       scenario 'viewing a text file with all names' do
         workshop = Fabricate(:workshop)
-        attendees = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
+        attendees = Fabricate.times(2, :attending_workshop_invitation, workshop: workshop)
         visit admin_workshop_attendees_checklist_path(workshop, format: :text)
         attendees.map(&:member).map(&:full_name).each do |name|
           expect(page).to have_content(name)

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'viewing a Chapter', type: :feature do
 
     it 'renders the 6 most recent sponsors for the chapter' do
       chapter = Fabricate(:chapter)
-      workshops = 6.times.map do |n|
+      workshops = 2.times.map do |n|
         Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.now - n.weeks)
       end
 

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -8,31 +8,31 @@ RSpec.feature 'when visiting the coaches page', type: :feature do
   scenario 'I can see the top coaches by year' do
     latest_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 1.year)
     old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 3.years)
-    invitations = 5.times { Fabricate(:attended_coach, workshop: latest_workshop) }
-    older_invitations = 15.times { Fabricate(:attended_coach, workshop: old_workshop) }
+    invitations = 2.times { Fabricate(:attended_coach, workshop: latest_workshop) }
+    older_invitations = 4.times { Fabricate(:attended_coach, workshop: old_workshop) }
 
     visit coaches_path(year: latest_workshop.date_and_time.year)
-    expect(page).to have_css(".coach", count: 5)
+    expect(page).to have_css(".coach", count: 2)
 
     visit coaches_path(year: old_workshop.date_and_time.year)
-    expect(page).to have_css(".coach", count: 15)
+    expect(page).to have_css(".coach", count: 4)
   end
 
   scenario 'I can navigate the top coaches by year' do
     current_workshop = Fabricate(:workshop, date_and_time: Time.zone.now)
     latest_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 1.year)
     old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 3.years)
-    current_invitations = 10.times { Fabricate(:attended_coach, workshop: current_workshop) }
-    invitations = 7.times { Fabricate(:attended_coach, workshop: latest_workshop) }
-    older_invitations = 12.times { Fabricate(:attended_coach, workshop: old_workshop) }
+    current_invitations = 1.times { Fabricate(:attended_coach, workshop: current_workshop) }
+    invitations = 3.times { Fabricate(:attended_coach, workshop: latest_workshop) }
+    older_invitations = 2.times { Fabricate(:attended_coach, workshop: old_workshop) }
 
     visit coaches_path
-    expect(page).to have_css(".coach", count: 10)
+    expect(page).to have_css(".coach", count: 1)
 
     click_on latest_workshop.date_and_time.year.to_s
-    expect(page).to have_css(".coach", count: 7)
+    expect(page).to have_css(".coach", count: 3)
 
     click_on old_workshop.date_and_time.year.to_s
-    expect(page).to have_css(".coach", count: 12)
+    expect(page).to have_css(".coach", count: 2)
   end
 end

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature 'event listing', type: :feature do
 
   context 'when there are more than the specified number of past events' do
     scenario 'I can only as many events allowed by the display limits' do
-      Fabricate.times(10, :event, date_and_time: 2.weeks.ago)
-      stub_const('EventsController::RECENT_EVENTS_DISPLAY_LIMIT', 10)
+      Fabricate.times(2, :event, date_and_time: 2.weeks.ago)
+      stub_const('EventsController::RECENT_EVENTS_DISPLAY_LIMIT', 2)
       Fabricate(:workshop, date_and_time: 3.weeks.ago)
 
       visit events_path
       within('*[data-test=past-events]') do
-        expect(page).to have_selector('*[data-test=event]', count: 10)
+        expect(page).to have_selector('*[data-test=event]', count: 2)
         expect(page).not_to have_content 'Workshop'
       end
     end

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Member portal', type: :feature do
     end
 
     it 'can view the invitations they RSVPed to' do
-      invitations = 5.times.map { Fabricate(:attending_workshop_invitation, member: member) }
+      invitations = 2.times.map { Fabricate(:attending_workshop_invitation, member: member) }
       visit invitations_path
 
       expect(page).to have_content('Invitations')

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature 'when visiting the homepage', type: :feature do
   let!(:next_workshop) { Fabricate(:workshop) }
-  let!(:events) { Fabricate.times(8, :event) }
+  let!(:events) { Fabricate.times(3, :event) }
 
   before(:each) do
     visit root_path
@@ -27,8 +27,8 @@ RSpec.feature 'when visiting the homepage', type: :feature do
   end
 
   scenario 'I can only view active chapters' do
-    inactive_chapters = Fabricate.times(3, :chapter, active: false)
-    active_chapters = Fabricate.times(4, :chapter)
+    inactive_chapters = Fabricate.times(1, :chapter, active: false)
+    active_chapters = Fabricate.times(2, :chapter)
 
     visit root_path
 

--- a/spec/lib/tasks/delete_member_rake_spec.rb
+++ b/spec/lib/tasks/delete_member_rake_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe 'rake member:delete', type: :task do
   end
 
   it 'anonymises member information' do
-    invitations = Fabricate.times(4, :workshop_invitation, member: member)
+    invitations = Fabricate.times(2, :workshop_invitation, member: member)
     tokens = invitations.map(&:token)
 
-    subscriptions = Fabricate.times(3, :subscription, member: member)
+    subscriptions = Fabricate.times(1, :subscription, member: member)
 
     allow($stdin).to receive(:getch)
 

--- a/spec/lib/tasks/mailing_list_rake_spec.rb
+++ b/spec/lib/tasks/mailing_list_rake_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'rake mailing_list:subscribe_active_members', type: :task do
 
   it 'subscribes all active members to the newsletter mailing list' do
     ENV['NEWSLETTER_ID'] = 'newsletterid'
-    non_subscribed = Fabricate.times(3, :member)
-    subscribed = Fabricate.times(6, :member)
+    non_subscribed = Fabricate.times(2, :member)
+    subscribed = Fabricate.times(2, :member)
     subscribed.each { |member| Fabricate(:subscription, member: member) }
     subscribed[0...3].each { |member| Fabricate(:subscription, member: member) }
 

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe Chapter, type: :model do
   context 'scopes' do
     context '#active' do
       it 'only returns active Chapters' do
-        2.times { Fabricate(:chapter) }
-        3.times { Fabricate(:chapter, active: false) }
+        1.times { Fabricate(:chapter) }
+        2.times { Fabricate(:chapter, active: false) }
 
-        expect(Chapter.active.all.count).to eq(2)
+        expect(Chapter.active.all.count).to eq(1)
       end
     end
   end

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Listable, type: :model do
     context '#today_and_upcoming' do
       it 'returns a list of all today and upcoming workshops' do
         Timecop.travel(Time.now.utc) do
-          Fabricate.times(5, :past_workshop)
-          future_workshops = Fabricate.times(3, :workshop)
+          Fabricate.times(2, :past_workshop)
+          future_workshops = Fabricate.times(1, :workshop)
 
           # Make sure one is not technically upcoming but is happening now
           future_workshops.last.date_and_time = 1.hour.ago
@@ -19,8 +19,8 @@ RSpec.describe Listable, type: :model do
 
     context '#upcoming' do
       it 'returns a list of all upcoming workshops' do
-        Fabricate.times(5, :past_workshop)
-        future_workshops = Fabricate.times(3, :workshop)
+        Fabricate.times(2, :past_workshop)
+        future_workshops = Fabricate.times(1, :workshop)
 
         expect(Workshop.upcoming).to match_array(future_workshops)
       end
@@ -28,8 +28,8 @@ RSpec.describe Listable, type: :model do
 
     context '#past' do
       it 'returns a list of all upcoming workshops' do
-        past_workshops = Fabricate.times(5, :past_workshop)
-        Fabricate.times(3, :workshop)
+        past_workshops = Fabricate.times(2, :past_workshop)
+        Fabricate.times(1, :workshop)
 
         expect(Workshop.past).to match_array(past_workshops)
       end
@@ -37,8 +37,8 @@ RSpec.describe Listable, type: :model do
 
     context '#recent' do
       it 'returns a list of the last 10 workshops' do
-        Fabricate.times(9, :past_workshop)
-        Fabricate.times(3, :workshop)
+        Fabricate.times(1, :past_workshop)
+        Fabricate.times(2, :workshop)
         recent_workshops = 10.times.map do |n|
           Fabricate(:workshop, date_and_time: n.days.ago)
         end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe Event, type: :model do
   context '#verified_students' do
     it 'returns all students who have verified their attendance' do
       event = Fabricate(:event)
-      2.times.map { Fabricate(:invitation, event: event, attending: true) }
-      3.times.map { Fabricate(:invitation, event: event, attending: true, verified: true) }
+      1.times.map { Fabricate(:invitation, event: event, attending: true) }
+      2.times.map { Fabricate(:invitation, event: event, attending: true, verified: true) }
 
-      expect(event.verified_students.count).to eq(3)
+      expect(event.verified_students.count).to eq(2)
     end
   end
 end

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe InvitationManager, type: :model do
 
   let(:chapter) { Fabricate(:chapter) }
   let(:workshop) { Fabricate(:workshop, chapter: chapter) }
-  let(:students) { Fabricate.times(3, :member) }
-  let(:coaches) { Fabricate.times(6, :member) }
+  let(:students) { Fabricate.times(2, :member) }
+  let(:coaches) { Fabricate.times(2, :member) }
 
   describe '#send_workshop_emails' do
     let(:mailer) { WorkshopInvitationMailer }
@@ -115,7 +115,7 @@ RSpec.describe InvitationManager, type: :model do
   describe '#send_monthly_attendance_reminder_emails', wip: true do
     it 'emails all attending members' do
       meeting = Fabricate(:meeting)
-      attendees = Fabricate.times(4, :attending_meeting_invitation, meeting: meeting).map(&:member)
+      attendees = Fabricate.times(2, :attending_meeting_invitation, meeting: meeting).map(&:member)
 
       attendees.each do |attendee|
         expect(MeetingInvitationMailer).to receive(:attendance_reminder).with(meeting, attendee)
@@ -128,7 +128,7 @@ RSpec.describe InvitationManager, type: :model do
   describe '#send_workshop_attendance_reminder_emails' do
     it 'emails all attending members' do
       workshop = Fabricate(:workshop)
-      invitations = Fabricate.times(4, :attending_workshop_invitation, workshop: workshop)
+      invitations = Fabricate.times(2, :attending_workshop_invitation, workshop: workshop)
 
       invitations.each do |invitation|
         expect(WorkshopInvitationMailer).to receive(:attending_reminder)
@@ -144,8 +144,8 @@ RSpec.describe InvitationManager, type: :model do
   describe '#send_workshop_waiting_list_reminders', wip: true do
     it 'emails everyone that hasn\'t already been reminded from the workshop\'s waitinglist' do
       workshop = Fabricate(:workshop)
-      invitations = Fabricate.times(4, :waitinglist_invitation, workshop: workshop)
-      reminded_invitations = Fabricate.times(3, :waitinglist_invitation_reminded, workshop: workshop)
+      invitations = Fabricate.times(2, :waitinglist_invitation, workshop: workshop)
+      reminded_invitations = Fabricate.times(2, :waitinglist_invitation_reminded, workshop: workshop)
 
       invitations.each do |invitation|
         expect(WorkshopInvitationMailer).to receive(:waiting_list_reminder)

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Sponsor, type: :model do
       describe 'searching by_name' do
         let!(:search_sponsor) { Fabricate(:sponsor, name: 'codebar') }
         before do
-          Fabricate.times(5, :sponsor)
+          Fabricate.times(2, :sponsor)
         end
 
         it 'matches on any part of the name' do

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe WorkshopInvitation, type: :model do
       new_workshop = Fabricate(:workshop, date_and_time: Time.zone.now)
       old_workshop = Fabricate(:workshop, date_and_time: Time.zone.now - 2.years)
 
-      4.times { Fabricate(:attended_coach, workshop: new_workshop) }
-      5.times { Fabricate(:attended_coach, workshop: old_workshop) }
+      2.times { Fabricate(:attended_coach, workshop: new_workshop) }
+      1.times { Fabricate(:attended_coach, workshop: old_workshop) }
 
-      expect(WorkshopInvitation.year(Time.zone.now.year).count).to eq(4)
-      expect(WorkshopInvitation.year((Time.zone.now - 2.years).year).count).to eq(5)
+      expect(WorkshopInvitation.year(Time.zone.now.year).count).to eq(2)
+      expect(WorkshopInvitation.year((Time.zone.now - 2.years).year).count).to eq(1)
     end
 
     context '#not_reminded' do
@@ -98,7 +98,7 @@ RSpec.describe WorkshopInvitation, type: :model do
     end
 
     it '#on_waiting_list' do
-      Fabricate.times(5, :workshop_invitation)
+      Fabricate.times(2, :workshop_invitation)
       waiting_list = Fabricate.times(2, :waitinglist_invitation)
 
       expect(WorkshopInvitation.on_waiting_list).to eq(waiting_list)

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Workshop, type: :model do
 
     context 'attendances' do
       it '#attendee? for students' do
-        attendee_invites = 4.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
+        attendee_invites = 1.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
         nonattendee_invites = 2.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: false) }
 
         attendee_invites.each { |a| expect(workshop.attendee?(a.member)).to be true }
@@ -160,7 +160,7 @@ RSpec.describe Workshop, type: :model do
       end
 
       it '#attendee? for coaches' do
-        attendee_invites = 4.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
+        attendee_invites = 1.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
         nonattendee_invites = 2.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: false) }
 
         attendee_invites.each { |a| expect(workshop.attendee?(a.member)).to be true }
@@ -170,18 +170,18 @@ RSpec.describe Workshop, type: :model do
 
     context 'Waitlist attendance' do
       it '#waitlisted? for students' do
-        invitations = 5.times.collect { Fabricate(:workshop_invitation, workshop: workshop) }
+        invitations = 2.times.collect { Fabricate(:workshop_invitation, workshop: workshop) }
         invitations.each { |invitation| WaitingList.add(invitation) }
-        attendee_invites = 4.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
+        attendee_invites = 1.times.collect { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
 
         invitations.each { |a| expect(workshop.waitlisted?(a.member)).to be true }
         attendee_invites.each { |a| expect(workshop.waitlisted?(a.member)).to be false }
       end
 
       it '#waitlisted? for coaches' do
-        invitations = 5.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop) }
+        invitations = 2.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop) }
         invitations.each { |invitation| WaitingList.add(invitation) }
-        attendee_invites = 4.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
+        attendee_invites = 1.times.collect { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
 
         invitations.each { |a| expect(workshop.waitlisted?(a.member)).to be true }
         attendee_invites.each { |a| expect(workshop.waitlisted?(a.member)).to be false }

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe WorkshopPresenter do
   it '#attendees_emails' do
     workshop = Fabricate(:workshop)
     presenter = WorkshopPresenter.new(workshop)
-    members = Fabricate.times(6, :member)
+    members = Fabricate.times(2, :member)
     members.each_with_index do |member, index|
       index % 2 == 0 ? Fabricate(:attending_workshop_invitation, member: member, workshop: workshop) :
         Fabricate(:attending_workshop_invitation, member: member, workshop: workshop, role: 'Coach')


### PR DESCRIPTION
Reduce test run time by reducing the amount of test data fabricated in multiple test files.  Based on time savings when running local tests this change reduced test run time by 79.8 seconds.
