### PR TITLE
spec helper: Remove removed keyword argument full: true from #save_screenshot

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,7 @@ RSpec.configure do |config|
       screenshot_filename = "#{filename}:#{line_number}.png"
 
       # Save the screenshot using the custom filename
-      page.save_screenshot(screenshot_filename, full: true)
+      page.save_screenshot(screenshot_filename)
     end
   end
 


### PR DESCRIPTION
As far as I can tell, `#save_screenshot` doesn't accept the `:full` option. This means that when a js test fails, it fails twice.

This should ensure it only fails once.