### PR TITLE
chore: Remove unused gosquard

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,7 +23,6 @@
 //= require pickadate/picker.date
 //= require pickadate/picker.time
 //= require analytics
-//= require gosquared
 //= require subscriptions-toggle
 //= require invitations
 //= require cocoon

--- a/app/assets/javascripts/gosquared.js
+++ b/app/assets/javascripts/gosquared.js
@@ -1,3 +1,0 @@
-!function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];d.src='//d1l6p2sc9645hc.cloudfront.net/tracker.js';q.parentNode.insertBefore(d,q)} (window,document,'script','_gs');
-
-_gs('GSN-171446-A');


### PR DESCRIPTION
This was introduced in 34de45fa4c2846abab0c8907ef343688791b2043, but has not been used for several years.

Removing this will make the JS bundle smaller, improving the user experience.

This was [discussed with @matyikriszta in the codebar Slack](https://codebar.slack.com/archives/C0970A68344/p1754467315999379)