### PR TITLE
README.md: Use a current GH Actions build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codebar website & event planner
 
-[![CI](https://github.com/codebar/planner/workflows/CI/badge.svg?branch=master)](https://github.com/codebar/planner/actions?query=workflow%3ACI)
+[![CI](https://github.com/codebar/planner/actions/workflows/ruby.yml/badge.svg)](https://github.com/codebar/planner/actions/workflows/ruby.yml)
 [![Coverage Status](https://coveralls.io/repos/codebar/planner/badge.png)](https://coveralls.io/r/codebar/planner)
 
 A tool to help manage [codebar.io](https://codebar.io) members and events.


### PR DESCRIPTION
The badge code had changed, it currently shows just "unknown" in gray. This change fixes it, to display green if default branch builds green.