### PR TITLE
chore: Don't attempt to upgrade Rails via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
   - dependency-name: pg
     versions:
     - ">= 1.2.a, < 1.3"
+  - dependency-name: rails
   - dependency-name: stripe
     versions:
     - "> 4.18.1"


### PR DESCRIPTION
This PR tells Dependabot to not try including Ruby on Rails in its update attempts.

We are a bit behind Rails' current release, so this allows us to use the "grouped" Pull Requests from Dependabot while managing Rails upgrades ourselves, manually. One such upgrade is ongoing in #2250.