### PR TITLE
chore: remove 2024 impact report banner

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,7 +1,7 @@
 - title t('homepage.title')
 
-.alert.alert-dark.mb-0.text-center
-  We’re beyond proud to launch our <strong>2024</strong> Impact Report, which you can read here - <a href="https://impact-report.codebar.io/" class="text-dark" target="_blank"">impact-report.codebar.io</a>
+-# .alert.alert-dark.mb-0.text-center
+-# We’re beyond proud to launch our <strong>2024</strong> Impact Report, which you can read here - <a href="https://impact-report.codebar.io/" class="text-dark" target="_blank"">impact-report.codebar.io</a>
 
 .homepage-hero.d-flex.align-items-center
   .container.d-flex


### PR DESCRIPTION
I'm working on a PR to improve the accessibility of the website, and there was a warning about the banner.

We're more than half way through 2024, 2025 is coming up soon :)

So, instead of putting effort into fixing this banner, let's not display it until we have the next thing to draw attention to.

#### Before

<img width="1470" height="507" alt="image" src="https://github.com/user-attachments/assets/1718abaf-0485-4afa-99b8-a5dc5f9bc959" />

#### After

<img width="1470" height="442" alt="image" src="https://github.com/user-attachments/assets/a250a3d1-61b1-4eee-9c99-7251b1e8e8f5" />
