### PR TITLE
Revert "chore: remove 2024 impact report banner"

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,7 +1,7 @@
 - title t('homepage.title')
 
--# .alert.alert-dark.mb-0.text-center
--# We’re beyond proud to launch our <strong>2024</strong> Impact Report, which you can read here - <a href="https://impact-report.codebar.io/" class="text-dark" target="_blank"">impact-report.codebar.io</a>
+.alert.alert-dark.mb-0.text-center
+  We’re beyond proud to launch our <strong>2024</strong> Impact Report, which you can read here - <a href="https://impact-report.codebar.io/" class="text-dark" target="_blank"">impact-report.codebar.io</a>
 
 .homepage-hero.d-flex.align-items-center
   .container.d-flex


### PR DESCRIPTION
This reverts commit 5294c81730648dd05b61eb7fa7ba42bbe75ec7a3.

we were over-enthusiastic in making this change, and it will need to be reverted before we roll out our next production bump

FYI @KimberleyCook 