### PR TITLE
CI: Do not fail the build if Coveralls fails

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,6 +43,7 @@ jobs:
         RAILS_ENV: test
       run: bundle exec rake spec
     - name: Report to Coveralls
+      continue-on-error: true # Don't fail the build if Coveralls fails to upload.
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
We had many build failures with "oh, the code coverage was not sent to that service", which is a little "them problem" rather than an "us problem", so I configured this to not be considered a failure.

To think about for next week's meeting: Do we wish to keep sending these coverage reports? How do we want to use them?

Screenshot of today's Coveralls:

<img width="891" height="697" alt="image" src="https://github.com/user-attachments/assets/2ba2f73e-c9b3-4db9-aabc-808acced999d" />


With this change, the Checks look like this, **non-failing** (the icon for the "Report to Coveralls" section is a circle with a checkmark in it), even though that non-essential service is down:

<img width="993" height="643" alt="image" src="https://github.com/user-attachments/assets/c3dca3a8-5b57-40f3-84ea-2243d892ff12" />
