### PR TITLE
fix: flaky test

### DIFF
--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe MeetingPresenter do
 
   it '#attendees_emails' do
     attendees = Fabricate.times(4, :attending_meeting_invitation, meeting: meeting)
-
-    expect(event.attendees_emails).to eq(
-      attendees.map(&:member).map(&:email).sort.join(', ')
-    )
+    emails = attendees.map(&:member).map(&:email)
+    emails.each do |email|
+      expect(event.attendees_emails).to include(email)
+    end
   end
 
   it '#time' do


### PR DESCRIPTION
Fix attendees emails test which was trying to match two strings together when order can change and cause flakiness.  Resolved by expecting string to include emails so order shouldn't matter