### PR TITLE
Procfile: Drop the Worker process type, and use Heroku Scheduler instead

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec rake jobs:workoff --trace


### PR DESCRIPTION
We use the [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) to run the "jobs:workoff" Rake task (from the [Delayed Job](https://github.com/collectiveidea/delayed_job) gem).

https://devcenter.heroku.com/articles/procfile#other-process-types mentions that

> No process types besides `web` and `release` have special properties.

And this is a `worker:` named process type.

This whole "worker" dyno can be stopped. The cost for this dyno is about 25 USD per month.

We have it double-configured, both correctly in Scheduler AND wrongly with this line in the Procfile. 



