### PR TITLE
Limit access to announcements

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,4 +1,4 @@
-class Admin::AnnouncementsController < Admin::ApplicationController
+class Admin::AnnouncementsController < SuperAdmin::ApplicationController
   before_action :set_announcement, only: %i[update edit]
 
   def index


### PR DESCRIPTION
Quick fix for #2296 

This updates the base controller for the AnnouncementController so that only admins, not admins + organisers, can access the announcements endpoint