### PR TITLE
fix: Improve introduction language

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
   homepage:
     title: Homepage
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."
@@ -339,7 +339,7 @@ en:
     new:
       intro_html: "We provide a welcoming, inclusive, and supportive learning environment, with a strict zero-tolerance policy for any form of harassment or inappropriate behavior. Please take a moment to review our <a href='%{link}'>code of conduct</a> before signing up."
       students:
-        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented minority groups."
+        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented groups."
         github: "When you click the sign-up button, you'll be redirected to GitHub. After logging in with your GitHub account, you'll return to the codebar website. If you don’t have an account yet, creating one is quick and easy—and it will be useful as you begin your coding journey!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
   terms_and_conditions:

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -48,7 +48,7 @@ en-AU:
         format: '%u%n'
   homepage:
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."
@@ -228,7 +228,7 @@ en-AU:
     new:
       intro_html: "We provide a welcoming, inclusive, and supportive learning environment, with a strict zero-tolerance policy for any form of harassment or inappropriate behavior. Please take a moment to review our <a href='%{link}'>code of conduct</a> before signing up."
       students:
-        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented minority groups."
+        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented groups."
         github: "When you click the sign-up button, you'll be redirected to GitHub. After logging in with your GitHub account, you'll return to the codebar website. If you don’t have an account yet, creating one is quick and easy—and it will be useful as you begin your coding journey!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
   footer:

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -47,8 +47,8 @@ en-GB:
         precision: 0
         format: '%u%n'
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."
@@ -228,7 +228,7 @@ en-GB:
     new:
       intro_html: "We provide a welcoming, inclusive, and supportive learning environment, with a strict zero-tolerance policy for any form of harassment or inappropriate behavior. Please take a moment to review our <a href='%{link}'>code of conduct</a> before signing up."
       students:
-        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented minority groups."
+        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented groups."
         github: "When you click the sign-up button, you'll be redirected to GitHub. After logging in with your GitHub account, you'll return to the codebar website. If you don’t have an account yet, creating one is quick and easy—and it will be useful as you begin your coding journey!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
   footer:

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -48,7 +48,7 @@ en-US:
         format: '%u%n'
   homepage:
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."
@@ -226,7 +226,7 @@ en-US:
     new:
       intro_html: "We provide a welcoming, inclusive, and supportive learning environment, with a strict zero-tolerance policy for any form of harassment or inappropriate behavior. Please take a moment to review our <a href='%{link}'>code of conduct</a> before signing up."
       students:
-        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented minority groups."
+        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented groups."
         github: "When you click the sign-up button, you'll be redirected to GitHub. After logging in with your GitHub account, you'll return to the codebar website. If you don’t have an account yet, creating one is quick and easy—and it will be useful as you begin your coding journey!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
   footer:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -48,7 +48,7 @@ fi:
         format: '%u%n'
   homepage:
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."
@@ -228,7 +228,7 @@ fi:
     new:
       intro_html: "We provide a welcoming, inclusive, and supportive learning environment, with a strict zero-tolerance policy for any form of harassment or inappropriate behavior. Please take a moment to review our <a href='%{link}'>code of conduct</a> before signing up."
       students:
-        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented minority groups."
+        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented groups."
         github: "When you click the sign-up button, you'll be redirected to GitHub. After logging in with your GitHub account, you'll return to the codebar website. If you don’t have an account yet, creating one is quick and easy—and it will be useful as you begin your coding journey!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
   footer:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -47,7 +47,7 @@ fr:
         format: '%u%n'
   homepage:
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -48,7 +48,7 @@
         format: '%u%n'
   homepage:
     intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
-    explanation: "Our goal is to enable minority group members to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
+    explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"
       students_explanation_p1: "Our students come from diverse backgrounds—some aspiring to become full-time developers, while others simply want to learn the basics of coding in a supportive environment."
@@ -228,7 +228,7 @@
     new:
       intro_html: "We provide a welcoming, inclusive, and supportive learning environment, with a strict zero-tolerance policy for any form of harassment or inappropriate behavior. Please take a moment to review our <a href='${link}'>code of conduct</a> before signing up."
       students:
-        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented minority groups."
+        intro_html: "If you’re interested in attending as a student, be sure to check our <a href='%{link}'>eligibility criteria</a>. Our workshops and events are exclusively for women, non-binary, LGBTQ+ members, and people from underrepresented groups."
         github: "When you click the sign-up button, you'll be redirected to GitHub. After logging in with your GitHub account, you'll return to the codebar website. If you don’t have an account yet, creating one is quick and easy—and it will be useful as you begin your coding journey!"
       invitations: "Invitations are sent out periodically, so don't worry if you don't receive one as soon as you register."
   footer:


### PR DESCRIPTION
> Our workshops and events are exclusively for women, non-binary, LGBTQ+
> members, and people from underrepresented **minority** groups (emphasis mine)

This might seem like nitpicking, but women are not a minority group. Whenever we divide up the general population along gender axis, women will always be the majority group.

However, women are underrepresented in programming roles, along with people from other underrepresented groups.

This changeset improves the copy on the website a bit.