### PR TITLE
feat: add checkboxes for how you found us options during onboarding

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,6 +27,7 @@
 //= require dietary-restrictions
 //= require cocoon
 //= require font_awesome5
+//= require how-you-found-us
 
 $(function() {
   $("body").removeClass("no-js");

--- a/app/assets/javascripts/how-you-found-us.js
+++ b/app/assets/javascripts/how-you-found-us.js
@@ -1,0 +1,20 @@
+$(document).ready(function() {
+  const $otherRadioButton = $('#member_how_you_found_us_other');
+  const $otherReason = $('#member_how_you_found_us_other_reason');
+  const $elementToToggle = $otherReason.parent();
+
+  function toggleOtherReason() {
+    if ($otherRadioButton.is(':checked')) {
+      $elementToToggle.removeClass('d-none').hide().slideDown(50);
+      $otherReason.prop('disabled', false).focus(); // Optional — disabling is not needed
+    } else {
+      $elementToToggle.slideUp(50, function() {
+        $elementToToggle.addClass('d-none');
+        $otherReason.val('');
+      });
+    }
+  }
+
+  toggleOtherReason();
+  $('input[name="member[how_you_found_us]"]').on('change', toggleOtherReason);
+});

--- a/app/controllers/concerns/member_concerns.rb
+++ b/app/controllers/concerns/member_concerns.rb
@@ -10,7 +10,8 @@ module MemberConcerns
 
     def member_params
       params.require(:member).permit(
-        :pronouns, :name, :surname, :email, :mobile, :about_you, :skill_list, :newsletter, :other_dietary_restrictions, :other_reason,  :how_you_found_us_other_reason, how_you_found_us: [], dietary_restrictions: [] 
+        :pronouns, :name, :surname, :email, :mobile, :about_you, :skill_list, :newsletter, :other_dietary_restrictions, :how_you_found_us,
+        :how_you_found_us_other_reason, dietary_restrictions: []
       ).tap do |params|
         # We want to keep Rails' hidden blank field in the form so that all dietary restrictions for a member can be
         # removed by submitting the form with all check boxes unticked. However, we want to remove the blank value
@@ -29,18 +30,13 @@ module MemberConcerns
       @member = current_user
     end
 
-    def how_you_found_us_selections
-      how_found = Array(member_params[:how_you_found_us]).reject(&:blank?)
-      other_reason = member_params[:how_you_found_us_other_reason]
+    def how_you_found_us_selections_valid?
+      how_found_present = member_params[:how_you_found_us].present?
+      other_reason_present = member_params[:how_you_found_us_other_reason].present?
+      return false if member_params[:how_you_found_us] == 'other' && !other_reason_present
+      return true if member_params[:how_you_found_us] == 'other' && other_reason_present
 
-      how_found << other_reason if other_reason.present?
-      how_found.uniq!
-
-      how_found
-    end
-
-    def member_params_without_how_you_found_us_other_reason
-      member_params.to_h.except(:how_you_found_us_other_reason)
+      how_found_present != other_reason_present
     end
   end
 end

--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -13,14 +13,19 @@ class Member::DetailsController < ApplicationController
   end
 
   def update
-    if how_you_found_us_selections.blank?
-      @member.assign_attributes(member_params_without_how_you_found_us_other_reason)
-      @member.errors.add(:how_you_found_us, 'You must select at least one option')
+    attrs = member_params
+    attrs[:how_you_found_us_other_reason] = nil if attrs[:how_you_found_us] != 'other'
+
+    unless how_you_found_us_selections_valid?
+      @member.errors.add(:how_you_found_us, 'You must select one option')
       return render :edit
     end
+    attrs[:how_you_found_us] = params[:member][:how_you_found_us] if params[:member][:how_you_found_us].present?
 
-    attrs = member_params_without_how_you_found_us_other_reason
-    attrs[:how_you_found_us] = how_you_found_us_selections
+    if params[:member][:how_you_found_us_other_reason].present? && attrs[:how_you_found_us] == 'other'
+      attrs[:how_you_found_us_other_reason] =
+        params[:member][:how_you_found_us_other_reason]
+    end
 
     return render :edit unless @member.update(attrs)
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,12 +1,13 @@
 class Member < ApplicationRecord
   include Permissions
 
-  HOW_YOU_FOUND_US_OPTIONS = [
-    'From a friend',
-    'Search engine (Google etc.)',
-    'Social Media',
-    "One of Codebar's hosts or partners"
-  ].freeze
+  enum how_you_found_us: {
+    from_a_friend: 0,
+    search_engine: 1,
+    social_media: 2,
+    codebar_host_or_partner: 3,
+    other: 4
+  }
 
   has_many :attendance_warnings
   has_many :bans
@@ -52,7 +53,7 @@ class Member < ApplicationRecord
 
   acts_as_taggable_on :skills
 
-  attr_accessor :attendance, :newsletter, :how_you_found_us_other_reason
+  attr_accessor :attendance, :newsletter
 
   def banned?
     bans.active.present? || bans.permanent.present?

--- a/app/views/member/details/edit.html.haml
+++ b/app/views/member/details/edit.html.haml
@@ -29,21 +29,20 @@
           %span.text-danger= @member.errors[:how_you_found_us].first
         .col-12.mb-3
           %fieldset
-            %legend= t('member.details.edit.how_you_found_us')
-            %span *
-
             = f.input :how_you_found_us,
-                      as: :check_boxes,
-                      collection: Member::HOW_YOU_FOUND_US_OPTIONS,
-                      item_wrapper_class: 'form-check',
+                      as: :radio_buttons,
+                      collection: Member.how_you_found_us.keys,
+                      label_method: ->(option) { t("member.details.edit.how_you_found_us_options.#{option}") },
+                      value_method: :to_s,
+                      label: t('member.details.edit.how_you_found_us_label'),
+                      item_wrapper_class: 'form-check d-flex align-items-center mb-2',
                       label_item: true,
-                      input_html: { class: 'form-check-input' },
-                      label_html: { class: 'form-check-label', style: 'margin-left: 8px;' }
+                      input_html: { class: 'form-check-input me-2', style: 'margin-top: 0;' },
+                      label_html: { class: 'form-check-label', style: 'margin-left: 0;' }
 
-          = f.input :how_you_found_us_other_reason,
-                    label: t('member.details.edit.how_you_found_us_other_reason'),
-                    placeholder: 'Please specify how you heard about us',
-                    input_html: { class: 'form-control w-100' }
+            = f.input :how_you_found_us_other_reason,
+                label: t('member.details.edit.how_you_found_us_other_reason'),
+                input_html: { class: 'form-control w-100' }
         = f.input :newsletter, as: :boolean, checked_value: true, unchecked_value: false
         .text-right.mb-4
           = hidden_field_tag :next_page, step2_member_path(member_type: @type)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,8 +442,14 @@ en:
       edit:
         title: Almost there...
         summary: We need some more details from you to finish creating your account. We use these to help run our events.
-        how_you_found_us: "How did you find out about us?"
-        how_you_found_us_other_reason: "Please specify (if Other)"
+        how_you_found_us_label: "How did you find out about us?*"
+        how_you_found_us_other_reason: "Please specify how you found us"
+        how_you_found_us_options:
+          from_a_friend: "From a friend"
+          search_engine: "Search engine (Google etc.)"
+          social_media: "Social media"
+          codebar_host_or_partner: "One of Codebar's hosts or partners"
+          other: "Other"
         coach:
           about_you: What experience do you have? What languages do you like to use? Tell us a little bit about yourself!
         student:

--- a/db/migrate/20250823151717_add_how_you_found_us_options.rb
+++ b/db/migrate/20250823151717_add_how_you_found_us_options.rb
@@ -1,5 +1,6 @@
 class AddHowYouFoundUsOptions < ActiveRecord::Migration[7.0]
   def change
-    add_column :members, :how_you_found_us, :text, array: true, default: []
+    add_column :members, :how_you_found_us, :integer
+    add_column :members, :how_you_found_us_other_reason, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -397,7 +397,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_23_151717) do
     t.datetime "opt_in_newsletter_at", precision: nil
     t.enum "dietary_restrictions", default: [], array: true, enum_type: "dietary_restriction_enum"
     t.string "other_dietary_restrictions"
-    t.text "how_you_found_us", default: [], array: true
+    t.integer "how_you_found_us"
+    t.string "how_you_found_us_other_reason"
     t.index ["email"], name: "index_members_on_email", unique: true
   end
 

--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -4,7 +4,6 @@ Fabricator(:member) do
   surname { Faker::Name.last_name }
   email { Faker::Internet.email }
   about_you { Faker::Lorem.sentence }
-  how_you_found_us { ['From a friend'] }
   auth_services(count: 1) { Fabricate(:auth_service) }
   accepted_toc_at { Time.zone.now }
 end

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'A new student signs up', type: :feature do
   end
 
   scenario 'A visitor must fill in all mandatory fields in order to sign up' do
-    member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil, how_you_found_us: [])
+    member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil, how_you_found_us: nil, how_you_found_us_other_reason: nil)
     member.update(can_log_in: true)
     login member
 
@@ -27,7 +27,7 @@ RSpec.feature 'A new student signs up', type: :feature do
     expect(page).to have_content "Surname can't be blank"
     expect(page).to have_content "Email address can't be blank"
     expect(page).to have_content "About you can't be blank"
-    expect(page).to have_content "You must select at least one option"
+    expect(page).to have_content "You must select one option"
   end
 
   scenario 'A new member details are successfully captured' do
@@ -45,6 +45,9 @@ RSpec.feature 'A new student signs up', type: :feature do
     check 'Other'
     fill_in 'Other dietary restrictions', with: 'peanut allergy'
     find('#member_how_you_found_us_from_a_friend').click
+
+    find('#member_how_you_found_us_other').click
+    expect(page).to have_content('Please specify how you found us')
     fill_in 'member_how_you_found_us_other_reason', with: 'found on a poster', id: true
     click_on 'Next'
 

--- a/spec/features/subscribing_to_newsletter_spec.rb
+++ b/spec/features/subscribing_to_newsletter_spec.rb
@@ -27,8 +27,7 @@ RSpec.feature 'Subscribing to the newsletter', type: :feature do
       fill_in 'member_surname', with: 'Doe'
       fill_in 'member_email', with: 'jane@codebar.io'
       fill_in 'member_about_you', with: Faker::Lorem.paragraph
-      find('#how_you_found_us_from-a-friend').click
-      fill_in 'member_how_you_found_us_other_reason', with: Faker::Lorem.paragraph, id: true
+      find('#member_how_you_found_us_from_a_friend').click
 
       click_on 'Next'
     end
@@ -48,7 +47,7 @@ RSpec.feature 'Subscribing to the newsletter', type: :feature do
       fill_in 'member_surname', with: 'Doe'
       fill_in 'member_email', with: 'jane@codebar.io'
       fill_in 'member_about_you', with: Faker::Lorem.paragraph
-      find('#how_you_found_us_from-a-friend').click
+      find('#member_how_you_found_us_other').click
       fill_in 'member_how_you_found_us_other_reason', with: Faker::Lorem.paragraph, id: true
 
       uncheck 'newsletter'


### PR DESCRIPTION
Add a column to member table called how_you_found_us and is populated with an array depending on options selected.  How you found us is a mandatory field on the onboarding page and if not added then warning text will appear.  Adding the 'how you found us' reason to a user's profile will follow in another PR.

Making the 'other' option a checkbox that reveals a text input would likely require some bespoke javascript code as simple forms don't allow that.  I have therefore just left the text field visible and removed the 'other' option so the implementation is kept simple.  

The options selected including the other text field are saved into the db in the members table under the `how_you_found_us` column as an array.

The below red message appears if you try to click next without selecting a reason

<img width="751" height="327" alt="Screenshot 2025-08-26 at 14 34 05" src="https://github.com/user-attachments/assets/bc9210f9-221f-4e3f-bc6e-24ad84c2ceaf" />
