### PR TITLE
Make event rendering faster

### DIFF
--- a/app/presenters/member_presenter.rb
+++ b/app/presenters/member_presenter.rb
@@ -1,6 +1,6 @@
 class MemberPresenter < BasePresenter
   def organiser?
-    has_role? :organiser, :any
+    @organiser ||= has_role? :organiser, :any
   end
 
   def event_organiser?(event)

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -9,7 +9,7 @@
           - if @user.attending?(event.__getobj__)
             %span.badge.bg-success.mb-3.mb-md-0
               = link_to 'Attending', event.path, class: 'text-light text-decoration-none'
-          - if @user.event_organiser?(event)
+          - if @user.organiser? && @user.event_organiser?(event)
             %span.badge.bg-secondary.mb-3.mb-md-0
               = link_to 'Manage', event.admin_path, class: 'text-light text-decoration-none'
       .order-md-1


### PR DESCRIPTION
This PR makes event rendering slightly faster, by memoising `MemberPresenter#organiser?` and using it to prevent unnecessary db queries (`@user.event_organiser?(event)`)

This PR overlaps slightly with @jonodrew's work in https://github.com/codebar/planner/pull/2305, which will make this much faster.

#### Before

<img width="897" height="651" alt="image" src="https://github.com/user-attachments/assets/e8324a4d-94a0-4a0b-a18b-17ff5ce2f263" />


#### After

<img width="765" height="640" alt="image" src="https://github.com/user-attachments/assets/1610b7b9-434b-4f29-a1dd-1ad8c81d8587" />
