### PR TITLE
update bin/drspec to use `bundle exec`

### DIFF
--- a/bin/drspec
+++ b/bin/drspec
@@ -2,4 +2,4 @@
 
 set -e
 
-docker compose exec web rspec $@
+docker compose exec web bundle exec rspec $@


### PR DESCRIPTION
fixes errors such as:

```
You have already activated activesupport 7.1.5.1, but your Gemfile requires activesupport 7.0.8.1. Prepending `bundle exec` to your command may solve this.
```

This can occur when switching between branches that uses different Rails versions. e.g. switching between the branch used for the 7.1 upgrade and a branch that was still on 7.0.

Isn't really a downside to adding this so feels worthwhile to mark the change.