### PR TITLE
chore: fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,3 +1,8 @@
+---
+name: New issue
+about: Use this template for tracking new issues
+---
+
 ## Description of the issue 📄
 
 ## Screenshots 📷


### PR DESCRIPTION
This is an attempt at fixing the broken issue template

> To be displayed with a  checkmark in the community profile checklist, issue
> templates must be located in the .github/ISSUE_TEMPLATE folder and contain
> valid name: and about: keys in the YAML frontmatter (for issue templates
> defined in .md files)

See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository

I'm interpreting that quote to mean that the issue template won't work, unless it have `name:` and `about:` fields in the frontmatter.