### PR TITLE
Add haml-lint gem

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,7 @@
+linters:
+  # We don't need to enforce line length in HAML files
+  LineLength:
+    enabled: false
+  # We don't need to enforce length of HAML files
+  ViewLength:
+    enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'public_activity'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'haml_lint', require: false
   gem 'letter_opener'
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,12 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    haml_lint (0.66.0)
+      haml (>= 5.0)
+      parallel (~> 1.10)
+      rainbow
+      rubocop (>= 1.0)
+      sysexits (~> 1.1)
     hashie (5.0.0)
     high_voltage (4.0.0)
     htmlentities (4.3.4)
@@ -519,6 +525,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.7)
     stripe (9.0.0)
+    sysexits (1.2.0)
     temple (0.10.3)
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
@@ -583,6 +590,7 @@ DEPENDENCIES
   foreman
   friendly_id
   haml
+  haml_lint
   high_voltage
   icalendar
   image_processing


### PR DESCRIPTION
https://github.com/sds/haml-lint is a linter for HAML markup.

I added a minimal configuration for it.

Future: Can run in CI.

Start it with:

    bundle exec haml-lint

Related to discussion on linting Ruby code.