### PR TITLE
chore: Configure plugins in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,16 +9,17 @@ AllCops:
     - bin/**/*
     - vendor/bundle/**/*
 
-require:
-  - rubocop
+plugins:
+  - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
-  - rubocop-performance
 
 Layout/LineLength:
   Max: 120
   Exclude:
     - "spec/**/*"
+    - "app/views/pages/*.haml"
+    - "app/views/**/*.erb"
 
 Layout/EndOfLine:
   EnforcedStyle: lf


### PR DESCRIPTION
This PR avoids a warning at RuboCop startup.