### PR TITLE
Update Skills field to use hint and placeholder

### DIFF
--- a/app/views/members/_new.html.haml
+++ b/app/views/members/_new.html.haml
@@ -14,6 +14,6 @@
       = f.input :about_you, as: :text, label: 'Tell us a little bit about yourself', input_html: { rows: 3 }, required: true
     - if @member.coach?
       .col-12
-        = f.input :skill_list, label: 'Skills, enter as a comma separated list', input_html: { value: @member.skill_list.join(", ") }
+        = f.input :skill_list, input_html: { value: @member.skill_list.join(", ") }
     .col-12.text-right
       = f.button :button, submit_text, class: 'btn btn-primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,6 +671,7 @@ en:
         name: 'Grace'
         surname: 'Hopper'
         pronouns: 'e.g she/her/they'
+        skill_list: 'e.g. HTML, CSS, JavaScript, React, Ruby, Python, SQL'
       job:
         company: 'e.g. codebar'
         company_website: 'e.g. https://codebar.io'
@@ -686,6 +687,7 @@ en:
     hints:
       member:
         email: 'This is needed so we can email you invitations to our events'
+        skill_list: 'Enter as a comma separated list'
       workshop_invitation:
         note: 'Pairing preferences or anything else you think we should know.'
       job:
@@ -721,6 +723,8 @@ en:
         accessibility_info: Accessibility information
         number_of_coaches: Coach spots
         seats: Student spots
+      member:
+        skill_list: Skills
   activerecord:
     attributes:
       job:


### PR DESCRIPTION
Pulling this out of #2312 as a separate PR following @davidmillen50's code review.

Just updates the Skills field to match the same style as other fields on the member form and to put the label text in the `en.yml` file instead of in the view.