### PR TITLE
fix(logging): implement semantic logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem 'rails', '~> 7.1.5.1' # LOCKED: It is Rails.
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 
+gem "amazing_print" # colourful output (suggested by rails_semantic_logger)
+gem "rails_semantic_logger" # condense log lines: https://github.com/codebar/planner/issues/2339
+
 gem 'acts-as-taggable-on'
 gem 'benchmark' # LOCKED: Added because of activesupport 7.0
 gem 'bigdecimal' # LOCKED: Added because of activesupport 7.0
@@ -114,7 +117,6 @@ end
 
 group :production do
   gem 'foreman'
-  gem 'rails_12factor'
 end
 
 gem 'rollbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       zeitwerk (>= 2.4, < 3.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    amazing_print (1.8.1)
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1137.0)
@@ -397,11 +398,10 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails4-autocomplete (1.1.1)
       rails (>= 3.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
+    rails_semantic_logger (4.18.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (7.1.5.1)
       actionpack (= 7.1.5.1)
       activesupport (= 7.1.5.1)
@@ -496,6 +496,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    semantic_logger (4.17.0)
+      concurrent-ruby (~> 1.0)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
     simple_form (5.3.1)
@@ -565,6 +567,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on
+  amazing_print
   benchmark
   better_errors
   bigdecimal
@@ -621,7 +624,7 @@ DEPENDENCIES
   rails (~> 7.1.5.1)
   rails-html-sanitizer (~> 1.6.2)
   rails4-autocomplete
-  rails_12factor
+  rails_semantic_logger
   reline
   rolify
   rollbar

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,11 @@ module Planner
     config.active_record.yaml_column_permitted_classes = [Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, ActiveSupport::HashWithIndifferentAccess]
 
     config.active_record.belongs_to_required_by_default = true
+
+    if ENV["RAILS_LOG_TO_STDOUT"].present?
+      $stdout.sync = true
+      config.rails_semantic_logger.add_file_appender = false
+      config.semantic_logger.add_appender(io: $stdout, formatter: config.rails_semantic_logger.format)
+    end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -49,4 +49,6 @@ on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::Base.establish_connection
   end
+
+  SemanticLogger.reopen
 end


### PR DESCRIPTION
we currently run out of log quota on a daily basis, so this
change aims to condense the log lines so we don't. :)

therefor we now use the rails_semantic_logger gem as its purpose
is to help with that. this commit also replaces rails_12factor
(which is why it's removed) since it would otherwise conflict with
the new gem.

logging config for all "environments" gets appeneded in application.rb
now.

resolves: #2339
