### PR TITLE
chore: freeze postgres version for local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17
+    image: postgres:17-bookworm
     ports:
       - 5433:5432
     volumes:


### PR DESCRIPTION
This fixes a collation issue in local, see https://github.com/docker-library/postgres/issues/1356 The `-bookworm` version works with our codebase, `-trixie` not so much

This will buy us another few years, until we have to fix local again.