### PR TITLE
chore: lock gem platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,8 +162,9 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (2.3.2)
-      rb_sys (~> 0.9)
+    commonmarker (2.3.2-aarch64-linux)
+    commonmarker (2.3.2-x86_64-darwin)
+    commonmarker (2.3.2-x86_64-linux)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
@@ -202,7 +203,9 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     font_awesome5_rails (1.5.0)
       nokogiri (>= 1.11.3)
       railties (>= 4.2)
@@ -283,7 +286,6 @@ GEM
     mini_magick (5.3.0)
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.25.5)
     multi_xml (0.6.0)
     mutex_m (0.3.0)
@@ -299,8 +301,11 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -328,7 +333,9 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    pg (1.6.2)
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-x86_64-darwin)
+    pg (1.6.2-x86_64-linux)
     pickadate-rails (3.5.6.1)
       railties (>= 3.1.0)
     popper_js (2.11.8)
@@ -420,12 +427,9 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
-    rake-compiler-dock (1.9.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rb_sys (0.9.117)
-      rake-compiler-dock (= 1.9.1)
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -571,7 +575,9 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  ruby
+  aarch64-linux
+  x86_64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   acts-as-taggable-on


### PR DESCRIPTION
This stops us compiling Postgres gems and others, and just use the precompiled ones.

For the mentioned platforms that we wish to support. This list of specified platforms can grow, as we may need more (some developer uses a new platform, we add it as a supported one).

This speeds up install considerably and removes some transitive dependencies, that are only using during compilation.