### PR TITLE
cleanup: Lint "Rails/Present"

### DIFF
--- a/app/views/virtual_workshops/show.html.haml
+++ b/app/views/virtual_workshops/show.html.haml
@@ -18,7 +18,7 @@
         = t('workshops.virtual.lead')
       %p.lead
         = t('workshops.virtual.intro', chapter_email: @workshop.chapter.email)
-      - unless @workshop.description.blank?
+      - if @workshop.description.present?
         %p.description
           = sanitize(@workshop.description)
       = render 'workshops/actions' unless current_user&.banned?

--- a/app/views/workshops/show.html.haml
+++ b/app/views/workshops/show.html.haml
@@ -16,7 +16,7 @@
     .col.col-md-9
       %p.lead
         = t('workshops.lead')
-      - unless @workshop.description.blank?
+      - if @workshop.description.present?
         %p
           = sanitize(@workshop.description)
       = render 'actions' unless current_user&.banned?


### PR DESCRIPTION
This was the warning this fixes, in templates:

> Use if @workshop.description.present? instead of unless @workshop.description.blank?.

Found using haml-lint.

The final line of output in haml-lint was:

> 172 files inspected, 750 lints detected