### PR TITLE
Gemfile.lock: also allow a macOS "platform"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     commonmarker (2.3.2-aarch64-linux)
+    commonmarker (2.3.2-arm64-darwin)
     commonmarker (2.3.2-x86_64-darwin)
     commonmarker (2.3.2-x86_64-linux)
     concurrent-ruby (1.3.5)
@@ -204,6 +205,7 @@ GEM
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     font_awesome5_rails (1.5.0)
@@ -303,6 +305,8 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
@@ -334,6 +338,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.2-aarch64-linux)
+    pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-darwin)
     pg (1.6.2-x86_64-linux)
     pickadate-rails (3.5.6.1)
@@ -576,6 +581,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-20
   x86_64-darwin-24
   x86_64-linux
 


### PR DESCRIPTION
To learn more about the platforms listed in the Gemfile.lock, see https://bundler.io/man/bundle-lock.1.html#SUPPORTING-OTHER-PLATFORMS

...which points you to the nice article at 'gem help platform'.