### PR TITLE
Remove unused high_voltage gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'font_awesome5_rails'
 gem 'bootstrap', '~> 5'
 gem 'friendly_id'
 gem 'haml'
-gem 'high_voltage'
 gem 'irb' # LOCKED: Added because of byebug
 gem 'jquery-rails'
 gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,6 @@ GEM
       rubocop (>= 1.0)
       sysexits (~> 1.1)
     hashie (5.0.0)
-    high_voltage (4.0.0)
     htmlentities (4.3.4)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -619,7 +618,6 @@ DEPENDENCIES
   friendly_id
   haml
   haml_lint
-  high_voltage
   icalendar
   image_processing
   importmap-rails

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,0 @@
-class PagesController < ApplicationController
-  include HighVoltage::StaticPage
-end


### PR DESCRIPTION
As far as I could see, we don’t use this gem. Less gems == less RAM used in production.