### PR TITLE
Stub Flodesk requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ group :test do
   gem 'simplecov',      require: false
   gem 'simplecov-lcov', require: false
   gem 'timecop', '~> 0.9.10'
+  gem 'webmock'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
     commonmarker (2.5.0-x86_64-linux)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
@@ -221,6 +224,7 @@ GEM
       rainbow
       rubocop (>= 1.0)
       sysexits (~> 1.1)
+    hashdiff (1.2.1)
     hashie (5.0.0)
     high_voltage (4.0.0)
     htmlentities (4.3.4)
@@ -568,6 +572,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.26.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -668,6 +676,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console (>= 4.1.0)
+  webmock
 
 RUBY VERSION
    ruby 3.4.7p58


### PR DESCRIPTION
Addresses the issue by disabling web requests while running tests (something I believe to be a good practice) and stubs requests specifically to Flodesk’s API. Fixes #2322