### PR TITLE
fix: increase max_run_time for delayed job

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,7 +1,10 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 5.minutes
+
+# The rake jobs:workoff task in Heroku scheduler is configured to run every 10 minutes
+Delayed::Worker.max_run_time = 9.minutes 
+
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?


### PR DESCRIPTION
This hopefully fixes the timeouts that we're seeing in https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/640/occurrence/449286860545#detail

The Heroku scheduler runs the job every 10 minutes, and thus gives us 10 minutes to complete the work. Hopefully we can complete it in 9 minutes.

<img width="641" height="358" alt="image" src="https://github.com/user-attachments/assets/4a66f8d5-f76f-46c1-bdf1-8fd928cd1200" />

Ping @mikej @olleolleolle: does it make sense to use 9 minutes timeout, or shall we just let the Heroku scheduler kill the job, hoping it will resume the work in the next iteration?

Also, would it make sense to switch to [`deliver_later`](https://api.rubyonrails.org/v8.1.1/classes/ActionMailer/MessageDelivery.html#method-i-deliver_later) in [`invite_coaches_to_virtual_workshop`](https://github.com/codebar/planner/blob/master/app/models/concerns/workshop_invitation_manager_concerns.rb#L68)?

This replaces https://github.com/codebar/planner/pull/2127
