### PR TITLE
Improve intro text

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -47,7 +47,7 @@ de:
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Unser Ziel ist unterrepräsentierten Menschen zu programmieren in einer sicheren und kollaborative Umgebung lernen und erweitern ihre Karrierechancen zu ermöglichen. Um dies zu erreichen betreiben wir kostenlose regelmäßige Workshops, regelmäßige Einzelveranstaltungen und versuchen, die Möglichkeiten für unsere Schüler die Technologie und Programmierung zugänglicher zu schaffen."
     participate:
       students_title: "Students"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,7 +81,7 @@ en:
         format: "%u%n"
   homepage:
     title: Homepage
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -47,7 +47,7 @@ en-AU:
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -47,7 +47,7 @@ en-GB:
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -47,7 +47,7 @@ en-US:
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -47,7 +47,7 @@ fi:
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -46,7 +46,7 @@ fr:
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -47,7 +47,7 @@
         precision: 0
         format: "%u%n"
   homepage:
-    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for minority groups in tech."
+    intro: "<strong>codebar</strong> is a charity that facilitates the growth of a diverse tech community by running free regular programming workshops for underrepresented groups in tech."
     explanation: "Our goal is to enable people from underrepresented groups to learn programming in a safe and collaborative environment and expand their career opportunities. To achieve this we run free regular workshops, regular one-off events and try to create opportunities for our students making technology and coding more accessible."
     participate:
       students_title: "Students"


### PR DESCRIPTION
In https://github.com/codebar/planner/commit/cf1cfab9ca8818bdd27f7062d8433f1d6109b1da I overlooked a few places where 'minority groups' was used. This replaces it to use 'underrepresented groups' instead.