### PR TITLE
Improve sharing image for codebar homepage

### DIFF
--- a/app/views/shared/_meta_tags.html.haml
+++ b/app/views/shared/_meta_tags.html.haml
@@ -1,7 +1,7 @@
 %meta{ property: 'og:title', content: 'codebar' }
 %meta{ property: 'og:type', content: 'website' }
 %meta{ property: 'og:url', content: request.original_url }
-%meta{ property: 'og:image', content: image_url('logo-square.png') }
+%meta{ property: 'og:image', content: image_url('codebar-social.jpg') }
 %meta{ property: 'og:description', content: 'Making tech more diverse and welcoming by bringing people together and helping teach programming skills.' }
 %meta{ property: 'og:site_name', content: 'codebar' }
 %meta{ property: 'og:locale', content: 'en_GB' }


### PR DESCRIPTION
This pull request brings the same improved image we used on #2380 for workshops to our homepage. A quick improvement for general codebar pages, I reckon.

|before|after|
|:-:|:-:|
|<img width="551" height="402" alt="image" src="https://github.com/user-attachments/assets/d8bdd99e-a1c6-4e80-b309-a6a5dcbefaab" />|<img width="551" height="403" alt="image" src="https://github.com/user-attachments/assets/845c0ef2-137e-4ddd-96be-570af534f128" />|