### PR TITLE
chore: set correct year for impact report link

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,7 +1,7 @@
 - title t('homepage.title')
 
 .alert.alert-dark.mb-0.text-center
-  We’re beyond proud to launch our <strong>2024</strong> Impact Report, which you can read here - <a href="https://impact-report.codebar.io/" class="text-dark" target="_blank"">impact-report.codebar.io</a>
+  We’re beyond proud to launch our <strong>2025</strong> Impact Report, which you can read here - <a href="https://impact-report.codebar.io/" class="text-dark" target="_blank"">impact-report.codebar.io</a>
 
 .homepage-hero.d-flex.align-items-center
   .container.d-flex


### PR DESCRIPTION
This PR sets `2025` as the year for the banner about the impact report.

<img width="966" height="104" alt="image" src="https://github.com/user-attachments/assets/21e36a8b-88de-48e0-842f-79a5a8337ec3" />
