### PR TITLE
feat: split how-to-support-us page into separate volunteer, fundraise, and donate pages

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,5 +1,5 @@
 class DonationsController < ApplicationController
   def new
-    redirect_to I18n.t('services.donations'), allow_other_host: true
+    redirect_to donate_path
   end
 end

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -28,14 +28,11 @@
           %li= link_to t("navigation.coaches"), coaches_path
           %li= link_to t("navigation.sponsors"), sponsors_path
           %li= link_to t("navigation.events"), upcoming_events_path
-          %li= link_to t("navigation.jobs"), "https://jobs.codebar.io/"
-          %li= link_to "Volunteer", volunteer_path
-          %li= link_to "Fundraise", fundraise_path
-          %li.active= link_to t("navigation.donate"), donate_path
-          %li
-            = link_to 'https://buymeacoffee.com/codebarhq', target: '_blank', rel: 'noopener noreferrer' do
-              %i.fas.fa-coffee.me-2
-              Buy us a coffee
+          %li= link_to t("navigation.job_board"), "https://jobs.codebar.io/"
+          %li= link_to t("navigation.volunteer"), volunteer_path
+          %li= link_to t("navigation.fundraise"), fundraise_path
+          %li.active= link_to t("navigation.donate"), "https://enthuse.com/@codebar/donate", target: '_blank', rel: 'noopener noreferrer'
+          %li= link_to t("navigation.buy_us_a_coffee"), 'https://buymeacoffee.com/codebarhq', target: '_blank', rel: 'noopener noreferrer'
 
       .col-sm-12.col-md-6.col-lg-3
         = render partial: 'shared/social_media'

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -29,8 +29,13 @@
           %li= link_to t("navigation.sponsors"), sponsors_path
           %li= link_to t("navigation.events"), upcoming_events_path
           %li= link_to t("navigation.jobs"), "https://jobs.codebar.io/"
-          %li.active= link_to t("navigation.donate"), new_donation_path
-          %li= link_to "Buy us a coffee", "https://buymeacoffee.com/codebarhq", target: '_blank', rel: 'noopener noreferrer'
+          %li= link_to "Volunteer", volunteer_path
+          %li= link_to "Fundraise", fundraise_path
+          %li.active= link_to t("navigation.donate"), donate_path
+          %li
+            = link_to 'https://buymeacoffee.com/codebarhq', target: '_blank', rel: 'noopener noreferrer' do
+              %i.fas.fa-coffee.me-2
+              Buy us a coffee
 
       .col-sm-12.col-md-6.col-lg-3
         = render partial: 'shared/social_media'

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -26,11 +26,11 @@
             %li.dropdown-divider
             %li= link_to 'Tutorials', 'http://tutorials.codebar.io', class: 'dropdown-item'
         %li.nav-item
-          = link_to sponsors_path, class: 'nav-link border-0' do
-            Sponsors
+          = link_to volunteer_path, class: 'nav-link border-0' do
+            Volunteer
         %li.nav-item
-          = link_to how_to_support_us_path, class: 'nav-link border-0' do
-            How to support us
+          = link_to fundraise_path, class: 'nav-link border-0' do
+            Fundraise
         %li.nav-item
           = link_to "http://jobs.codebar.io/", class: 'nav-link border-0' do
             Job Board
@@ -54,8 +54,5 @@
             = render 'layouts/member_menu'
         %li.nav-item.d-flex.align-items-center
           %div.nav-link.d-flex.gap-2.py-0
-            = link_to new_donation_path, class: 'btn btn-sm fs-6 fw-semibold btn-primary' do
+            = link_to donate_path, class: 'btn btn-sm fs-6 fw-semibold btn-primary' do
               Donate
-            = link_to 'https://buymeacoffee.com/codebarhq', class: 'btn btn-sm fs-6 fw-semibold btn-secondary', target: '_blank', rel: 'noopener noreferrer' do
-              %i.fas.fa-coffee.me-1
-              Buy us a coffee

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -18,6 +18,7 @@
           = link_to '#', {'role': 'button', 'aria-expanded': 'false', 'data-bs-toggle': 'dropdown', class: 'nav-link border-0 dropdown-toggle', id: 'navbarDropdownMenuLinkCommunity'} do
             Community
           %ul.dropdown-menu{'aria-labelledby': 'navbarDropdownMenuLinkCommunity'}
+            %li= link_to 'Sponsors', sponsors_path, class: 'dropdown-item'
             %li= link_to 'Coaches', coaches_path, class: 'dropdown-item'
             %li= link_to 'Impact Report', 'https://impact-report.codebar.io/', class: 'dropdown-item'
             %li= link_to 'codebar Stories Podcast', codebar_stories_podcast_path, class: 'dropdown-item'
@@ -26,11 +27,15 @@
             %li.dropdown-divider
             %li= link_to 'Tutorials', 'http://tutorials.codebar.io', class: 'dropdown-item'
         %li.nav-item
-          = link_to volunteer_path, class: 'nav-link border-0' do
-            Volunteer
-        %li.nav-item
-          = link_to fundraise_path, class: 'nav-link border-0' do
-            Fundraise
+          = link_to sponsors_path, class: 'nav-link border-0' do
+            Sponsors
+        %li.nav-item.dropdown
+          = link_to '#', {'role': 'button', 'aria-expanded': 'false', 'data-bs-toggle': 'dropdown', class: 'nav-link border-0 dropdown-toggle', id: 'navbarDropdownMenuLinkSupport'} do
+            How to support us
+          %ul.dropdown-menu{'aria-labelledby': 'navbarDropdownMenuLinkSupport'}
+            %li= link_to 'Volunteer', volunteer_path, class: 'dropdown-item'
+            %li= link_to 'Fundraise', fundraise_path, class: 'dropdown-item'
+            %li= link_to 'Donate', 'https://enthuse.com/@codebar/donate', class: 'dropdown-item', target: '_blank', rel: 'noopener noreferrer'
         %li.nav-item
           = link_to "http://jobs.codebar.io/", class: 'nav-link border-0' do
             Job Board
@@ -54,5 +59,5 @@
             = render 'layouts/member_menu'
         %li.nav-item.d-flex.align-items-center
           %div.nav-link.d-flex.gap-2.py-0
-            = link_to donate_path, class: 'btn btn-sm fs-6 fw-semibold btn-primary' do
+            = link_to 'https://enthuse.com/@codebar/donate', class: 'btn btn-sm fs-6 fw-semibold btn-primary', target: '_blank', rel: 'noopener noreferrer' do
               Donate

--- a/app/views/pages/donate.html.haml
+++ b/app/views/pages/donate.html.haml
@@ -1,0 +1,16 @@
+.py-4.py-lg-5.bg-primary
+  .container
+    .row.align-items-center
+      .col-12.col-md-6
+        %h1.display-2.text-white.lh-1.mb-4
+          Donate
+          %br
+          to codebar
+        %p.text-white.lead.mb-4
+          Your donation helps us continue running free coding workshops for people from underrepresented groups in tech.
+      .col-12.col-md-6
+        = image_tag 'how-to-support-us/codebar-festival-2023.jpg', alt: '', class: 'mw-100 rounded'
+
+.py-4.py-lg-5
+  .container
+    = render partial: 'shared/donation_platforms'

--- a/app/views/pages/fundraise.html.haml
+++ b/app/views/pages/fundraise.html.haml
@@ -1,0 +1,29 @@
+.py-4.py-lg-5.bg-primary
+  .container
+    .row.align-items-center
+      .col-12.col-md-6
+        %h1.display-2.text-white.lh-1.mb-4
+          Fundraise
+          %br
+          for codebar
+        %p.text-white.lead.mb-4
+          Join our team at a physical challenge event and help keep our workshops running.
+      .col-12.col-md-6
+        = image_tag 'how-to-support-us/hackney-half.jpeg', alt: t('pages.how_to_support_us.fundraise.image_alt'), class: 'mw-100 rounded'
+
+.py-4.py-lg-5
+  .container
+    .row.mb-5
+      .col-12.col-lg-8
+        %p.lead
+          = t('pages.how_to_support_us.fundraise.description_html', email: 'hello@codebar.io')
+    .row
+      .col-12.col-lg-4
+        .ratio.shadow{style: '--bs-aspect-ratio: 150%;'}
+          %iframe{title: 'Royal Parks Half Marathon', src: '//runforcharity.com/codebar/royal-parks-half-marathon/registration'}
+      .col-12.col-lg-4
+        .ratio.shadow{style: '--bs-aspect-ratio: 150%;'}
+          %iframe{title: 'Brighton Marathon April 2026', src: '//runforcharity.com/codebar/the-brighton-marathon/1744707816740.9279'}
+      .col-12.col-lg-4
+        .ratio.shadow{style: '--bs-aspect-ratio: 150%;'}
+          %iframe{title: 'Hackney Half May 2026', src: '//runforcharity.com/codebar/hackney-half/1747652084027971'}

--- a/app/views/pages/volunteer.html.haml
+++ b/app/views/pages/volunteer.html.haml
@@ -1,0 +1,55 @@
+.py-4.py-lg-5.bg-primary
+  .container
+    .row.align-items-center
+      .col-12.col-md-6
+        %h1.display-2.text-white.lh-1.mb-4
+          Volunteer
+          %br
+          with us
+        %p.text-white.lead.mb-4
+          Use your skills to help people from groups underrepresented in tech break into the industry.
+        %ul.list-inline
+          %li.list-inline-item
+            = link_to t('pages.how_to_support_us.volunteer.become_a_coach.title'), '#become-a-coach', class: 'btn btn-light'
+          %li.list-inline-item
+            = link_to t('pages.how_to_support_us.volunteer.become_an_organiser.title'), '#become-an-organiser', class: 'btn btn-light'
+      .col-12.col-md-6
+        = image_tag 'how-to-support-us/become-a-coach.jpg', alt: '', class: 'mw-100 rounded'
+
+.py-4.py-lg-5#become-a-coach
+  .container
+    .row.mb-5
+      .col
+        %h2.h1.text-center= t('pages.how_to_support_us.volunteer.become_a_coach.title')
+    .row.justify-content-center
+      .col-12.col-lg-9
+        %p.lead.text-center.mb-5
+          = t('pages.how_to_support_us.volunteer.become_a_coach.description')
+        .text-center
+          = link_to registration_path(member_type: 'coach'), class: 'btn btn-primary btn-lg text-decoration-none' do
+            = t('members.sign_up_as_coach')
+            %i.fab.fa-github
+
+.py-4.py-lg-5.bg-light#become-an-organiser
+  .container
+    .row.mb-5
+      .col
+        %h2.h1.text-center= t('pages.how_to_support_us.volunteer.become_an_organiser.title')
+    .row.justify-content-center
+      .col-12.col-lg-9
+        %p.lead.text-center.mb-5
+          = t('pages.how_to_support_us.volunteer.become_an_organiser.description')
+        .text-center
+          = mail_to 'hello@codebar.io', t('pages.how_to_support_us.volunteer.become_an_organiser.link'), subject: "I'd like to become a codebar organiser for [city] chapter", class: 'btn btn-primary btn-lg text-decoration-none'
+
+.py-4.py-lg-5#other-skills
+  .container
+    .row.mb-5
+      .col
+        %h2.h1.text-center= t('pages.how_to_support_us.volunteer.volunteer.title')
+    .row.justify-content-center
+      .col-12.col-lg-9
+        %p.lead.text-center.mb-5
+          = t('pages.how_to_support_us.volunteer.volunteer.description')
+        .text-center
+          = mail_to 'hello@codebar.io', t('pages.how_to_support_us.volunteer.volunteer.link'), subject: "I'd like to volunteer with codebar", class: 'btn btn-primary btn-lg text-decoration-none'

--- a/app/views/shared/_donation_platforms.html.haml
+++ b/app/views/shared/_donation_platforms.html.haml
@@ -12,7 +12,7 @@
         .bg-white.rounded-top.p-3.d-flex.align-items-center
           = image_tag("logo.png", alt:t("donation_platforms.donation_form.image_alt"), class: "mw-100")
       .card-body
-        %h3.h6= link_to(t("donation_platforms.donation_form.title"), new_donation_path)
+        %h3.h6= link_to(t("donation_platforms.donation_form.title"), "https://codebar.enthuse.com/donate/")
         %p.card-text= t("donation_platforms.donation_form.text")
   .d-flex.col-sm-12.col-md-6.col-lg-3
     .card.mt-3.mt-lg-0.shadow
@@ -41,4 +41,4 @@
 
 - if local_assigns[:with_button]
   .d-flex.justify-content-center.mt-4
-    = link_to t("donation_platforms.link"), how_to_support_us_path, class: "btn btn-primary btn-lg my-4"
+    = link_to t("donation_platforms.link"), donate_path, class: "btn btn-primary btn-lg my-4"

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -6,7 +6,7 @@ en:
         Eligible members are those who:
         1. Have accepted the codebar Terms & Conditions
         2. Are not banned from the platform
-        
+
         Members who haven't accepted T&C or are banned do not receive invitations and cannot RSVP to workshops.
 
     shared:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -127,6 +127,12 @@ de:
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Stats"
+    how_to_support_us: "Uns unterstützen"
+    volunteer: "Ehrenamtlich"
+    fundraise: "Spenden sammeln"
+    donate: "Spenden"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Jobbörse"
   dashboard:
     join_workshops_in: "Komm zu unseren <i>kostenlosen</i> Workshops in"
     workshops_goal: "um sich mit den Programmier- und Webentwicklungsgrundlagen vertraut zu machen."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,12 @@ en:
     stats: "Stats"
     cookies: "Cookies"
     privacy-policy: "Privacy Policy"
+    how_to_support_us: "How to support us"
+    volunteer: "Volunteer"
+    fundraise: "Fundraise"
+    donate: "Donate"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Job Board"
     contact_preferences:
       updated: "Contact preferences updated"
 

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -118,6 +118,12 @@ en-AU:
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Stats"
+    how_to_support_us: "How to support us"
+    volunteer: "Volunteer"
+    fundraise: "Fundraise"
+    donate: "Donate"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Job Board"
   dashboard:
     join_workshops_in: "Join our <i>free</i> workshops in"
     workshops_goal: "to get to grips with the basics of programming and web development."

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -118,6 +118,12 @@ en-GB:
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Stats"
+    how_to_support_us: "How to support us"
+    volunteer: "Volunteer"
+    fundraise: "Fundraise"
+    donate: "Donate"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Job Board"
   dashboard:
     join_workshops_in: "Join our <i>free</i> workshops in"
     workshops_goal: "to get to grips with the basics of programming and web development."

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -118,6 +118,12 @@ en-US:
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Stats"
+    how_to_support_us: "How to support us"
+    volunteer: "Volunteer"
+    fundraise: "Fundraise"
+    donate: "Donate"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Job Board"
   dashboard:
     join_workshops_in: "Join our <i>free</i> workshops in"
     workshops_goal: "to get to grips with the basics of programming and web development."

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -118,6 +118,12 @@ fi:
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Stats"
+    how_to_support_us: "Kuinka tukea meitä"
+    volunteer: "Vapaaehtoinen"
+    fundraise: "Kerää varoja"
+    donate: "Lahjoita"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Työpaikat"
   dashboard:
     join_workshops_in: "Join our <i>free</i> workshops in"
     workshops_goal: "to get to grips with the basics of programming and web development."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -117,6 +117,12 @@ fr:
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Statistiques"
+    how_to_support_us: "Comment nous soutenir"
+    volunteer: "Bénévole"
+    fundraise: "Collecte de fonds"
+    donate: "Donner"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Offres d'emploi"
   dashboard:
     join_workshops_in: "Rejoignez nos ateliers <i>gratuit</i>"
     workshops_goal: "pour apprendre les bases de la programmation et du développement web."

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -118,6 +118,12 @@
     blog: "Blog"
     codebar_stories: "codebar Stories"
     stats: "Stats"
+    how_to_support_us: "Hvordan støtte oss"
+    volunteer: "Frivillig"
+    fundraise: "Samle inn midler"
+    donate: "Doner"
+    buy_us_a_coffee: "Buy us a coffee"
+    job_board: "Jobbørs"
   dashboard:
     join_workshops_in: "Join our <i>free</i> workshops in"
     workshops_goal: "to get to grips with the basics of programming and web development."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,7 +176,10 @@ Rails.application.routes.draw do
   get 'cookie-policy' => 'pages#show', id: 'cookie-policy'
   get 'privacy-policy' => 'pages#show', id: 'privacy-policy'
   get 'breach-code-of-conduct' => 'pages#show', id: 'breach-code-of-conduct'
-  get 'how-to-support-us' => 'pages#show', id: 'how-to-support-us'
+  get 'how-to-support-us' => redirect('/volunteer')
+  get 'volunteer' => 'pages#show', id: 'volunteer'
+  get 'fundraise' => 'pages#show', id: 'fundraise'
+  get 'donate' => 'pages#show', id: 'donate'
   get 'codebar-stories-podcast' => 'pages#show', id: 'codebar-stories-podcast'
 
   get ':id' => 'chapter#show', as: :chapter


### PR DESCRIPTION
## Summary

- Split the monolithic `/how-to-support-us` page into three dedicated pages:
  - `/volunteer` - Volunteer opportunities (coach, organiser, other skills)
  - `/fundraise` - Fundraising events (running challenges)
  - `/donate` - Donation platforms
- Old `/how-to-support-us` now redirects to `/volunteer`
- Added new menu items: Volunteer, Fundraise in header
- Updated footer with links to all three new pages
- Removed "Buy us a coffee" button from header, added coffee icon in footer
- Changed "Jobs" to "Job Board" in nav and footer
- Removed Sponsors menu item
- Updated donation links to point directly to Enthuse

<img width="822" height="127" alt="image" src="https://github.com/user-attachments/assets/f79dc193-23db-42c8-a463-05af4712d68f" />
<img width="282" height="323" alt="image" src="https://github.com/user-attachments/assets/b75e96b8-0766-4508-9d99-44935c364c39" />
