### PR TITLE
fix(invitations): remove overly restrictive unique constraint on invitation log entries

### DIFF
--- a/app/models/invitation_log_entry.rb
+++ b/app/models/invitation_log_entry.rb
@@ -4,6 +4,4 @@ class InvitationLogEntry < ApplicationRecord
   belongs_to :invitation_log
   belongs_to :member
   belongs_to :invitation, polymorphic: true, optional: true
-
-  validates :member_id, uniqueness: { scope: %i[invitation_type invitation_id] }, allow_nil: true
 end

--- a/db/migrate/20260410174346_remove_global_unique_constraint_from_invitation_log_entries.rb
+++ b/db/migrate/20260410174346_remove_global_unique_constraint_from_invitation_log_entries.rb
@@ -1,0 +1,13 @@
+class RemoveGlobalUniqueConstraintFromInvitationLogEntries < ActiveRecord::Migration[8.1]
+  def up
+    remove_index :invitation_log_entries,
+                 name: 'idx_on_invitation_type_invitation_id_6d6ef495e6'
+  end
+
+  def down
+    add_index :invitation_log_entries,
+              %i[invitation_type invitation_id],
+              name: 'idx_on_invitation_type_invitation_id_6d6ef495e6',
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_220120) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_10_174346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -297,9 +297,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_220120) do
     t.datetime "processed_at"
     t.string "status", default: "success", null: false
     t.datetime "updated_at", null: false
+    t.index ["invitation_log_id", "invitation_type", "invitation_id"], name: "index_invitation_log_entries_on_batch_and_invitation"
     t.index ["invitation_log_id", "status"], name: "index_invitation_log_entries_on_invitation_log_id_and_status"
     t.index ["invitation_log_id"], name: "index_invitation_log_entries_on_invitation_log_id"
-    t.index ["invitation_type", "invitation_id"], name: "idx_on_invitation_type_invitation_id_6d6ef495e6", unique: true
     t.index ["invitation_type", "invitation_id"], name: "index_invitation_log_entries_on_invitation"
     t.index ["member_id", "processed_at"], name: "index_invitation_log_entries_on_member_id_and_processed_at"
     t.index ["member_id"], name: "index_invitation_log_entries_on_member_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -297,7 +297,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_174346) do
     t.datetime "processed_at"
     t.string "status", default: "success", null: false
     t.datetime "updated_at", null: false
-    t.index ["invitation_log_id", "invitation_type", "invitation_id"], name: "index_invitation_log_entries_on_batch_and_invitation"
     t.index ["invitation_log_id", "status"], name: "index_invitation_log_entries_on_invitation_log_id_and_status"
     t.index ["invitation_log_id"], name: "index_invitation_log_entries_on_invitation_log_id"
     t.index ["invitation_type", "invitation_id"], name: "index_invitation_log_entries_on_invitation"

--- a/spec/models/invitation_log_entry_spec.rb
+++ b/spec/models/invitation_log_entry_spec.rb
@@ -16,12 +16,4 @@ RSpec.describe InvitationLogEntry do
                                                 })
     end
   end
-
-  describe 'validations' do
-    it 'validates uniqueness of member_id scoped to invitation' do
-      entry = Fabricate(:invitation_log_entry)
-      expect(entry).to validate_uniqueness_of(:member_id)
-        .scoped_to(:invitation_type, :invitation_id)
-    end
-  end
 end


### PR DESCRIPTION
## Problem

Invitation batch #28 for Berlin chapter students is stuck in `running` status with only 5 of 431 students processed. The batch crashed with:

```
ActiveRecord::RecordInvalid: Validation failed: Entries is invalid
InvitationLogger#fail_batch(/app/app/services/invitation_logger.rb:71)
```

## Root Cause

The database has a global unique constraint on `invitation_log_entries(invitation_type, invitation_id)` that prevents the same invitation from being logged in multiple batches. This constraint is more restrictive than the model validation.

When a batch tries to create a log entry for an invitation that already has an entry from a previous batch, the INSERT fails. The unsaved entry remains in `@log.entries`. When `fail_batch` tries to save the log, Rails validates all entries including the invalid one.

## Why the Constraint Was Wrong

1. **Multiple audiences:** Different batches (`students`, `coaches`, `everyone`) may process overlapping member lists
2. **Retry scenarios:** Failed batches can be retried, requiring re-logging of entries
3. **Within-batch uniqueness:** Already handled by `find_or_create_by(member: member, invitation: invitation)` + `processed_at` check

## Changes

- Remove global unique index on `invitation_log_entries`
- Remove model validation that enforced the same constraint

Note: The non-unique index on `invitation_log_entries(invitation_type, invitation_id)` remains for queries by invitation.

## Testing

All tests pass:
- `spec/services/invitation_logger_spec.rb` (13 examples)
- `spec/models/invitation_log_entry_spec.rb` (4 examples)

## Deployment Notes

After deploying:
1. Clear stuck batches: `UPDATE invitation_logs SET status = 'failed' WHERE id IN (22, 28);`
2. Trigger new invitation batch for Berlin students

Fixes #2561