### PR TITLE
Replace Chosen.js with TomSelect for meeting invitations

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -70,13 +70,42 @@ $(function() {
     });
   }
 
-  // Chosen for all other selects (exclude #member_lookup_id)
+  // TomSelect for meeting invitation member lookup
+  if ($('#meeting_invitations_member').length) {
+    new TomSelect('#meeting_invitations_member', {
+      placeholder: 'Type to search members...',
+      valueField: 'id',
+      labelField: 'full_name',
+      searchField: ['full_name', 'email'],
+      create: false,
+      loadThrottle: 300,
+      shouldLoad: function(query) {
+        return query.length >= 3;
+      },
+      load: function(query, callback) {
+        fetch('/admin/members/search?q=' + encodeURIComponent(query))
+          .then(response => response.json())
+          .then(json => callback(json))
+          .catch(() => callback());
+      },
+      render: {
+        option: function(item, escape) {
+          return '<div>' + escape(item.full_name) + ' <small class="text-muted">' + escape(item.email) + '</small></div>';
+        },
+        no_results: function(data, escape) {
+          return '<div class="no-results">No members found</div>';
+        }
+      }
+    });
+  }
+
+  // Chosen for all other selects (exclude TomSelect fields)
   // Chosen hides inputs and selects, which becomes problematic when they are
   // required: browser validation doesn't get shown to the user.
   // This fix places "the original input behind the Chosen input, matching the
   // height and width so that the warning appears in the correct position."
   // https://github.com/harvesthq/chosen/issues/515#issuecomment-474588057
-  $('select').not('#member_lookup_id').on('chosen:ready', function () {
+  $('select').not('#member_lookup_id, #meeting_invitations_member').on('chosen:ready', function () {
     var height = $(this).next('.chosen-container').height();
     var width = $(this).next('.chosen-container').width();
 
@@ -88,7 +117,7 @@ $(function() {
     }).show();
   });
 
-  $('select').not('#member_lookup_id').chosen({
+  $('select').not('#member_lookup_id, #meeting_invitations_member').chosen({
     allow_single_deselect: true,
     no_results_text: 'No results matched'
   });

--- a/app/views/admin/meetings/_invitation_management.html.haml
+++ b/app/views/admin/meetings/_invitation_management.html.haml
@@ -3,15 +3,13 @@
     .card.bg-white.border-success
       .card-body
         %p.mb-0
-          <strong>#{@invitations.count}</strong> members have RSVP'd to this event.
+          %strong #{@invitations.count}
+          members have RSVP'd to this event.
 
 = simple_form_for :meeting_invitations, url: admin_meeting_invitations_path do |f|
   .row
     .col-6
-      = f.select :member,
-                  Member.all.map { |u| ["#{u.full_name}", u.id] },
-                  { include_blank: true }, { class: 'chosen-select', required: true,
-                  data: { placeholder: t('messages.invitations.select_a_member_to_rsvp') } }
+      = f.select :member, [], { include_blank: true }, { class: 'tom-select', required: true, data: { placeholder: t('messages.invitations.select_a_member_to_rsvp') } }
       = f.hidden_field :meeting_id, value: @meeting.slug
     .col
       = f.button :button, 'Add', class: 'btn btn-sm btn-primary mb-0 me-2'

--- a/app/views/admin/meetings/show.html.haml
+++ b/app/views/admin/meetings/show.html.haml
@@ -54,6 +54,9 @@
       = sanitize(@meeting.description)
 
 - if @invitations.any?
+  - content_for :head do
+    %link{ href: 'https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.bootstrap5.min.css', rel: 'stylesheet', type: 'text/css' }
+    %script{ src: 'https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/js/tom-select.complete.min.js' }
   .py-4.py-lg-5.bg-light
     .container#invitations
       = render partial: 'invitation_management'

--- a/spec/features/admin/managing_meeting_invitations_spec.rb
+++ b/spec/features/admin/managing_meeting_invitations_spec.rb
@@ -8,25 +8,27 @@ RSpec.feature 'Managing meeting invitations', type: :feature do
   end
 
   describe 'creating a new meeting invitation' do
-    scenario 'for a member that is not already attending' do
+    scenario 'for a member that is not already attending', :js do
       Fabricate(:attending_meeting_invitation, meeting: meeting)
       member = Fabricate(:member)
 
       visit admin_meeting_path(meeting)
-      select member.name
+
+      select_from_tom_select(member.full_name, from: 'meeting_invitations_member')
       click_on 'Add'
 
       expect(page).to have_content("#{member.full_name} has been successfully added and notified via email")
     end
 
-    scenario 'for a member that is already attending' do
+    scenario 'for a member that is already attending', :js do
       meeting = Fabricate(:meeting)
       attending_member = Fabricate(:member)
       Fabricate(:attending_meeting_invitation, meeting: meeting)
       Fabricate(:attending_meeting_invitation, meeting: meeting, member: attending_member)
 
       visit admin_meeting_path(meeting)
-      select attending_member.name
+
+      select_from_tom_select(attending_member.full_name, from: 'meeting_invitations_member')
       click_on 'Add'
 
       expect(page).to have_content("#{attending_member.full_name} is already on the list!")
@@ -35,11 +37,9 @@ RSpec.feature 'Managing meeting invitations', type: :feature do
 
   scenario 'Updating the attendance of an invitation' do
     meeting = Fabricate(:meeting, date_and_time: 1.day.ago)
-    member = Fabricate(:member)
     Fabricate(:attending_meeting_invitation, meeting: meeting)
 
     visit admin_meeting_path(meeting)
-
     find('.verify-attendance').click
 
     expect(page).to have_content('Updated attendance')

--- a/spec/support/select_from_tom_select.rb
+++ b/spec/support/select_from_tom_select.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Helper for interacting with TomSelect dropdowns in Capybara feature tests
+# Similar to select_from_chosen but for TomSelect remote data loading
+module SelectFromTomSelect
+  # Select an item from a TomSelect dropdown
+  # @param item_text [String] The text to select
+  # @param from [String, Symbol] The field ID (for documentation purposes)
+  def select_from_tom_select(item_text, from: nil)
+    # Wait for TomSelect to initialize
+    expect(page).to have_css('.ts-wrapper', wait: 5)
+
+    # Open dropdown and type search query
+    find('.ts-control').click
+    input = find('.ts-control input')
+
+    # Type first 3 characters to trigger search (shouldLoad requires >= 3)
+    input.send_keys(item_text[0, 3])
+
+    # Wait for debounce (300ms) and network request
+    sleep 0.5
+
+    # Type the rest if item_text is longer than 3 characters
+    input.send_keys(item_text[3..]) if item_text.length > 3
+
+    # Wait for results (includes debounce + network)
+    expect(page).to have_css('.ts-dropdown .option', wait: 5)
+
+    # Click the matching option
+    find('.ts-dropdown .option', text: item_text, match: :prefer_exact).click
+  end
+end
+
+RSpec.configure do |config|
+  config.include SelectFromTomSelect, type: :feature
+end


### PR DESCRIPTION
## Why

The `/admin/meetings/:id` invitation management page loads **all members** into a dropdown using `Member.all`, identical to the anti-pattern fixed in PR #2562:

- Loads ~28,000 members on every page render
- Causes slow page loads
- Will only get worse as membership grows
- Chosen.js is unmaintained (archived since 2017)

## What

Replace Chosen.js with TomSelect for the member lookup field in meeting invitations, using remote data loading:

- TomSelect fetches members on-demand via the existing `/admin/members/search` endpoint
- Minimum 3 characters before search triggers
- 300ms debounce on requests
- Searches both name and email fields
- Results limited to 50 matches

## Changes

**Frontend:**
- Updated `app/views/admin/meetings/_invitation_management.html.haml` - removed `Member.all`, changed class to `tom-select`
- Updated `app/views/admin/meetings/show.html.haml` - added TomSelect CDN via `content_for :head`

**JavaScript:**
- Added TomSelect initialization for `#meeting_invitations_member` in `app/assets/javascripts/application.js`
- Excluded `#meeting_invitations_member` from Chosen.js initialization

**Tests:**
- Created `spec/support/select_from_tom_select.rb` - Capybara helper for TomSelect dropdowns
- Updated `spec/features/admin/managing_meeting_invitations_spec.rb` - changed from `select` to `select_from_tom_select`, added `:js` metadata

## How to Verify Locally

### 1. Run migrations and seed (if needed)
```bash
bundle exec rails db:migrate db:seed
```

### 2. Start the server
```bash
bundle exec rails server
```

### 3. Ensure you have an admin user
```bash
bundle exec rails runner "Member.find_by(email: 'your-email@example.com').add_role(:admin)"
```

Or log in via GitHub OAuth and visit `/admin/members` to verify admin access.

### 4. Create test data (if not exists)
```bash
bundle exec rails runner "
m = Meeting.first || Fabricate(:meeting, name: 'Test Meeting')
members = Member.limit(3).to_a
members.each { |member| MeetingInvitation.create!(meeting: m, member: member, attending: true, role: 'Participant') rescue nil }
puts 'Meeting URL: /admin/meetings/' + m.slug
"
```

### 5. Test the member search
1. Visit `/admin/meetings/:slug` (replace `:slug` with the meeting slug from step 4)
2. The invitation management section appears at the bottom (requires at least 1 invitation)
3. Click the member dropdown - it should show "Type to search members..." placeholder
4. Type 2 characters - no search should trigger (minimum 3 required)
5. Type 3+ characters - search triggers with 300ms debounce
6. Results show member name and email
7. Select a member - the field updates
8. Click "Add" - the invitation is created

<img width="1479" height="875" alt="image" src="https://github.com/user-attachments/assets/c7f02250-6103-4409-a742-fbd3145af04f" />


### 6. Run the tests
```bash
bundle exec rspec spec/features/admin/managing_meeting_invitations_spec.rb
```

All 3 tests should pass:
- `creating a new meeting invitation for a member that is not already attending` (JS)
- `creating a new meeting invitation for a member that is already attending` (JS)
- `Updating the attendance of an invitation`

### 7. Verify TomSelect tests still work
```bash
bundle exec rspec spec/features/admin/tom_select_member_lookup_spec.rb
```

Both tests should pass (the `/admin/members` page TomSelect functionality).

## Related

- Reuses `/admin/members/search` endpoint from PR #2562
- Part of larger `Member.all` and Chosen.js removal effort

## Future Work

### Remaining `Member.all` scalability issues:
1. **Meeting form organisers field** - `app/views/admin/meetings/_form.html.haml` line 20 uses `Member.all` for the organisers multi-select (same issue, different page)

### Other Chosen.js uses (small datasets, low priority):
- **Workshop invitation management** - Uses Chosen.js with `@workshop.invitations.not_accepted` (local data, ~dozens of records)
- **Feedback form** - Uses Chosen.js with `@coaches` (workshop's coaches, ~5-20) and `Tutorial.all` (small dataset)
- **Sponsors chapter filter** - Uses Chosen.js with `@chapters` (small dataset, ~10-20)
- **invitations.js** - AJAX-loaded content for workshop invitations

### Final cleanup:
- Remove Chosen.js gem and vendor assets once all uses are replaced