### PR TITLE
feat: display eligible member counts in admin pages

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -48,6 +48,14 @@ class Chapter < ApplicationRecord
           .distinct
   end
 
+  def eligible_students
+    Member.in_group(groups.students).distinct
+  end
+
+  def eligible_coaches
+    Member.in_group(groups.coaches).distinct
+  end
+
   private
 
   def expire_chapters_sidebar_cache

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -20,4 +20,8 @@ class Group < ApplicationRecord
   def to_s
     "#{name} #{chapter.name}"
   end
+
+  def eligible_members
+    members.not_banned.accepted_toc.distinct
+  end
 end

--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -30,7 +30,7 @@
             - @groups.each do |group|
               %li.nav-item
                 = link_to [ :admin, group ], class: 'nav-link' do
-                  #{group.name} (#{group.members.count})
+                  #{group.name} (#{group.eligible_members.count} eligible, #{group.members.count} total)
               %li.nav-item
                 = link_to admin_chapter_members_path(@chapter, type: group.name.downcase), class: 'nav-link' do
                   View #{group.name} emails

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -7,7 +7,7 @@
 
   .row
     .col
-      %h3.mb-3 Members (#{@group.members.count})
+      %h3.mb-3 Members (#{@group.eligible_members.count} eligible, #{@group.members.count} total)
       %table.table.table-striped.table-hover
         %tbody
           - @group.members.each do |member|

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Chapter do
-  it { should validate_presence_of(:city) }
-  it { should validate_length_of(:description).is_at_most(280) }
+  it { is_expected.to validate_presence_of(:city) }
+  it { is_expected.to validate_length_of(:description).is_at_most(280) }
 
   context 'validations' do
-    context '#slug' do
+    describe '#slug' do
       it 'a chapter must have a slug set' do
         chapter = Chapter.new(name: 'London', city: 'London', email: 'london@codebar.io')
         chapter.save
@@ -19,7 +19,7 @@ RSpec.describe Chapter do
       end
     end
 
-    context '#time_zone' do
+    describe '#time_zone' do
       it 'requires a time zone' do
         chapter = Fabricate(:chapter)
         expect(chapter).to be_valid
@@ -32,7 +32,7 @@ RSpec.describe Chapter do
   end
 
   context 'scopes' do
-    context '#active' do
+    describe '#active' do
       it 'only returns active Chapters' do
         1.times { Fabricate(:chapter) }
         2.times { Fabricate(:chapter, active: false) }
@@ -63,6 +63,42 @@ RSpec.describe Chapter do
       chapter = Fabricate(:chapter)
       chapter.destroy
       expect(Rails.cache.read(cache_key)).to be_nil
+    end
+  end
+
+  describe '#eligible_students' do
+    let(:chapter) { Fabricate(:chapter) }
+    let(:student_group) { Fabricate(:group, chapter: chapter, name: 'Students') }
+
+    it 'includes only students with accepted TOC who are not banned' do
+      eligible_student = Fabricate(:member, groups: [student_group], accepted_toc_at: Time.zone.now)
+      _ineligible_no_toc = Fabricate(:member, groups: [student_group], accepted_toc_at: nil)
+      _ineligible_banned = Fabricate(:banned_member, groups: [student_group], accepted_toc_at: Time.zone.now)
+
+      expect(chapter.eligible_students).to contain_exactly(eligible_student)
+    end
+
+    it 'returns empty relation when no eligible students' do
+      Fabricate(:member, groups: [student_group], accepted_toc_at: nil)
+      expect(chapter.eligible_students).to be_empty
+    end
+  end
+
+  describe '#eligible_coaches' do
+    let(:chapter) { Fabricate(:chapter) }
+    let(:coach_group) { Fabricate(:group, chapter: chapter, name: 'Coaches') }
+
+    it 'includes only coaches with accepted TOC who are not banned' do
+      eligible_coach = Fabricate(:member, groups: [coach_group], accepted_toc_at: Time.zone.now)
+      _ineligible_no_toc = Fabricate(:member, groups: [coach_group], accepted_toc_at: nil)
+      _ineligible_banned = Fabricate(:banned_member, groups: [coach_group], accepted_toc_at: Time.zone.now)
+
+      expect(chapter.eligible_coaches).to contain_exactly(eligible_coach)
+    end
+
+    it 'returns empty relation when no eligible coaches' do
+      Fabricate(:member, groups: [coach_group], accepted_toc_at: nil)
+      expect(chapter.eligible_coaches).to be_empty
     end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -2,12 +2,29 @@ RSpec.describe Group do
   subject(:group) { Fabricate.build(:group) }
 
   context 'validations' do
-    it { should validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:name) }
 
     it do
-      should validate_inclusion_of(:name)
+      expect(subject).to validate_inclusion_of(:name)
         .in_array(%w[Coaches Students])
         .with_message('Invalid name for Group')
+    end
+  end
+
+  describe '#eligible_members' do
+    let(:group) { Fabricate(:group, name: 'Students') }
+
+    it 'includes only members with accepted TOC who are not banned' do
+      eligible_member = Fabricate(:member, groups: [group], accepted_toc_at: Time.zone.now)
+      _ineligible_no_toc = Fabricate(:member, groups: [group], accepted_toc_at: nil)
+      _ineligible_banned = Fabricate(:banned_member, groups: [group], accepted_toc_at: Time.zone.now)
+
+      expect(group.eligible_members).to contain_exactly(eligible_member)
+    end
+
+    it 'returns empty relation when no eligible members' do
+      Fabricate(:member, groups: [group], accepted_toc_at: nil)
+      expect(group.eligible_members).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds eligible member counts to admin pages, giving chapter organisers visibility into how many members can actually receive workshop invitations vs. total registered members.

**Eligible members** = members who have accepted Terms of Service AND are not banned/suspended.

## Changes

### Models
- `Chapter#eligible_students` - Returns students eligible for invitations
- `Chapter#eligible_coaches` - Returns coaches eligible for invitations  
- `Group#eligible_members` - Returns members eligible for invitations

### Admin Views
- Chapter show page: Shows "(X eligible, Y total)" for each group
- Group show page: Shows "(X eligible, Y total)" in members header

## Motivation

From investigation in #2576, Brighton chapter discovered that 43% of registered members (653 out of 1,513) weren't receiving invitations because they hadn't accepted the Terms of Service. These were primarily legacy members who registered before TOC was required in February 2020.

Currently, organisers only see total member counts, giving them no visibility into this gap. This PR addresses that by showing both numbers.

## How to Verify

### Step 1: Setup
```bash
git checkout feature/add-eligible-methods-to-chapter
bundle install
rails db:migrate  # if needed
```

### Step 2: Run Tests
```bash
# Run model specs
bundle exec rspec spec/models/chapter_spec.rb spec/models/group_spec.rb

# Expected: 17 examples, 0 failures

# Run feature specs
bundle exec rspec spec/features/admin/

# Expected: All tests pass
```

### Step 3: Manual Verification

1. **Start the Rails server:**
   ```bash
   rails server
   ```

2. **Create test data (in rails console):**
   ```ruby
   chapter = Chapter.first || Chapter.create!(name: 'Test Chapter', city: 'Test City', email: 'test@example.com', time_zone: 'London')
   
   # Create student group
   students = Group.find_or_create_by!(chapter: chapter, name: 'Students')
   
   # Create eligible member (accepted TOC, not banned)
   eligible = Member.create!(
     name: 'Eligible', surname: 'Student', email: 'eligible@example.com',
     about_you: 'Test', accepted_toc_at: Time.now,
     auth_services: [AuthService.new(provider: 'github', uid: '12345')]
   )
   Subscription.create!(member: eligible, group: students)
   
   # Create ineligible member (no TOC)
   ineligible = Member.create!(
     name: 'Ineligible', surname: 'Student', email: 'ineligible@example.com',
     about_you: 'Test', accepted_toc_at: nil,
     auth_services: [AuthService.new(provider: 'github', uid: '67890')]
   )
   Subscription.create!(member: ineligible, group: students)
   ```

3. **Visit Admin Chapter Page:**
   - Go to: http://localhost:3000/admin/chapters/[chapter-id]
   - **Expected:** See "Students (1 eligible, 2 total)" in the sidebar

4. **Visit Admin Group Page:**
   - Go to: http://localhost:3000/admin/groups/[group-id]
   - **Expected:** See "Members (1 eligible, 2 total)" in the header

### Step 4: Edge Cases (Optional)

1. **Create a banned member:**
   ```ruby
   banned = Member.create!(
     name: 'Banned', surname: 'Student', email: 'banned@example.com',
     about_you: 'Test', accepted_toc_at: Time.now,
     auth_services: [AuthService.new(provider: 'github', uid: '99999')]
   )
   Subscription.create!(member: banned, group: students)
   Ban.create!(
     member: banned,
     reason: 'Test ban',
     note: 'Test note',
     expires_at: 1.month.from_now,
     added_by: Member.first
   )
   ```
   
   - Refresh the pages
   - **Expected:** Eligible count stays at 1, total increases to 3

2. **Test with no eligible members:**
   - Set all members' `accepted_toc_at` to `nil`
   - **Expected:** See "Students (0 eligible, N total)"

### Alternative: Using Fabricators

If you have test data set up, you can use Fabricators instead:

```ruby
chapter = Fabricate(:chapter)
students = Fabricate(:group, chapter: chapter, name: 'Students')

# Eligible member
Fabricate(:member, groups: [students], accepted_toc_at: Time.now)

# Ineligible member (no TOC)
Fabricate(:member_without_toc, groups: [students])

# Banned member
Fabricate(:banned_member, groups: [students], accepted_toc_at: Time.now)
```

## Checklist

- [x] Added model methods with tests
- [x] Updated admin views
- [x] All tests pass
- [x] No RuboCop offenses (on new code)
- [x] Clean commit history

## Related

- Investigation: #2576
