### PR TITLE
fix: #students and #coaches return Chapter-specific students and coaches

### DIFF
--- a/app/models/README.md
+++ b/app/models/README.md
@@ -40,6 +40,13 @@ is only accessed via the `Permission` class and Rolify.
 A `chapter` represents a local organisation. It primarily serves to
 collate things by location and organisers.
 
+`Chapter` exposes two tiers of member access methods. The raw methods
+(`#students`, `#coaches`) return all members subscribed to that group
+regardless of eligibility. The filtered methods (`#eligible_students`,
+`#eligible_coaches`) exclude banned members and those who have not
+accepted the terms of conduct, and should be preferred when building
+workshop invitation lists.
+
 ## Sponsor
 
 A `sponsor` represents a location and organisation. Sponsors have a

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -36,19 +36,21 @@ class Chapter < ApplicationRecord
     @organisers ||= Member.with_role(:organiser, self)
   end
 
+
   def students
-    Member.joins(:groups)
-          .merge(Group.students)
-          .distinct
+    members_for_group('Students')
   end
 
   def coaches
-    Member.joins(:groups)
-          .merge(Group.coaches)
-          .distinct
+    members_for_group('Coaches')
   end
 
+
   private
+
+  def members_for_group(name)
+    members.where(groups: { name: name }).distinct
+  end
 
   def expire_chapters_sidebar_cache
     Rails.cache.delete('chapters-sidebar')

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -36,27 +36,33 @@ class Chapter < ApplicationRecord
     @organisers ||= Member.with_role(:organiser, self)
   end
 
+  # All members subscribed to this chapter's Students group, regardless of ban or TOC status.
+  # Use #eligible_students when building invitation lists.
   def students
-    Member.joins(:groups)
-          .merge(Group.students)
-          .distinct
+    members_for_group('Students')
   end
 
+  # All members subscribed to this chapter's Coaches group, regardless of ban or TOC status.
+  # Use #eligible_coaches when building invitation lists.
   def coaches
-    Member.joins(:groups)
-          .merge(Group.coaches)
-          .distinct
+    members_for_group('Coaches')
   end
 
+  # Chapter students who are not banned and have accepted the TOC — safe to invite to workshops.
   def eligible_students
     Member.in_group(groups.students).distinct
   end
 
+  # Chapter coaches who are not banned and have accepted the TOC — safe to invite to workshops.
   def eligible_coaches
     Member.in_group(groups.coaches).distinct
   end
 
   private
+
+  def members_for_group(name)
+    members.where(groups: { name: name }).distinct
+  end
 
   def expire_chapters_sidebar_cache
     Rails.cache.delete('chapters-sidebar')

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -65,4 +65,34 @@ RSpec.describe Chapter do
       expect(Rails.cache.read(cache_key)).to be_nil
     end
   end
+
+  describe "helper methods return only that chapter's coaches/students" do
+    RSpec.shared_examples 'group-scoped members' do |group_name, method_name|
+      let(:this_chapter) { Fabricate(:chapter) }
+      let(:that_chapter) { Fabricate(:chapter) }
+
+      let!(:this_group)  { Fabricate(:group, chapter: this_chapter, name: group_name) }
+      let!(:that_group)  { Fabricate(:group, chapter: that_chapter, name: group_name) }
+
+      let!(:this_member) { Fabricate(:member) }
+      let!(:that_member) { Fabricate(:member) }
+
+      before do
+        Fabricate(:subscription, group: this_group, member: this_member)
+        Fabricate(:subscription, group: that_group, member: that_member)
+      end
+
+      it "returns only #{group_name.downcase} for the chapter" do
+        expect(this_chapter.public_send(method_name))
+          .to contain_exactly(this_member)
+      end
+
+      it "does not include #{group_name.downcase} from another chapter" do
+        expect(this_chapter.public_send(method_name))
+          .not_to include(that_member)
+      end
+    end
+    it_behaves_like 'group-scoped members', 'Students', :students
+    it_behaves_like 'group-scoped members', 'Coaches', :coaches
+  end
 end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -66,6 +66,34 @@ RSpec.describe Chapter do
     end
   end
 
+  describe '#students' do
+    let(:chapter) { Fabricate(:chapter) }
+    let(:student_group) { Fabricate(:group, chapter: chapter, name: 'Students') }
+
+    it 'returns only students from this chapter' do
+      other_chapter = Fabricate(:chapter)
+      other_group = Fabricate(:group, chapter: other_chapter, name: 'Students')
+      this_student = Fabricate(:member, groups: [student_group])
+      _other_student = Fabricate(:member, groups: [other_group])
+
+      expect(chapter.students).to contain_exactly(this_student)
+    end
+  end
+
+  describe '#coaches' do
+    let(:chapter) { Fabricate(:chapter) }
+    let(:coach_group) { Fabricate(:group, chapter: chapter, name: 'Coaches') }
+
+    it 'returns only coaches from this chapter' do
+      other_chapter = Fabricate(:chapter)
+      other_group = Fabricate(:group, chapter: other_chapter, name: 'Coaches')
+      this_coach = Fabricate(:member, groups: [coach_group])
+      _other_coach = Fabricate(:member, groups: [other_group])
+
+      expect(chapter.coaches).to contain_exactly(this_coach)
+    end
+  end
+
   describe '#eligible_students' do
     let(:chapter) { Fabricate(:chapter) }
     let(:student_group) { Fabricate(:group, chapter: chapter, name: 'Students') }


### PR DESCRIPTION
This fixes a bug where the methods returned _all_ of the students and coaches that the user could access

`#coaches` query: `"SELECT DISTINCT \"members\".* FROM \"members\" INNER JOIN \"subscriptions\" ON \"members\".\"id\" = \"subscriptions\".\"member_id\" INNER JOIN \"groups\" ON \"subscriptions\".\"group_id\" = \"groups\".\"id\" WHERE \"groups\".\"chapter_id\" = 1 AND \"groups\".\"name\" = 'Coaches'"`

`#students` query: `"SELECT DISTINCT \"members\".* FROM \"members\" INNER JOIN \"subscriptions\" ON \"members\".\"id\" = \"subscriptions\".\"member_id\" INNER JOIN \"groups\" ON \"subscriptions\".\"group_id\" = \"groups\".\"id\" WHERE \"groups\".\"chapter_id\" = 1 AND \"groups\".\"name\" = 'Students'"`