### PR TITLE
fix(avatar): handle nil email with fallback to member-ID-based placeholder

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include DigestHelper
+
   def humanize_date(datetime, end_time = nil, with_time: false, with_year: false)
     return I18n.l(datetime, format: :humanised_with_year) if with_year
     return humanize_date_with_time(datetime, end_time) if with_time

--- a/app/helpers/digest_helper.rb
+++ b/app/helpers/digest_helper.rb
@@ -1,0 +1,7 @@
+module DigestHelper
+  def md5_of(identifier)
+    return '' if identifier.nil?
+
+    Digest::MD5.hexdigest(identifier.to_s.strip.downcase)
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,5 +1,6 @@
 class Member < ApplicationRecord
   include Permissions
+  include DigestHelper
 
   enum :how_you_found_us, {
     from_a_friend: 0,
@@ -99,7 +100,8 @@ class Member < ApplicationRecord
   end
 
   def avatar(size = 100)
-    "https://secure.gravatar.com/avatar/#{md5_email}?size=#{size}&default=identicon"
+    identifier = email.presence || "member-#{id}@example.com"
+    "https://secure.gravatar.com/avatar/#{md5_of(identifier)}?size=#{size}&default=identicon"
   end
 
   def requires_additional_details?
@@ -170,10 +172,6 @@ class Member < ApplicationRecord
       .joins(:workshop)
       .where('workshops.date_and_time BETWEEN ? AND ?', date.beginning_of_day, date.end_of_day)
       .where(attending: true)
-  end
-
-  def md5_email
-    Digest::MD5.hexdigest(email.strip.downcase)
   end
 
   def rsvps(period:)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ApplicationHelper do
 
   describe '#number_to_currency' do
     it 'correctly formats a number to British pounds' do
-      expect(helper.number_to_currency(20100)).to eq('£20,100')
+      expect(helper.number_to_currency(20_100)).to eq('£20,100')
     end
   end
 
   describe '#title and #get_title' do
     it 'sets page title with the given title name' do
-      helper.title("Homapage")
+      helper.title('Homapage')
 
       expect(helper.retrieve_title).to eq('Homapage | codebar.io')
     end
@@ -58,6 +58,24 @@ RSpec.describe ApplicationHelper do
     it 'returns custom title for community level' do
       title = helper.sponsorship_level_title('community')
       expect(title).to eq('Community partners')
+    end
+  end
+
+  describe '#md5_of' do
+    it 'returns MD5 hash of lowercase string' do
+      expect(helper.md5_of('Test@Example.COM')).to eq(Digest::MD5.hexdigest('test@example.com'))
+    end
+
+    it 'handles nil gracefully' do
+      expect(helper.md5_of(nil)).to eq('')
+    end
+
+    it 'converts integer to string' do
+      expect(helper.md5_of(123)).to eq(Digest::MD5.hexdigest('123'))
+    end
+
+    it 'strips whitespace' do
+      expect(helper.md5_of('  spaces@example.com  ')).to eq(Digest::MD5.hexdigest('spaces@example.com'))
     end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe Member do
         expect(member.avatar).to eq("https://secure.gravatar.com/avatar/#{encrypted_email}?size=100&default=identicon")
       end
 
+      describe '#avatar' do
+        let(:member) { Fabricate.build(:member, email: nil) }
+
+        it 'falls back to member ID based email' do
+          encrypted_email = Digest::MD5.hexdigest("member-#{member.id}@example.com")
+          expect(member.avatar).to eq("https://secure.gravatar.com/avatar/#{encrypted_email}?size=100&default=identicon")
+        end
+      end
+
       describe '#recent_notes' do
         it 'returns no notes when member attented no workshops' do
           expect(member.workshop_invitations.attended.length).to eq(0)


### PR DESCRIPTION
This was re-introduced when we null'ed invalid email addresses in the database in recent work fixing sending out email invites for workshops.

## Summary

- Fixes `ActionView::Template::Error: undefined method 'strip' for nil` when rendering avatar for members with nil email
- Extracts MD5 hashing into new `DigestHelper#md5_of` helper (pure function)
- Refactors `Member#avatar` to use fallback email (`member-{id}@example.com`) when member.email is nil
- Removes deprecated `Member#md5_email` method

## Error

Refs: https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/676

```
ActionView::Template::Error: undefined method 'strip' for nil
Member#md5_email(/app/app/models/member.rb:176)
    Digest::MD5.hexdigest(email.strip.downcase)
Member#avatar(/app/app/models/member.rb:102)
    "https://secure.gravatar.com/avatar/#{md5_email}?size=#{size}&default=identicon"
```

<img width="1340" height="903" alt="image" src="https://github.com/user-attachments/assets/3d24fea5-f786-474e-a9ed-dd4232ca3ce4" />


## Testing

- Added tests for `md5_of` helper in `spec/helpers/application_helper_spec.rb`
- Added test for nil email fallback in `spec/models/member_spec.rb`
- All tests passing:
  - 41 member spec tests
  - 10 application helper spec tests