### PR TITLE
fix: handle blank email from GitHub OAuth

### DIFF
--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -26,8 +26,15 @@ class AuthServicesController < ApplicationController
 
       finish_registration || redirect_to(referer_or_dashboard_path)
     else
-        member = Member.find_by(email: omnihash[:info][:email])
-        member ||= Member.new(email: omnihash[:info][:email])
+        email = omnihash[:info][:email].to_s.strip
+
+        if email.blank?
+          flash[:error] = I18n.t('notifications.email_missing_from_provider')
+          return redirect_to root_url
+        end
+
+        member = Member.find_by(email:)
+        member ||= Member.new(email:)
 
         member.name    ||= omnihash[:info][:name]&.split(' ')&.first || ''
         member.surname ||= omnihash[:info][:name]&.split(' ')&.drop(1)&.join(' ') || ''

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
     not_logged_in: "You must be logged in to access this page."
     signing_up: "Thanks for signing up. Please fill in your details to complete the registration process."
     authentication_error: "Authentication failed. Please try again."
+    email_missing_from_provider: "We could not retrieve your email address from GitHub. Please make sure your GitHub account has a public email address and try again."
   navigation:
     dashboard: "Dashboard"
     code_of_conduct: "Code of Conduct"


### PR DESCRIPTION
## Summary

- Validates email is present before attempting to find or create a Member
- Shows friendly error message when GitHub returns a blank/missing email
- Prevents ActiveRecord::RecordInvalid error with "email can't be blank, already taken, is invalid"

## Root Cause

When GitHub returns a blank/nil email:
1. Controller tried to find/create Member with blank email
2. Found existing member with blank email in database  
3. Uniqueness validation failed with multiple errors

Fix adds early validation of email presence before any database operations.


This fixes https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/663#detail

<img width="1350" height="904" alt="image" src="https://github.com/user-attachments/assets/3c320fa8-017f-428c-a04e-2b190b9e4e76" />
