### PR TITLE
fix: ignore Accept header to prevent UnknownFormat errors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -15,8 +15,13 @@ Rails.application.configure do
   # Turn on fragment caching in view templates.
   config.action_controller.perform_caching = true
 
+  # Ignore Accept header for format negotiation.
+  # Prevents UnknownFormat errors from crawlers/scripts sending non-HTML Accept headers.
+  # See: https://github.com/rails/rails/commit/2f4aaed7b3feb3be787a316fab3144c06bb21a27
+  config.action_dispatch.ignore_accept_header = true
+
   # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  config.public_file_server.headers = { 'cache-control' => "public, max-age=#{1.year.to_i}" }
 
   config.assets.js_compressor = :terser
 
@@ -39,14 +44,14 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!).
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 
   # Prevent health checks from clogging up the logs.
-  config.silence_healthcheck_path = "/up"
+  config.silence_healthcheck_path = '/up'
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
@@ -70,15 +75,15 @@ Rails.application.configure do
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   config.action_mailer.smtp_settings = {
-     port: '587',
-     address: 'smtp.sendgrid.net',
-     user_name: ENV['SENDGRID_USERNAME'],
-     password: ENV['SENDGRID_PASSWORD'],
-     domain: 'heroku.com',
-     authentication: :plain,
-     enable_starttls_auto: true
-   }
-   ActionMailer::Base.delivery_method = :smtp
+    port: '587',
+    address: 'smtp.sendgrid.net',
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'heroku.com',
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+  ActionMailer::Base.delivery_method = :smtp
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -88,7 +93,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [


### PR DESCRIPTION
## Summary

- Adds `config.action_dispatch.ignore_accept_header = true` to production environment
- Prevents `ActionController::UnknownFormat` errors when clients send non-HTML Accept headers (e.g., `Accept: application/json`)

## Problem

Requests with non-HTML Accept headers cause server errors:

```
ActionController::UnknownFormat: ChapterController#show is missing a template for this request format and variant.
request.formats: [\"application/json\"]
```

Example error from production - AHC HTTP client requesting JSON:
```
curl -H \"Accept: application/json\" https://codebar.io/shanghai
```

## Root Cause

Rails determines response format from (in priority order):
1. `?format=` query parameter
2. **HTTP Accept header** ← The problem
3. URL path extension (`.csv`, `.json`)
4. Default to HTML

When a client sends `Accept: application/json`, Rails tries to render JSON. Without JSON templates, it raises `UnknownFormat`.

## Solution

Single configuration change in `config/environments/production.rb`:

```ruby
config.action_dispatch.ignore_accept_header = true
```

This tells Rails to ignore the HTTP Accept header for format negotiation. Format comes only from:
- `?format=` query parameter
- URL path extension (`.csv`, `.json`)
- Default to HTML

## How This Is Safe

### What continues to work:

- **CSV exports** - `/admin/events/1.csv` (path extension)
- **Text exports** - `/admin/events/1?format=text` (query param)
- **TomSelect member search** - Uses `/admin/members/search` which explicitly renders JSON with `render json:`
- **HTML pages** - All normal browser requests

### What gets fixed:

- JSON/other Accept headers → falls back to HTML instead of 500 error
- No more server errors that need investigation

### Documentation

- **Rails API**: [ActionDispatch::Http::MimeNegotiation#ignore_accept_header](https://api.rubyonrails.org/v7.0.4.2/classes/ActionDispatch/Http/MimeNegotiation.html)
- **Rails API (instance method)**: [use_accept_header](https://api.rubyonrails.org/v7.0.4.2/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-use_accept_header) 
- **Rails commit (2008)**: [rails/rails#2f4aaed](https://github.com/rails/rails/commit/2f4aaed7b3feb3be787a316fab3144c06bb21a27)

From the original Rails commit:
> "The accept header is poorly implemented by browsers and causes strange errors when used on **public sites where crawlers make requests too**."

This is the recommended approach for public websites per Rails core team.