### PR TITLE
fix: handle nil paginated in fetch_upcoming_events and fetch_past_events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -82,7 +82,10 @@ class EventsController < ApplicationController
     events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions).all
 
     sorted = events.compact.flatten.sort_by(&:date_and_time)
+    return [{}, nil] if sorted.empty?
+
     pagy, paginated = pagy(sorted, items: 20)
+    paginated ||= []
 
     grouped = paginated.group_by(&:date)
     decorated = grouped.transform_values { |items| EventPresenter.decorate_collection(items) }
@@ -101,7 +104,10 @@ class EventsController < ApplicationController
     events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions).all
 
     sorted = events.compact.flatten.sort_by(&:date_and_time).reverse
+    return [{}, nil] if sorted.empty?
+
     pagy, paginated = pagy(sorted, items: 20)
+    paginated ||= []
 
     grouped = paginated.group_by(&:date)
     decorated = grouped.transform_values { |items| EventPresenter.decorate_collection(items) }

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe EventsController do
+  describe '#fetch_upcoming_events' do
+    context 'when no events exist' do
+      it 'returns empty hash and nil pagy' do
+        expect(controller.send(:fetch_upcoming_events)).to eq([{}, nil])
+      end
+    end
+  end
+
+  describe '#fetch_past_events' do
+    context 'when no events exist' do
+      it 'returns empty hash and nil pagy' do
+        expect(controller.send(:fetch_past_events)).to eq([{}, nil])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes `NoMethodError: undefined method 'group_by' for nil` when `/events/upcoming` or `/events/past` is accessed with no events or an out-of-bounds page number

## Root Cause

In `EventsController#fetch_upcoming_events` and `fetch_past_events`, the code collects events from Workshops, Meetings, and Events, sorts them, and then calls `pagy` to paginate. However:

1. When `sorted` is empty (no upcoming/past events), `paginated` can be nil
2. When requesting an out-of-bounds page (e.g., page 3 when only 2 pages exist), `paginated` can also be nil

The code then calls `paginated.group_by(&:date)` without checking for nil, causing the error.

## Changes

1. Added early return `[{}, nil]` when no events exist to avoid unnecessary pagination
2. Added `paginated ||= []` guard clause to handle edge cases where `paginated` is nil even with events

## Testing

- Added `spec/controllers/events_controller_spec.rb` with tests for empty events edge case
- All existing tests continue to pass

## Rollbar Reference

https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/669#detail