### PR TITLE
feat(admin): add eligible members explanation to admin pages

### DIFF
--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -26,7 +26,7 @@
 
       .card.border-info.my-4.my-md-0.my-lg-4.ms-md-4.ms-lg-0
         .card-body
-          %ul.nav.flex-column.ms-0.mb-0
+          %ul.nav.flex-column.ms-0.mb-2
             - @groups.each do |group|
               %li.nav-item
                 = link_to [ :admin, group ], class: 'nav-link' do
@@ -34,10 +34,14 @@
               %li.nav-item
                 = link_to admin_chapter_members_path(@chapter, type: group.name.downcase), class: 'nav-link' do
                   View #{group.name} emails
+          %ul.nav.flex-column.ms-0.mb-0
             %li.nav-item
               = link_to 'View all sponsors', admin_sponsors_path, class: 'nav-link'
             %li.nav-item
               = link_to 'View all workshops', admin_chapter_workshops_path(@chapter), class: 'nav-link'
+          .alert.alert-info.mt-2.mb-0
+            %strong= t('admin.groups.eligible_title')
+            = simple_format(t('admin.groups.eligible_help'))
 
       - if @how_you_found_us.data_present?
         .card.border-info.my-4.my-md-0.my-lg-4.ms-md-4.ms-lg-0

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -11,7 +11,12 @@
 
   .row
     .col
-      %h3.mb-3 Members (#{@eligible_count} eligible, #{@total_count} total)
+      %h3.mb-3
+        Members
+        %small (#{@eligible_count} eligible, #{@total_count} total)
+      .alert.alert-info.mt-2
+        %strong= t('admin.groups.eligible_title')
+        = simple_format(t('admin.groups.eligible_help'))
 
   .row.mb-4
     .col-12.col-md-6

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -1,5 +1,14 @@
 en:
   admin:
+    groups:
+      eligible_title: "What is \"eligible\"?"
+      eligible_help: |
+        Eligible members are those who:
+        1. Have accepted the codebar Terms & Conditions
+        2. Are not banned from the platform
+        
+        Members who haven't accepted T&C or are banned do not receive invitations and cannot RSVP to workshops.
+
     shared:
       workshops: Workshops
       events: Events

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -144,4 +144,19 @@ RSpec.feature 'Chapters', type: :feature do
       expect(page).not_to have_content('How members found this chapter')
     end
   end
+
+  context 'eligible members tooltip' do
+    let(:chapter) { Fabricate(:chapter_with_groups) }
+
+    before do
+      login_as_admin(member)
+    end
+
+    scenario 'shows explanation for eligible members' do
+      visit admin_chapter_path(chapter)
+
+      expect(page).to have_content('What is "eligible"?')
+      expect(page).to have_content(/Are not banned/i)
+    end
+  end
 end

--- a/spec/features/admin/groups_spec.rb
+++ b/spec/features/admin/groups_spec.rb
@@ -17,4 +17,21 @@ RSpec.feature 'admin groups', type: :feature do
       expect(page).to have_content('Group Students for chapter Brighton has been successfully created')
     end
   end
+
+  context '#show page' do
+    let(:member) { Fabricate(:member) }
+    let(:chapter) { Fabricate(:chapter, name: 'Brighton') }
+    let(:group) { Fabricate(:group, chapter: chapter, name: 'Students') }
+
+    before do
+      login_as_admin(member)
+    end
+
+    scenario 'shows explanation for eligible members' do
+      visit admin_group_path(group)
+
+      expect(page).to have_content('What is "eligible"?')
+      expect(page).to have_content(/Are not banned/i)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add 'What is eligible?' explanation to chapter and group admin pages
- Explain eligibility criteria: accepted Terms & Conditions and not banned
- Explain the consequence: cannot receive invitations or RSVP to workshops
- Add feature tests for both admin pages

#### Screenshot from localhost with fake data

<img width="459" height="591" alt="image" src="https://github.com/user-attachments/assets/bde86715-4b78-40a5-82af-b320f93eab8d" />

<img width="1356" height="533" alt="image" src="https://github.com/user-attachments/assets/412aed3f-c25e-47f5-be6d-5c9348b5e25e" />
