### PR TITLE
feat: add nginx reverse proxy for Plausible analytics

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: bundle exec rake db:migrate
-web: bundle exec puma -C config/puma.rb
+web: bin/start-nginx bundle exec puma -C config/puma.rb

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,10 +31,10 @@
     = csp_meta_tag
 
     <!-- Privacy-friendly analytics by Plausible -->
-    %script{ async: true, src: 'https://plausible.io/js/pa-PFruVsE_br97UUCRXE_6f.js' }
+    %script{ async: true, src: '/js/script.js' }
     %script
       window.plausible = window.plausible || function() { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function(i) { plausible.o = i || {} };
-      plausible.init()
+      plausible.init({ endpoint: '/api/event' })
 
   %body.no-js{ 'class': "#{params[:controller]}-#{params[:action]}", 'data-bs-no-jquery': 'true' }
     #top

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,77 @@
+daemon off;
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  charset utf-8;
+  server_tokens off;
+
+  # DNS resolver for proxy_pass
+  resolver 9.9.9.9 valid=30s;
+
+  # Proxy cache in /dev/shm (tmpfs, persists across dyno restarts)
+  proxy_cache_path /dev/shm/nginx_cache levels=1:2 keys_zone=plausible_cache:1m max_size=100m inactive=5m use_temp_path=off;
+
+  # Security headers
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+  # Logs to stdout/stderr for Heroku
+  access_log /dev/stdout;
+  error_log /dev/stderr;
+
+  # Proxy settings
+  proxy_http_version 1.1;
+  proxy_buffering on;
+
+  upstream app_server {
+    server unix:/tmp/nginx.socket fail_timeout=0;
+  }
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name _;
+    keepalive_timeout 5;
+
+    # Plausible endpoints (set inside server context)
+    set $plausible_script_url https://plausible.io/js/pa-PFruVsE_br97UUCRXE_6f.js;
+    set $plausible_event_url https://plausible.io/api/event;
+
+    # Plausible: Proxy script.js (cached)
+    location = /js/script.js {
+      proxy_cache plausible_cache;
+      proxy_cache_valid 200 5m;
+      proxy_cache_key "$host$uri";
+      proxy_pass $plausible_script_url;
+      proxy_set_header Host plausible.io;
+      proxy_buffering on;
+
+      # Cache response headers
+      add_header X-Cache $upstream_cache_status;
+    }
+
+    # Plausible: Proxy event API
+    location = /api/event {
+      proxy_pass $plausible_event_url;
+      proxy_set_header Host plausible.io;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_buffering on;
+    }
+
+    # Rails: All other requests
+    location / {
+      proxy_pass http://app_server;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+    }
+  }
+}

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -15,12 +15,6 @@ http {
   # Proxy cache in /dev/shm (tmpfs, persists across dyno restarts)
   proxy_cache_path /dev/shm/nginx_cache levels=1:2 keys_zone=plausible_cache:1m max_size=100m inactive=5m use_temp_path=off;
 
-  # Security headers
-  add_header X-Frame-Options "SAMEORIGIN" always;
-  add_header X-Content-Type-Options "nosniff" always;
-  add_header X-XSS-Protection "1; mode=block" always;
-  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
   # Logs to stdout/stderr for Heroku
   access_log /dev/stdout;
   error_log /dev/stderr;

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,9 @@
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
-#
+
+require 'fileutils'
+
 # Puma starts a configurable number of processes (workers) and each process
 # serves each request in a thread from an internal thread pool.
 #
@@ -29,7 +31,16 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+# Use Unix socket when nginx config exists (from heroku-community/nginx buildpack)
+# Falls back to port if nginx config not present
+if File.exist?("config/nginx.conf.erb")
+  bind "unix:///tmp/nginx.socket?umask=0077"  # Restrict socket permissions to owner only
+  
+  # Signal to nginx buildpack that app is ready (required for nginx to start)
+  FileUtils.touch("/tmp/app-initialized")
+else
+  port ENV.fetch("PORT", 3000)
+end
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
## Summary

This PR implements the proposal from #2580 to run nginx as a reverse proxy in front of Rails on Heroku. This achieves two primary goals:

1. **Plausible Proxy** — Serve Plausible analytics through our domain, bypassing adblockers
2. ~~**Security Headers** — Add security headers at nginx level before requests reach Rails~~

   *Security headers removed pending further research. See commit d15a4ce1.*

## Changes

### Infrastructure
- Add `heroku-community/nginx` buildpack configuration (`config/nginx.conf.erb`)
- Update `Procfile` to use `bin/start-nginx` wrapper
- Configure Puma to bind to Unix socket on Heroku (`config/puma.rb`)

### Analytics
- Update Plausible snippet to use proxied endpoints (`/js/script.js`, `/api/event`)
- Pass through Cache-Control headers from Plausible

### Proxy Caching
- Cache Plausible script in `/dev/shm` (memory-backed, faster than disk)
- X-Cache header shows HIT/MISS for debugging
- 1m max cache size (single ~30KB JS file)
- Note: Cache is ephemeral — cleared on dyno restart (same as /tmp)

### ~~Security Headers~~
- ~~X-Frame-Options: SAMEORIGIN~~
- ~~X-Content-Type-Options: nosniff~~
- ~~X-XSS-Protection: 1; mode=block~~
- ~~Referrer-Policy: strict-origin-when-cross-origin~~

*Removed pending proper security research. See commit d15a4ce1.*

## Implementation Notes

### What we learned (deviations from initial plan)

1. **/dev/shm for proxy_cache** — Initial plan suggested /tmp, but /dev/shm is a memory-backed tmpfs which is faster than disk-backed /tmp. Both are ephemeral and cleared on dyno restart.

2. **Detection method** — Initial plan used ENV["DYNO"], but this isn't set on all dyno types. Used File.exist?("config/nginx.conf.erb") instead to detect when nginx config is present.

3. **Nginx 'set' directive** — Initially placed in http block (lines 23-24), but nginx only allows 'set' inside server or location blocks. Had to move into server context.

4. **DNS resolver** — Heroku handles DNS for the main app, but nginx needs explicit resolver for upstream proxy_pass domains (plausible.io). Added Quad9 (9.9.9.9) as recommended by Plausible.

### Key technical discoveries

- **heroku-buildpack-nginx** waits for `/tmp/app-initialized` file before starting nginx. Puma must create this file after binding to socket.
- **nginx 'set'** directive only works in server/location contexts, not http block
- **Puma** must bind to unix socket AND signal readiness for nginx to connect
- **Quad9 DNS** (9.9.9.9) is recommended by Plausible for upstream resolution

### Security filters not included

The initial proposal included security filters (blocking malicious UAs, attack paths). These were removed to simplify the implementation and reduce maintenance burden. Security headers provide most of the benefit with minimal complexity.

## Deployment

### One-time setup: Add nginx buildpack

The nginx buildpack must be added BEFORE the Ruby buildpack so it runs AFTER to serve the final response:

```bash
# Check current buildpack order
heroku buildpacks --app codebar-staging

# Add nginx buildpack (position 1 = first, runs last)
heroku buildpacks:add --index 1 heroku-community/nginx --app codebar-staging
heroku buildpacks:add --index 1 heroku-community/nginx --app codebar-production

# Verify order should be:
# 1. heroku-community/nginx  (runs last, serves response)
# 2. heroku/ruby         (runs first, builds app)
```

Expected output after adding:
```
=== codebar-staging Buildpack URLs
1. https://github.com/heroku/heroku-buildpack-nginx
2. https://github.com/heroku/heroku-buildpack-ruby
```

### Deploy

```bash
# Deploy to staging first
git push staging feature/nginx-plausible-proxy-clean:main

# Test proxy and caching (see Testing section below)

# Deploy to production after confirming staging is working
git push production feature/nginx-plausible-proxy-clean:main
```

## Testing Checklist

**Plausible Proxy:**
- [x] `/js/script.js` returns Plausible script with correct content-type (200 OK)
- [x] `/api/event` accepts POST and forwards to Plausible ({ok})
- [x] First request returns `X-Cache: MISS`
- [x] Second request returns `X-Cache: HIT`

**~~Security Headers~~:**
- [ ] ~~X-Frame-Options: SAMEORIGIN~~
- [ ] ~~X-Content-Type-Options: nosniff~~
- [ ] ~~X-XSS-Protection: 1; mode=block~~
- [ ] ~~Referrer-Policy: strict-origin-when-cross-origin~~

*Security headers removed pending further research. See commit d15a4ce1.*

**Rails Functionality:**
- [x] Homepage loads correctly (200 OK)
- [x] Login redirect works (302)
- [x] Routes respond correctly

## Rollback

If issues arise:

```bash
# Remove nginx buildpack
heroku buildpacks:remove heroku-community/nginx --app codebar-production
heroku buildpacks:remove heroku-community/nginx --app codebar-staging

# Rollback to previous release
heroku releases:rollback --app codebar-production
heroku releases:rollback --app codebar-staging
```

## References

- Proposal: #2580
- Plausible proxy guide: https://plausible.io/docs/proxy/guides/nginx
- Heroku nginx buildpack: https://github.com/heroku/heroku-buildpack-nginx
