### PR TITLE
chore(deps): switch sitemap_generator to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,4 +126,4 @@ gem 'rollbar'
 gem 'scout_apm'
 
 gem 'carrierwave-aws', '~> 1.6'
-gem 'sitemap_generator', github: 'kjvarga/sitemap_generator', branch: 'master' # LOCKED: When a version higher than 6.3.0 is released, drop this LOCKED.
+gem 'sitemap_generator', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/kjvarga/sitemap_generator.git
-  revision: 747988328566c84b0b8aa1ab898ababc371284dc
-  branch: master
-  specs:
-    sitemap_generator (6.4.0)
-      builder (~> 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -546,6 +538,8 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
+    sitemap_generator (7.0.1)
+      builder (~> 3.0)
     slop (3.6.0)
     snaky_hash (2.0.1)
       hashie
@@ -691,7 +685,7 @@ DEPENDENCIES
   simple_form
   simplecov
   simplecov-lcov
-  sitemap_generator!
+  sitemap_generator (~> 7.0)
   sprockets-rails
   stimulus-rails
   stripe


### PR DESCRIPTION
## Summary

Switch `sitemap_generator` from GitHub source to RubyGems for improved stability.

## Changes

- Remove GitHub lock (was waiting for version > 6.3.0 to be released)
- Use RubyGems version 7.0.1 with `~> 7.0` constraint
- `sitemap_generator` 7.x includes Rails 8 support

## Why

The dependency was locked to GitHub because we needed a version higher than 6.3.0, which wasn't available on RubyGems at the time. Version 7.0.1 is now available on RubyGems, allowing us to use the standard gem source.

Benefits:
- More stable dependency resolution (no GitHub API rate limits)
- Faster bundle installs (RubyGems is cached by bundler)
- Clear version constraint prevents unexpected major version upgrades

## Verification

- [x] `bundle install` succeeds
- [x] `bundle exec rake sitemap:refresh` works correctly
- [x] `public/sitemap.xml.gz` is generated successfully

## Breaking Changes Assessment

sitemap_generator 7.0 has some breaking changes that don't affect this project:

| Change | Impact |
|--------|--------|
| Default search engines list is empty | None - we don't use the ping feature |
| LinkSet#create finalize! behavior change | None - we use standard `create` with a block |
| Ruby 2.5 / Rails 5.2 dropped | None - we use Rails 8.1, Ruby 3.x |