### PR TITLE
Fix: Workshop capacity checks now properly compare attending count with available spaces

### DIFF
--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -74,6 +74,14 @@ class WorkshopPresenter < EventPresenter
     venue.seats
   end
 
+  def event_student_spaces?
+    model.student_spaces > attending_students.length
+  end
+
+  def event_coach_spaces?
+    model.coach_spaces > attending_coaches.length
+  end
+
   def pairing_csv
     pairing_details = model.attendances.inject([PAIRING_HEADINGS]) do |content, invitation|
       member = MemberPresenter.new(invitation.member)

--- a/spec/presenters/workshop_presenter_capacity_spec.rb
+++ b/spec/presenters/workshop_presenter_capacity_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
+  describe '#event_student_spaces?' do
+    let(:workshop) { Fabricate(:workshop, student_count: 2, coach_count: 2) }
+    let(:presenter) { WorkshopPresenter.new(workshop) }
+
+    context 'when workshop is at capacity' do
+      before do
+        # Create 2 attending students (at capacity)
+        2.times do
+          member = Fabricate(:member)
+          Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student', attending: true)
+        end
+      end
+
+      it 'returns false when no spaces are available' do
+        expect(workshop.attending_students.count).to eq(2)
+        expect(workshop.student_spaces).to eq(2)
+        expect(presenter.event_student_spaces?).to eq(false), 
+          "Expected event_student_spaces? to be false when at capacity (2/2), but got true"
+      end
+    end
+
+    context 'when workshop has available spaces' do
+      before do
+        # Create 1 attending student (below capacity)
+        member = Fabricate(:member)
+        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student', attending: true)
+      end
+
+      it 'returns true when spaces are available' do
+        expect(workshop.attending_students.count).to eq(1)
+        expect(workshop.student_spaces).to eq(2)
+        expect(presenter.event_student_spaces?).to eq(true),
+          "Expected event_student_spaces? to be true when spaces available (1/2), but got false"
+      end
+    end
+  end
+
+  describe '#event_coach_spaces?' do
+    let(:workshop) { Fabricate(:workshop, student_count: 2, coach_count: 2) }
+    let(:presenter) { WorkshopPresenter.new(workshop) }
+
+    context 'when workshop is at coach capacity' do
+      before do
+        # Create 2 attending coaches (at capacity)
+        2.times do
+          member = Fabricate(:member)
+          Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: true)
+        end
+      end
+
+      it 'returns false when no coach spaces are available' do
+        expect(workshop.attending_coaches.count).to eq(2)
+        expect(presenter.event_coach_spaces?).to eq(false),
+          "Expected event_coach_spaces? to be false when at capacity (2/2), but got true"
+      end
+    end
+
+    context 'when workshop has available coach spaces' do
+      before do
+        # Create 1 attending coach (below capacity)
+        member = Fabricate(:member)
+        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: true)
+      end
+
+      it 'returns true when coach spaces are available' do
+        expect(workshop.attending_coaches.count).to eq(1)
+        expect(presenter.event_coach_spaces?).to eq(true),
+          "Expected event_coach_spaces? to be true when spaces available (1/2), but got false"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a bug introduced in #2605 where workshop capacity checks were not working correctly.

## Problem

PR #2605 changed the capacity check methods from `student_spaces?`/`coach_spaces?` to `event_student_spaces?`/`event_coach_spaces?`, but the new methods inherited from `EventPresenter` called `model.student_spaces?` which just checks if the attribute is present (truthy), not if spaces are actually available.

This caused workshops to incorrectly show as full when spaces were available, and vice versa.

## Solution

Added proper `event_student_spaces?` and `event_coach_spaces?` methods to `WorkshopPresenter` that correctly compare the number of attending students/coaches with the available spaces:

```ruby
def event_student_spaces?
  model.student_spaces > attending_students.length
end

def event_coach_spaces?
  model.coach_spaces > attending_coaches.length
end
```

## Key Fix

Uses `model.student_spaces` (the database column) instead of `student_spaces` (the presenter method that delegates to `venue.seats`). This ensures that when tests or admins set `workshop.student_spaces = 0`, the capacity check respects that value rather than reading from the venue.

## Testing

- Added `spec/presenters/workshop_presenter_capacity_spec.rb` with 4 test cases
- All 43 related invitation tests pass
- All 81 presenter tests pass

## Bug Report Context

From Slack:
> An error has popped up, I'm not sure if it's all workshops or just the latest Barcelona one. But invites have gone out and on the invitation page it says the workshop is full. When I then try to RSVP it adds me to waitilist even though all students spots are still available

> I just tried it out on the latest virtual UK workshop and it seemed to work fine. The Berlin one though is broken and doing the same as Barcelona