### PR TITLE
Fix: Flaky tests in CI

### DIFF
--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'managing workshop attendances', type: :feature do
 
     scenario 'can remove a member from the attendee list' do
       visit admin_workshop_path(workshop)
+      expect(page).to have_css('.cancel_attendance', wait: 5)
       find('.cancel_attendance').click
 
       expect(page).to have_content('0 are attending as students')

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -1,8 +1,10 @@
 RSpec.feature 'when visiting the coaches page', type: :feature do
   scenario 'I can see the most active coaches' do
-    coach = Fabricate(:attended_coach).member
+    # Use a past workshop date in the current year to ensure the coach is counted
+    workshop = Fabricate(:workshop, date_and_time: Time.zone.today.beginning_of_year + 1.month)
+    coach = Fabricate(:attended_coach, workshop: workshop).member
     visit coaches_path
-    expect(page).to have_content coach.name
+    expect(page).to have_content(coach.name, wait: 5)
   end
 
   scenario 'I can see the top coaches by year' do


### PR DESCRIPTION
This PR fixes two flaky tests that were failing intermittently in CI parallel test execution.

## Fixed Tests

### 1. `spec/features/listing_coaches_spec.rb:2` - "I can see the most active coaches"

**Problem:** The test was using the default workshop fabricator which creates a workshop 2 days in the future. In parallel CI execution with database timing issues, this could cause the coach to not appear in the query results for the current year.

**Fix:** 
- Explicitly create a workshop with a date in the current year (`Time.zone.today.beginning_of_year + 1.month`) to ensure it's counted in the current year query
- Added 5-second wait to the expectation to handle page load timing

### 2. `spec/features/admin/manage_workshop_attendances_spec.rb:25` - "can remove a member from the attendee list"

**Problem:** The test was immediately trying to find and click the `.cancel_attendance` element after visiting the page. In CI with parallel execution, the element might not be rendered yet when Capybara tries to interact with it.

**Fix:**
- Added explicit wait for `.cancel_attendance` element to be present before attempting to click it

## Changes
- `spec/features/listing_coaches_spec.rb`: Use current year date, add wait
- `spec/features/admin/manage_workshop_attendances_spec.rb`: Add wait for element

## Verification
Both tests pass consistently locally and should be more reliable in CI parallel execution.