### PR TITLE
Fix: Use sponsor capacity for in-person workshop attendance checks

### DIFF
--- a/app/presenters/workshop_presenter.rb
+++ b/app/presenters/workshop_presenter.rb
@@ -75,11 +75,11 @@ class WorkshopPresenter < EventPresenter
   end
 
   def event_student_spaces?
-    model.student_spaces > attending_students.length
+    student_spaces > attending_students.length
   end
 
   def event_coach_spaces?
-    model.coach_spaces > attending_coaches.length
+    coach_spaces > attending_coaches.length
   end
 
   def pairing_csv

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -5,7 +5,19 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
     let(:invitation_route) { invitation_path(invitation) }
     let(:accept_invitation_route) { accept_invitation_path(invitation) }
     let(:reject_invitation_route) { reject_invitation_path(invitation) }
-    let(:set_no_available_slots) { invitation.workshop.update_attribute(:student_spaces, 0) }
+    let(:set_no_available_slots) do
+      # Fill up the workshop by creating attending students up to capacity
+      # This ensures the waiting list/full state is triggered properly
+      workshop = invitation.workshop
+      capacity = workshop.host.seats
+      attending_count = workshop.attending_students.count
+      spots_to_fill = capacity - attending_count
+
+      spots_to_fill.times do
+        member = Fabricate(:member)
+        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student', attending: true)
+      end
+    end
     let!(:tutorial) { Fabricate(:tutorial) }
 
     it_behaves_like 'invitation route'

--- a/spec/features/coach_accepting_invitation_spec.rb
+++ b/spec/features/coach_accepting_invitation_spec.rb
@@ -6,7 +6,19 @@ RSpec.feature 'a Coach can', type: :feature do
     let(:reject_invitation_route) { reject_invitation_path(invitation) }
     let(:accept_invitation_route) { accept_invitation_path(invitation) }
 
-    let(:set_no_available_slots) { invitation.workshop.update_attribute(:coach_spaces, 0) }
+    let(:set_no_available_slots) do
+      # Fill up the workshop by creating attending coaches up to capacity
+      # This ensures the waiting list/full state is triggered properly
+      workshop = invitation.workshop
+      capacity = workshop.host.coach_spots
+      attending_count = workshop.attending_coaches.count
+      spots_to_fill = capacity - attending_count
+
+      spots_to_fill.times do
+        member = Fabricate(:member)
+        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: true)
+      end
+    end
 
     before(:each) do
       login(member)

--- a/spec/presenters/workshop_presenter_capacity_spec.rb
+++ b/spec/presenters/workshop_presenter_capacity_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       it 'returns false when no spaces are available' do
         expect(workshop.attending_students.count).to eq(2)
         expect(workshop.student_spaces).to eq(2)
-        expect(presenter.event_student_spaces?).to eq(false), 
+        expect(presenter.event_student_spaces?).to eq(false),
           "Expected event_student_spaces? to be false when at capacity (2/2), but got true"
       end
     end
@@ -34,6 +34,30 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
         expect(workshop.student_spaces).to eq(2)
         expect(presenter.event_student_spaces?).to eq(true),
           "Expected event_student_spaces? to be true when spaces available (1/2), but got false"
+      end
+    end
+
+    context 'when workshop.student_spaces is 0 but sponsor has capacity (production data scenario)' do
+      let(:sponsor) { Fabricate(:sponsor, seats: 20, number_of_coaches: 10) }
+      let(:workshop_with_zero_spaces) do
+        Fabricate(:workshop_no_sponsor, student_spaces: 0, coach_spaces: 0).tap do |ws|
+          Fabricate(:workshop_sponsor, workshop: ws, sponsor: sponsor, host: true)
+        end
+      end
+      let(:presenter_zero_spaces) { WorkshopPresenter.new(workshop_with_zero_spaces) }
+
+      before do
+        # Create 1 attending student
+        member = Fabricate(:member)
+        Fabricate(:workshop_invitation, workshop: workshop_with_zero_spaces, member: member, role: 'Student', attending: true)
+      end
+
+      it 'returns true because capacity comes from sponsor, not workshop.student_spaces' do
+        expect(workshop_with_zero_spaces.attending_students.count).to eq(1)
+        expect(workshop_with_zero_spaces.student_spaces).to eq(0)
+        expect(presenter_zero_spaces.student_spaces).to eq(20), 'Capacity should come from sponsor'
+        expect(presenter_zero_spaces.event_student_spaces?).to eq(true),
+          "Expected event_student_spaces? to be true when sponsor has capacity (1/20), but got false"
       end
     end
   end
@@ -69,6 +93,30 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
         expect(workshop.attending_coaches.count).to eq(1)
         expect(presenter.event_coach_spaces?).to eq(true),
           "Expected event_coach_spaces? to be true when spaces available (1/2), but got false"
+      end
+    end
+
+    context 'when workshop.coach_spaces is 0 but sponsor has capacity (production data scenario)' do
+      let(:sponsor) { Fabricate(:sponsor, seats: 20, number_of_coaches: 10) }
+      let(:workshop_with_zero_spaces) do
+        Fabricate(:workshop_no_sponsor, student_spaces: 0, coach_spaces: 0).tap do |ws|
+          Fabricate(:workshop_sponsor, workshop: ws, sponsor: sponsor, host: true)
+        end
+      end
+      let(:presenter_zero_spaces) { WorkshopPresenter.new(workshop_with_zero_spaces) }
+
+      before do
+        # Create 1 attending coach
+        member = Fabricate(:member)
+        Fabricate(:workshop_invitation, workshop: workshop_with_zero_spaces, member: member, role: 'Coach', attending: true)
+      end
+
+      it 'returns true because capacity comes from sponsor, not workshop.coach_spaces' do
+        expect(workshop_with_zero_spaces.attending_coaches.count).to eq(1)
+        expect(workshop_with_zero_spaces.coach_spaces).to eq(0)
+        expect(presenter_zero_spaces.coach_spaces).to eq(10), 'Capacity should come from sponsor'
+        expect(presenter_zero_spaces.event_coach_spaces?).to eq(true),
+          "Expected event_coach_spaces? to be true when sponsor has capacity (1/10), but got false"
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in #2609 where in-person workshops incorrectly appear as full even when the sponsor has available capacity.

## Problem

PR #2609 changed `WorkshopPresenter#event_student_spaces?` and `event_coach_spaces?` to use `model.student_spaces` and `model.coach_spaces` (database columns). However, most in-person workshops in production have these values set to `0`, with actual capacity coming from the sponsor/venue:

```sql
workshop.student_spaces = 0
workshop.coach_spaces = 0
sponsor.seats = 20
sponsor.number_of_coaches = 20
```

This caused workshops like Barcelona #3747 to show "The workshop is full" when there were actually 20 student spots and 20 coach spots available.

## Solution

Changed the capacity check methods to use the presenter methods `student_spaces` and `coach_spaces` instead of the database columns directly:

```ruby
def event_student_spaces?
  student_spaces > attending_students.length
end

def event_coach_spaces?
  coach_spaces > attending_coaches.length
end
```

This ensures:
- **In-person workshops**: Use `venue.seats` and `venue.coach_spots` (sponsor capacity)
- **Virtual workshops**: Use `model.student_spaces` and `model.coach_spaces` (via `VirtualWorkshopPresenter` delegation)

## Testing

- Added test cases for the production data scenario (workshop spaces = 0, sponsor has capacity)
- Updated feature tests to properly fill workshops to capacity
- All 82 presenter tests pass
- All 39 invitation feature tests pass

## Affected Workflows

This fixes the issue where:
- Invites go out
- Invitation page says "The workshop is full"
- RSVP adds user to waiting list even though spots are available

As reported for Barcelona and Berlin workshops.