### PR TITLE
chore(deps): bump premailer to ~> 1.26 to fix deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (1.22.0)
+    css_parser (2.2.0)
       addressable
     csv (3.3.5)
     database_cleaner (2.1.0)
@@ -225,7 +225,7 @@ GEM
     hashdiff (1.2.1)
     hashie (5.0.0)
     high_voltage (5.0.0)
-    htmlentities (4.3.4)
+    htmlentities (4.4.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     icalendar (2.12.2)
@@ -356,9 +356,9 @@ GEM
     popper_js (2.11.8)
     pp (0.6.3)
       prettyprint
-    premailer (1.21.0)
+    premailer (1.29.0)
       addressable
-      css_parser (>= 1.12.0)
+      css_parser (>= 1.19.0)
       htmlentities (>= 4.0.0)
     premailer-rails (1.12.0)
       actionmailer (>= 3)


### PR DESCRIPTION
## Summary

Updates premailer from 1.21.0 to 1.29.0 via bundle update.

### Changes
- premailer: 1.21.0 → 1.29.0
- css_parser: 1.14.0 → 2.2.0 (transitive dependency)
- htmlentities: 4.3.4 → 4.4.2 (transitive dependency)

### Why

The old premailer version (1.21.0) was causing deprecation warnings in test output:


This was fixed in premailer 1.26.0+, which updated to use css_parser with keyword arguments.

### Files Changed
Only  - no changes to  required.

### Testing

Maler tests pass successfully:

Randomized with seed 49267
.......

Finished in 1.52 seconds (files took 3.47 seconds to load)
7 examples, 0 failures

Randomized with seed 49267