### PR TITLE
fix: deliver monthly attendance reminder emails

### DIFF
--- a/app/models/invitation_manager.rb
+++ b/app/models/invitation_manager.rb
@@ -12,7 +12,7 @@ class InvitationManager
   def send_monthly_attendance_reminder_emails(monthly)
     invitees = Member.attending_meeting(monthly)
     invitees.each do |member|
-      MeetingInvitationMailer.attendance_reminder(monthly, member)
+      MeetingInvitationMailer.attendance_reminder(monthly, member).deliver_now
     end
   end
   handle_asynchronously :send_monthly_attendance_reminder_emails

--- a/spec/models/invitation_manager_spec.rb
+++ b/spec/models/invitation_manager_spec.rb
@@ -112,16 +112,18 @@ RSpec.describe InvitationManager do
     end
   end
 
-  describe '#send_monthly_attendance_reminder_emails', :wip do
+  describe '#send_monthly_attendance_reminder_emails' do
     it 'emails all attending members' do
       meeting = Fabricate(:meeting)
       attendees = Fabricate.times(2, :attending_meeting_invitation, meeting: meeting).map(&:member)
 
-      attendees.each do |attendee|
-        expect(MeetingInvitationMailer).to receive(:attendance_reminder).with(meeting, attendee)
-      end
+      expect {
+        manager.send_monthly_attendance_reminder_emails(meeting)
+      }.to change { ActionMailer::Base.deliveries.count }.by(attendees.count)
 
-      manager.send_monthly_attendance_reminder_emails(meeting)
+      emails = ActionMailer::Base.deliveries.last(attendees.count)
+      attendee_emails = attendees.map(&:email)
+      expect(emails.map(&:to).flatten).to match_array(attendee_emails)
     end
   end
 


### PR DESCRIPTION
## Summary

`send_monthly_attendance_reminder_emails` has been broken since the feature was introduced in 2016. It instantiates a mailer message but never calls `.deliver_now` or `.deliver_later`, so the message is created in memory and immediately discarded.

## The Bug

```ruby
# Before (broken — message is instantiated and discarded)
MeetingInvitationMailer.attendance_reminder(monthly, member)

# After (fixed — message is actually sent)
MeetingInvitationMailer.attendance_reminder(monthly, member).deliver_now
```

Since the method is already wrapped in `handle_asynchronously`, the correct fix is `.deliver_now` (send synchronously within the already-async job). Using `.deliver_later` would double-queue emails.

## History

See discussion #2593 for the full analysis. In short:

- **May 2016** — Feature introduced by Denise Yu (PR #445) without `.deliver_now`
- **May 2018** — Refactored by Despo Pentara, but the bug persisted
- **~9 years** — Mock-based tests masked the bug by verifying the mailer was *called*, not that emails were *sent*

## Changes

- `app/models/invitation_manager.rb`: add `.deliver_now` to the mailer call
- `spec/models/invitation_manager_spec.rb`: convert `:wip` mock-based test to a delivery assertion

## Testing

All 39 examples in `spec/models/invitation_manager_spec.rb` pass, including the newly-converted delivery assertion. The rake task spec also passes.

## Risk

**Very low.** This only affects upcoming monthly meetings. There is no backlog of unsent emails (the mailer objects were never persisted). Fixing this will simply cause future monthly attendance reminders to actually be delivered.
