### PR TITLE
fix: delay nginx start until Puma socket is bound

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,9 +35,12 @@ threads threads_count, threads_count
 # Falls back to port if nginx config not present
 if File.exist?("config/nginx.conf.erb")
   bind "unix:///tmp/nginx.socket?umask=0077"  # Restrict socket permissions to owner only
-  
-  # Signal to nginx buildpack that app is ready (required for nginx to start)
-  FileUtils.touch("/tmp/app-initialized")
+
+  # Signal to nginx buildpack that app is ready only after Puma has bound the socket.
+  # Using on_booted prevents 502 errors caused by nginx starting before the socket exists.
+  on_booted do
+    FileUtils.touch("/tmp/app-initialized")
+  end
 else
   port ENV.fetch("PORT", 3000)
 end


### PR DESCRIPTION
## Problem

Our staging dyno intermittently returns **502 Bad Gateway** errors when waking from idle (cold start). The Heroku router logs show:

```
connect() to unix:/tmp/nginx.socket failed (2: No such file or directory) while connecting to upstream
```

This happens because nginx starts proxying requests to Puma before Puma has finished booting Rails and created the Unix socket at `/tmp/nginx.socket`.

## Root Cause

In `config/puma.rb`, we signal the Heroku nginx buildpack that the app is ready by touching `/tmp/app-initialized`:

```ruby
if File.exist?("config/nginx.conf.erb")
  bind "unix:///tmp/nginx.socket?umask=0077"
  FileUtils.touch("/tmp/app-initialized")  # ← runs during config evaluation
end
```

`FileUtils.touch` executes during **Puma config loading**, not after Puma has bound the socket. The nginx buildpack sees the file and starts nginx immediately. Rails boot takes a few seconds, so nginx tries to connect to a socket that doesn't exist yet — producing 502s until Puma is ready.

## Fix

Move the readiness signal into Puma's `on_booted` hook, which fires **after** the server has bound its sockets and is ready to accept connections:

```ruby
on_booted do
  FileUtils.touch("/tmp/app-initialized")
end
```

This eliminates the race condition between nginx startup and socket creation.

## Verification Steps (Staging)

**Before marking this PR ready for review, please follow these steps and paste the log output into a comment.**

### 1. Deploy this branch to staging
```bash
git push staging fix/nginx-puma-socket-race:master
# or via Heroku dashboard / pipeline
```

### 2. Warm start sanity check
Visit the staging site and confirm normal 200 responses. Check the latest dyno boot in the logs:
```bash
heroku logs --app codebar-staging --tail | grep -E "(nginx-start|Listening on|status=200|status=502)"
```

Expected: `Listening on unix:///tmp/nginx.socket` appears **before** `at=nginx-start`.

### 3. Cold start (unidle) test
The race condition only triggers on a cold dyno boot. To force one:

**Option A — Wait for natural idle:**
- Confirm the site is up
- Wait 30+ minutes with no traffic
- Make the next request and inspect logs

**Option B — Manual cold start (faster):**
```bash
heroku ps:scale web=0 --app codebar-staging
# wait ~30 seconds for dyno to stop
heroku ps:scale web=1 --app codebar-staging
```

Then immediately tail logs and hit the site:
```bash
heroku logs --app codebar-staging --tail | grep -E "(Unidling|starting|nginx-start|Listening on|status=200|status=502)"
```

**Expected result (GOOD):**
- `Unidling` / `State changed from down to starting`
- `Listening on unix:///tmp/nginx.socket`
- `at=nginx-start`
- First request returns `status=200`

**Bad result (before fix):**
- `at=nginx-start` appears **before** `Listening on unix:///tmp/nginx.socket`
- One or more `status=502` entries before the first `status=200`

### 4. Paste your results
Drop the relevant log lines into a PR comment so reviewers can confirm the fix works.

---

Once verified, mark the PR ready for review.
