### PR TITLE
fix: wrap fabricator time attributes in blocks to prevent flaky tests

### DIFF
--- a/spec/fabricators/event_fabricator.rb
+++ b/spec/fabricators/event_fabricator.rb
@@ -1,7 +1,7 @@
 Fabricate.sequence(:slug) { |i| "#{Faker::Lorem.word}-#{i}" }
 
 Fabricator(:event) do
-  date_and_time Time.zone.now + 2.days
+  date_and_time { Time.zone.now + 2.days }
   ends_at { |attrs| attrs[:date_and_time] + 8.hours }
   name Faker::Lorem.sentence
   description Faker::Lorem.sentence

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:workshop) do
-  date_and_time Time.zone.now + 2.days
+  date_and_time { Time.zone.now + 2.days }
   ends_at { |attrs| attrs[:date_and_time] + 2.hours }
   chapter
   student_spaces { |transients| transients[:student_count] || 10 }
@@ -18,27 +18,27 @@ Fabricator(:workshop) do
 end
 
 Fabricator(:workshop_no_sponsor, class_name: :workshop) do
-  date_and_time Time.zone.now + 2.days
+  date_and_time { Time.zone.now + 2.days }
   ends_at { |attrs| attrs[:date_and_time] + 2.hours }
   chapter
 end
 
 Fabricator(:workshop_auto_rsvp_in_past, from: :workshop) do
-  rsvp_opens_at Time.zone.now - 1.day
+  rsvp_opens_at { Time.zone.now - 1.day }
   invitable false
 end
 
 Fabricator(:workshop_auto_rsvp_in_future, from: :workshop) do
-  rsvp_opens_at Time.zone.now + 1.day
+  rsvp_opens_at { Time.zone.now + 1.day }
   invitable false
 end
 
 Fabricator(:past_workshop, from: :workshop) do
-  date_and_time 3.months.ago
+  date_and_time { 3.months.ago }
 end
 
 Fabricator(:virtual_workshop, class_name: :workshop) do
-  date_and_time Time.zone.now + 2.days
+  date_and_time { Time.zone.now + 2.days }
   ends_at { |attrs| attrs[:date_and_time] + 2.hours }
   chapter
   virtual true
@@ -49,11 +49,11 @@ Fabricator(:virtual_workshop, class_name: :workshop) do
 end
 
 Fabricator(:virtual_workshop_auto_rsvp_in_past, from: :virtual_workshop) do
-  rsvp_opens_at Time.zone.now - 1.day
+  rsvp_opens_at { Time.zone.now - 1.day }
 end
 
 Fabricator(:virtual_workshop_auto_rsvp_in_future, from: :virtual_workshop) do
-  rsvp_opens_at Time.zone.now + 1.day
+  rsvp_opens_at { Time.zone.now + 1.day }
   invitable false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,6 +103,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
+    Capybara.reset_sessions! if defined?(Capybara)
   end
 
   config.after do |example|


### PR DESCRIPTION
## Problem

The Fabrication gem evaluates attributes without blocks once and caches the value. When `Fabricate(:event)` was first called inside a `travel_to` block (e.g. in `event_spec.rb`), the `date_and_time` default was cached as a past date. All subsequent events fabricated in the same process reused that cached value, making them appear as past events.

This caused `view_event_spec` feature tests to fail because the event page showed **'This event has already occurred'** instead of the **'Log in'** link.

## Changes

- Wrap `date_and_time`, `rsvp_opens_at`, and `past_workshop.date_and_time` in Fabrication blocks so they evaluate dynamically at fabrication time
- Reset Capybara sessions after each feature spec as a defensive measure against session leaks between tests

## Verification

Reproduced the failure locally with the exact CI command and seed (41835, group 2). After the fix, the same command passes with 0 failures. Ran multiple additional seeds and the full test suite — all green.