### PR TITLE
feat: replace dotenv-rails with mise for env management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@
 
 TAGS
 .env
+mise.local.toml
+docker-compose.override.yml
 .DS_Store
 
 .byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ TAGS
 .env
 mise.local.toml
 docker-compose.override.yml
+docker-compose.env
 .DS_Store
 
 .byebug_history

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,21 @@ codebar planner is a Rails 8.1 application for managing [codebar.io](https://cod
 
 **IMPORTANT**: Always use native installation with `bundle exec` commands. Never use Docker or `bin/d*` commands.
 
+### Prerequisites
+
+- **mise** — install via `brew install mise`, then enable `mise activate` in your shell profile (see [mise docs](https://mise.jdx.dev/getting-started.html)). Alternatively, use `mise exec` to run commands with project env vars without shell activation.
+- PostgreSQL running locally (default port 5432, or configure via `DB_PORT`)
+
 ### Native Installation
 
-- **Setup**: `bundle && rake db:create db:migrate db:seed`
+```
+cp mise.local.toml.example mise.local.toml
+# Edit mise.local.toml with your GitHub OAuth credentials
+# Optionally delete .env if it exists from a prior setup:
+rm .env
+bundle && rake db:create db:migrate db:seed
+```
+
 - **Server**: `bundle exec rails server`
 - **Tests**: `make test` or `bundle exec parallel_rspec spec/ -n 3` - runs RSpec tests in parallel (3 processes is optimal)
 - **Single test**: `bundle exec rspec spec/path/to/file_spec.rb:42`
@@ -37,19 +49,24 @@ codebar planner is a Rails 8.1 application for managing [codebar.io](https://cod
 - **Run rake tasks**: `bundle exec rake [task]`
 - **Linting**: `bundle exec rubocop`
 
+### Environment Variables
+
+Managed by `mise` via `mise.toml` (shared, committed) and `mise.local.toml` (secrets, gitignored). Automatically loaded when you enter the project directory (requires `mise activate`).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | Postgres host |
+| `DB_PORT` | `5432` | Postgres port |
+| `DB_USER` | (empty) | Postgres user |
+| `POSTGRES_PASSWORD` | (empty) | Postgres password |
+| `GITHUB_KEY` | — | GitHub OAuth client ID (set in `mise.local.toml`) |
+| `GITHUB_SECRET` | — | GitHub OAuth client secret (set in `mise.local.toml`) |
+
+Create GitHub OAuth app at https://github.com/settings/applications/new with callback URL `http://localhost:3000/auth/github`.
+
 ### Docker Setup (Not Used)
 
 Docker setup exists in this repository (`bin/d*` commands) but is **not used** for development work with Claude Code, OpenCode, etc.
-
-### Environment Variables
-
-Required in `.env` file:
-```
-GITHUB_KEY=<your_github_oauth_client_id>
-GITHUB_SECRET=<your_github_oauth_client_secret>
-```
-
-Create GitHub OAuth app at https://github.com/settings/applications/new with callback URL `http://localhost:3000/auth/github`.
 
 ## Architecture & Domain Model
 

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'dotenv-rails'
+
   gem 'fabrication'
   gem 'faker'
   gem 'irb' # LOCKED: Added because of byebug

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ group :development do
 end
 
 group :development, :test do
-
   gem 'fabrication'
   gem 'faker'
   gem 'irb' # LOCKED: Added because of byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,10 +182,6 @@ GEM
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.6.2)
     docile (1.4.0)
-    dotenv (3.2.0)
-    dotenv-rails (3.2.0)
-      dotenv (= 3.2.0)
-      railties (>= 6.1)
     drb (2.2.3)
     email_validator (2.2.4)
       activemodel
@@ -634,7 +630,6 @@ DEPENDENCIES
   database_cleaner
   delayed_job
   delayed_job_active_record
-  dotenv-rails
   drb
   email_validator
   fabrication

--- a/README.md
+++ b/README.md
@@ -42,23 +42,26 @@ Visit [https://github.com/settings/applications/new](https://github.com/settings
 
 #### Add your application details to your environment variables
 
-##### Mac/Linux:
-1. Run `touch .env` to create a file named `.env` in the root of the application folder.
-2. Open this .env file in a text editor, and add the GitHub key (Client ID) and secret (Client Secret) like so:
+**Native installation (recommended):** Copy `mise.local.toml.example` to `mise.local.toml`
+and fill in your GitHub key and secret:
+
 ```
-    GITHUB_KEY=YOUR_KEY
-    GITHUB_SECRET=YOUR_SECRET
+cp mise.local.toml.example mise.local.toml
+# Edit mise.local.toml with your values
 ```
 
-##### Windows:
-Windows doesn't like creating a file named `.env`, so run the following
-from a command prompt in your project folder:
+Environment variables are managed by [mise](https://mise.jdx.dev). Install it
+with `brew install mise` and enable `mise activate` in your shell profile.
+
+**Docker installation:** Copy `docker-compose.override.yml.example` to
+`docker-compose.override.yml` and fill in your GitHub key and secret:
+
 ```
-    echo GITHUB_KEY=YOUR_KEY >> .env
-    echo GITHUB_SECRET=YOUR_SECRET >> .env
+cp docker-compose.override.yml.example docker-compose.override.yml
+# Edit docker-compose.override.yml with your values
 ```
 
-**Note:** If when starting the application with Docker you get the error `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte` this may be because you created the `.env`-file using PowerShell. This can be solved by deleting that file and creating a new one using a bash shell (for example Git Bash).
+Docker Compose automatically merges this file — no extra configuration needed.
 
 ### 3. Install and set up the environment using docker
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,7 @@ development: &default
   username: <%= ENV['DB_USER'] || ''  %>
   password: <%= ENV['POSTGRES_PASSWORD'] || '' %>
   host: <%= (ENV['DB_HOST'] || 'localhost').to_json %>
+  port: <%= ENV['DB_PORT'] || 5432 %>
 
 test:
   <<: *default

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,3 +1,0 @@
-DB_HOST=db
-DB_USER=postgres
-POSTGRES_PASSWORD=password

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,5 @@
+services:
+  web:
+    environment:
+      GITHUB_KEY: your_github_oauth_client_id
+      GITHUB_SECRET: your_github_oauth_client_secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,13 @@ services:
     environment:
       POSTGRES_PASSWORD: password
   web:
-    env_file:
-      - docker-compose.env
     build: .
     command: tail -f /dev/null
     environment:
       DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      POSTGRES_PASSWORD: password
     volumes:
       - .:/planner
       - gem_cache:/usr/local/bundle/gems

--- a/mise.local.toml.example
+++ b/mise.local.toml.example
@@ -1,0 +1,3 @@
+[env]
+GITHUB_KEY = "your_github_oauth_client_id"
+GITHUB_SECRET = "your_github_oauth_client_secret"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[env]
+DB_HOST = "localhost"
+DB_PORT = "5432"


### PR DESCRIPTION
The local development setup is a bit clunky for me still, because it assumes that Postgres is running on the default port.

I do other work on the same machine, and would like to at least be able to specify which Postgres port to use.

I've been having good results with using [`mise`](https://mise.jdx.dev) in my day job, so I am proposing that we use that (or set environment variables manually for those that prefer that), which allows us to also drop `dotenv` and `dotenv-rails`. I prefer to have fewer dependencies to manage.

---

Replace `dotenv-rails` + `.env` with `mise` for environment variable management. Add `DB_PORT` support to `database.yml` for running multiple Postgres instances.

### Changes
- **Create** `mise.toml` — shared env defaults (`DB_HOST`, `DB_PORT`)
- **Create** `mise.local.toml.example` — template for local secrets (native install)
- **Create** `docker-compose.override.yml.example` — template for Docker users
- **Add** `DB_PORT` support to `config/database.yml`
- **Add** `mise.local.toml` and `docker-compose.override.yml` to `.gitignore`
- **Remove** `dotenv-rails` gem
- **Update** `AGENTS.md` and `README.md` with new setup workflows

### Migration for Contributors
**Native:**
1. `brew install mise` and add `mise activate` to shell profile
2. `cp mise.local.toml.example mise.local.toml` and fill in GitHub OAuth creds
3. `bundle install` (removes dotenv-rails)
4. (Optional) `rm .env`

**Docker:**
1. `cp docker-compose.override.yml.example docker-compose.override.yml`
2. Fill in GitHub OAuth creds
3. No `.env` file needed