### PR TITLE
fix: skip CSRF protection for feedback form submission

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,4 +1,6 @@
 class FeedbackController < ApplicationController
+  skip_forgery_protection only: :submit
+
   def show
     feedback_request = FeedbackRequest.find_by(token: params[:id], submited: false)
 

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -1,0 +1,92 @@
+RSpec.describe FeedbackController do
+  let(:feedback_request) { Fabricate(:feedback_request) }
+  let(:coach) { Fabricate(:coach) }
+  let(:tutorial) { Fabricate(:tutorial) }
+
+  describe 'GET #show' do
+    context 'with a valid token' do
+      it 'renders the feedback form' do
+        get :show, params: { id: feedback_request.token }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'with an already submitted token' do
+      it 'redirects to the root path' do
+        submitted_request = Fabricate(:feedback_request, submited: true)
+        get :show, params: { id: submitted_request.token }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'PATCH #submit' do
+    before do
+      Fabricate(:attended_workshop_invitation, workshop: feedback_request.workshop, member: coach, role: 'Coach')
+    end
+
+    context 'with valid data' do
+      it 'saves the feedback and redirects to the root path' do
+        patch :submit, params: {
+          id: feedback_request.token,
+          feedback: {
+            coach_id: coach.id,
+            tutorial_id: tutorial.id,
+            request: 'It was great!',
+            rating: 5,
+            suggestions: ''
+          }
+        }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq(I18n.t('messages.feedback_saved'))
+        expect(feedback_request.reload.submited).to be true
+      end
+    end
+
+    context 'with invalid data' do
+      it 'renders the feedback form with errors' do
+        patch :submit, params: {
+          id: feedback_request.token,
+          feedback: {
+            coach_id: coach.id,
+            tutorial_id: tutorial.id,
+            request: '',
+            rating: nil,
+            suggestions: ''
+          }
+        }
+
+        expect(response).to have_http_status(:success)
+        expect(flash[:alert]).to include("Rating can't be blank")
+      end
+    end
+
+    context 'without a CSRF token (browser did not send session cookie)' do
+      it 'still accepts the feedback submission' do
+        # Simulate the real-world scenario where the browser withholds the
+        # session cookie (e.g. Safari ITP, cross-site navigation, or cookie
+        # blocking). With protect_from_forgery enabled, this would normally
+        # raise ActionController::InvalidAuthenticityToken.
+        ActionController::Base.allow_forgery_protection = true
+
+        patch :submit, params: {
+          id: feedback_request.token,
+          feedback: {
+            coach_id: coach.id,
+            tutorial_id: tutorial.id,
+            request: 'It was great!',
+            rating: 5,
+            suggestions: ''
+          }
+        }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq(I18n.t('messages.feedback_saved'))
+        expect(feedback_request.reload.submited).to be true
+      ensure
+        ActionController::Base.allow_forgery_protection = false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

We are seeing `ActionController::InvalidAuthenticityToken` errors when students try to submit feedback. This has occurred 82 times in production (Rollbar #535).

The root cause is that the feedback form requires a session cookie for CSRF protection, but browsers like Safari withhold the session cookie when they classify the request as cross-site. This happens when:

- The user navigates to the feedback link from a third-party app (Mail, Slack, etc.)
- Safari Intelligent Tracking Prevention (ITP) is active
- The browser sets `Sec-Fetch-Site: cross-site`

## Why the fix is safe

The feedback form already has its own security mechanism: a unique, unguessable secret token in the URL (e.g. `/feedback/QecUjt60K2J94mBc169Myw/submit`). The `FeedbackRequest` is looked up by this token. An attacker would need to know the token to submit the form, which is exactly the same bar as CSRF protection.

This is the standard "one-time secret link" pattern — the token itself is sufficient to prevent CSRF.

## Changes

- `skip_forgery_protection only: :submit` in `FeedbackController`
- New controller specs covering:
  - Showing the feedback form with valid/invalid tokens
  - Submitting feedback with valid data
  - Submitting feedback with invalid data (renders form with errors)
  - Submitting feedback without a session cookie / CSRF token (the regression test)

## Rollbar issue

https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/535#detail
