### PR TITLE
fix: only bind to Unix socket on Heroku with nginx buildpack

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,9 +31,9 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-# Use Unix socket when nginx config exists (from heroku-community/nginx buildpack)
-# Falls back to port if nginx config not present
-if File.exist?("config/nginx.conf.erb")
+# Use Unix socket when running on Heroku with nginx buildpack (ENV["DYNO"] is set by Heroku)
+# Falls back to port if not on Heroku or nginx config not present
+if ENV["DYNO"] && File.exist?("config/nginx.conf.erb")
   bind "unix:///tmp/nginx.socket?umask=0077"  # Restrict socket permissions to owner only
 
   # Signal to nginx buildpack that app is ready only after Puma has bound the socket.


### PR DESCRIPTION
## Problem

`config/puma.rb` was checking for the presence of `config/nginx.conf.erb` to decide whether to bind to a Unix socket or a TCP port. Since the nginx config file is committed to the repository, this check evaluated to **true in all environments** — including development — causing Puma to bind to `unix:///tmp/nginx.socket` instead of a TCP port.

This meant that running `bundle exec rails server` in development would listen on a Unix socket that is not accessible via a browser, breaking the local development workflow.

## Root cause

The condition was introduced in PR #2629 to support the `heroku-community/nginx` buildpack, which uses `bin/start-nginx` to launch nginx alongside Puma. The socket and `/tmp/app-initialized` signal are only meaningful when that buildpack orchestrates the boot. However, checking `File.exist?("config/nginx.conf.erb")` as a proxy for "running under nginx" is unreliable because the file exists in development, CI, and everywhere the repo is cloned.

## Fix

Add a check for `ENV["DYNO"]` before the socket binding. Heroku sets this variable on all dynos, making it a reliable signal that the nginx buildpack is actually in use.

```ruby
# Before
if File.exist?("config/nginx.conf.erb")

# After
if ENV["DYNO"] && File.exist?("config/nginx.conf.erb")
```

This preserves the nginx buildpack integration on Heroku while restoring the default TCP port binding in development and other non-Heroku environments.

## Verification

- [x] `bundle exec rails server` in development binds to `http://localhost:3000`
- [ ] Heroku deployment still works with the nginx buildpack