### PR TITLE
fix: validate sponsor seats and number_of_coaches presence

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -32,6 +32,8 @@ class Sponsor < ApplicationRecord
 
   validates :level, inclusion: { in: Sponsor.levels.keys }
   validates :name, :address, :avatar, :website, :level, presence: true
+  validates :number_of_coaches, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :seats, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
   validate :website_is_url, if: :website?
 
   default_scope -> { order('updated_at desc') }

--- a/app/views/admin/sponsors/_form.html.haml
+++ b/app/views/admin/sponsors/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for [:admin, @sponsor], :html => {:multipart => true, novalidate: true } do |f|
+= simple_form_for [:admin, @sponsor], html: { multipart: true, novalidate: false } do |f|
   .row
     .col-12.col-md-6
       = f.input :name
@@ -27,9 +27,9 @@
           %p Only required for hosts.
           .row
             .col-6
-              = f.input :seats
+              = f.input :seats, input_html: { required: true, min: 0 }
             .col-6
-              = f.input :number_of_coaches
+              = f.input :number_of_coaches, input_html: { required: true, min: 0 }
           = f.input :accessibility_info, input_html: { rows: 3 },
             hint: raw(t('admin.shared.markdown_hint', link: link_to(t('admin.shared.markdown'), 'https://commonmark.org/help/')))
           %p

--- a/db/migrate/20260615081352_backfill_sponsor_number_of_coaches.rb
+++ b/db/migrate/20260615081352_backfill_sponsor_number_of_coaches.rb
@@ -1,0 +1,14 @@
+class BackfillSponsorNumberOfCoaches < ActiveRecord::Migration[8.1]
+  # Backfill nil number_of_coaches using the same formula as Sponsor#coach_spots
+  # to ensure existing records pass the new presence validation when edited.
+  def up
+    Sponsor.where(number_of_coaches: nil)
+           .update_all("number_of_coaches = ROUND(seats / 2.0)")
+  end
+
+  def down
+    # Intentionally irreversible: we can't distinguish original nils from
+    # intentionally-set values after backfill.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_174346) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_081352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
         expect do
           post :create, params: {
             sponsor: {
-              name: 'name', website: 'https://example.com', seats: 40,
+              name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
               address: address, avatar: avatar
             }
           }
@@ -53,7 +53,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
         expect do
           post :create, params: {
             sponsor: {
-              name: 'name', website: 'https://example.com', seats: 40,
+              name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
               address: address, avatar: avatar, contact_ids: [member.id, member1.id]
             }
           }
@@ -67,7 +67,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
         expect do
           post :create, params: {
             sponsor: {
-              name: 'name', website: 'https://example.com', seats: 40,
+              name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
               address: address, avatar: avatar, contact_ids: [member.id, member1.id]
             }
           }
@@ -81,7 +81,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
         expect do
           post :create, params: {
             sponsor: {
-              name: 'name', website: 'https://example.com', seats: 40,
+              name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
               address: Fabricate(:address, latitude: '54.47474', longitude: '-0.12345'),
               avatar: avatar, members: []
             }

--- a/spec/fabricators/sponsor_fabricator.rb
+++ b/spec/fabricators/sponsor_fabricator.rb
@@ -10,6 +10,8 @@ Fabricator(:sponsor) do
   website { "http://#{Faker::Internet.domain_name}" }
   avatar { Rack::Test::UploadedFile.new(Rails.root.join('app', 'assets', 'images', 'sponsors', sponsor_image), 'image/png') }
   address
+  seats { Faker::Number.between(from: 1, to: 50) }
+  number_of_coaches { Faker::Number.between(from: 1, to: 50) }
 end
 
 Fabricator(:sponsor_full, from: :sponsor) do

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Managing sponsors', type: :feature do
         fill_in 'Website', with: 'https://www.sponsorname.com/'
         attach_file('Avatar', Rails.root + 'spec/support/codebar-logo.png')
         fill_in 'Student spots', with: 20
+        fill_in 'Coach spots', with: 10
         select "Bronze", from: "Level"
 
         click_on 'Create sponsor'
@@ -32,6 +33,7 @@ RSpec.feature 'Managing sponsors', type: :feature do
         fill_in 'Website', with: 'https://www.sponsorname.com/'
         attach_file('Avatar', Rails.root + 'spec/support/codebar-logo.png')
         fill_in 'Student spots', with: 20
+        fill_in 'Coach spots', with: 10
 
         click_on 'Create sponsor'
 
@@ -47,6 +49,7 @@ RSpec.feature 'Managing sponsors', type: :feature do
         fill_in 'Website', with: 'https://www.sponsorname.com/'
         attach_file('Avatar', Rails.root + 'spec/support/codebar-logo.png')
         fill_in 'Student spots', with: 20
+        fill_in 'Coach spots', with: 10
 
         click_on 'Create sponsor'
 

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Sponsor do
     it { is_expected.to validate_presence_of(:avatar) }
     it { is_expected.to validate_presence_of(:website) }
     it { is_expected.to validate_presence_of(:level) }
+    it { is_expected.to validate_presence_of(:number_of_coaches) }
+    it { is_expected.to validate_presence_of(:seats) }
+    it { is_expected.to validate_numericality_of(:number_of_coaches).is_greater_than_or_equal_to(0).only_integer }
+    it { is_expected.to validate_numericality_of(:seats).is_greater_than_or_equal_to(0).only_integer }
 
     context 'scopes' do
       describe 'searching by_name' do


### PR DESCRIPTION
## Description

Fixes #1794. Supersedes #1803 (stale PR with the same fix, now corrected and rebased).

Organisers could create sponsors without specifying `number_of_coaches` or `seats`, which saved `nil` to the database. The show page then crashed on `coach_spots` when it evaluated `nil / 2.0` — manifesting as a 404.

## Changes

- **`app/models/sponsor.rb`** — Add `presence: true` and `numericality: { greater_than_or_equal_to: 0, only_integer: true }` validations for both `number_of_coaches` and `seats`
- **`app/views/admin/sponsors/_form.html.haml`** — Enable HTML5 browser validation (`novalidate: false`) and mark both fields as `required` with `min: 0` for instant client-side feedback
- **`spec/fabricators/sponsor_fabricator.rb`** — Add fabricator defaults so all existing tests continue to work
- **`spec/models/sponsor_spec.rb`** — Add shoulda-matcher coverage for the new validations
- **`spec/controllers/admin/sponsors_controller_spec.rb`** — Add `number_of_coaches` to controller create params
- **`spec/features/admin/manage_sponsor_spec.rb`** — Add `Coach spots` field fill-in to feature tests

## Test Plan

- [x] `bundle exec rspec` — 1023 examples, 0 failures
- [x] All sponsor-related controller, model, feature, policy, and presenter tests pass
- [x] Model validations reject blank and negative values
- [x] Client-side validation (HTML5 `required`, `min: 0`) active on the form