### PR TITLE
fix: stabilise flaky TomSelect test helper

### DIFF
--- a/spec/support/select_from_tom_select.rb
+++ b/spec/support/select_from_tom_select.rb
@@ -7,11 +7,10 @@ module SelectFromTomSelect
   # @param item_text [String] The text to select
   # @param from [String, Symbol] The field ID (for documentation purposes)
   def select_from_tom_select(item_text, from: nil)
-    # Ensure TomSelect is initialized (workaround for pages where it doesn't auto-init)
-    ensure_tom_select_initialized('meeting_organisers')
-
-    # Wait for TomSelect to initialize - give extra time for page to fully load JS
-    expect(page).to have_css('.ts-wrapper', wait: 10)
+    # Wait for TomSelect to initialize - the real initialization runs via the
+    # jQuery DOMContentLoaded handler in application.js, which fires after the
+    # CDN script (loaded in the page head) defines the TomSelect global.
+    expect(page).to have_css('.ts-wrapper', wait: 15)
 
     # Open dropdown and type search query
     find('.ts-control').click
@@ -27,7 +26,8 @@ module SelectFromTomSelect
     input.send_keys(item_text[3..]) if item_text.length > 3
 
     # Wait for results (includes debounce + network)
-    expect(page).to have_css('.ts-dropdown .option', wait: 5)
+    # Uses a generous timeout for CI environments where AJAX may be slower
+    expect(page).to have_css('.ts-dropdown .option', wait: 10)
 
     # Click the matching option
     # Use JavaScript click to avoid element interception issues
@@ -38,53 +38,13 @@ module SelectFromTomSelect
   # Remove an item from a TomSelect multi-select
   # @param item_text [String] The text of the item to remove (must match exactly)
   def remove_from_tom_select(item_text)
-    # Ensure TomSelect is initialized (workaround for pages where it doesn't auto-init)
-    ensure_tom_select_initialized('meeting_organisers')
-
     # Wait for TomSelect to initialize and items to be present
-    expect(page).to have_css('.ts-wrapper', wait: 10)
+    expect(page).to have_css('.ts-wrapper', wait: 15)
     expect(page).to have_css('.ts-wrapper .item', text: item_text, wait: 5)
 
     within '.ts-wrapper' do
       find('.item', text: item_text, match: :prefer_exact).find('.remove').click
     end
-  end
-
-  private
-
-  def ensure_tom_select_initialized(element_id)
-    # Check if TomSelect is already initialized
-    return if page.has_css?('.ts-wrapper', wait: 2)
-
-    # Try to initialize TomSelect manually if the element exists
-    # Note: This is a minimal initialization for tests where TomSelect doesn't auto-init
-    script = <<~JS
-      (function() {
-        var elem = document.getElementById('#{element_id}');
-        if (elem && typeof TomSelect !== 'undefined' && !elem.tomselect) {
-          new TomSelect(elem, {
-            plugins: ['remove_button'],
-            placeholder: 'Type to search members...',
-            valueField: 'id',
-            labelField: 'full_name',
-            searchField: ['full_name', 'email'],
-            create: false,
-            loadThrottle: 300,
-            shouldLoad: function(query) { return query.length >= 3; },
-            load: function(query, callback) {
-              fetch('/admin/members/search?q=' + encodeURIComponent(query))
-                .then(response => response.json())
-                .then(json => callback(json))
-                .catch(() => callback());
-            }
-          });
-        }
-      })();
-    JS
-    page.execute_script(script)
-
-    # Wait for initialization
-    expect(page).to have_css('.ts-wrapper', wait: 5)
   end
 end
 


### PR DESCRIPTION
## Description

Fixes a flaky test in `Managing meeting invitations` that intermittently failed in CI with:

```
expected to find css ".ts-dropdown .option" but there were no matches
```

## Root cause

The `SelectFromTomSelect` test helper had two issues:

1. **`ensure_tom_select_initialized` hardcoded `meeting_organisers`** as the element ID to manually initialize. This helper is called from pages using `meeting_invitations_member` (meeting invitations) and `meeting_organisers` (meeting edit form). When called with the wrong ID, the manual init targeted a non-existent element, creating a race condition with the real init code.

2. **`wait: 5` for `.ts-dropdown .option`** was too short for CI environments where the TomSelect AJAX search (`/admin/members/search`) can take longer than 5 seconds to respond.

## Changes

- **Removed `ensure_tom_select_initialized`** — This was a fragile workaround that tried to manually re-initialize TomSelect if the real init hadn't run yet. The real init (jQuery handler in `application.js` running after CDN script loads) is reliable when given enough time. Manual init with a hardcoded element ID only made things worse.

- **Increased timeout for `.ts-dropdown .option`** from 5s to 10s — Gives CI more time for the AJAX search round-trip.

- **Increased `.ts-wrapper` wait** from 10s to 15s — Extra margin for the CDN script to load and TomSelect to initialize in slow CI environments.

- **Same cleanup applied to `remove_from_tom_select`** for consistency.

## Test Plan

- [x] `bundle exec rspec` — 1023 examples, 0 failures
- [x] `managing_meeting_invitations_spec.rb` passes 5/5 consecutive runs locally
- [x] `meeting_spec.rb` passes (also uses `select_from_tom_select`)
