### PR TITLE
Request: Add a comment field to sponsors

### DIFF
--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -70,7 +70,7 @@ class Admin::SponsorsController < Admin::ApplicationController
       :name, :avatar, :website, :seats, :accessibility_info,
       :number_of_coaches, :level, :description,
       address_attributes: [:id, :flat, :street, :postal_code, :city, :latitude, :longitude, :directions],
-      contacts_attributes: [:id, :name, :surname, :email, :mailing_list_consent, :_destroy]
+      contacts_attributes: [:id, :name, :surname, :email, :comment, :mailing_list_consent, :_destroy]
     )
   end
 

--- a/app/views/admin/sponsors/_contact_fields.html.haml
+++ b/app/views/admin/sponsors/_contact_fields.html.haml
@@ -5,4 +5,5 @@
     = f.input :name
     = f.input :surname
     = f.input :email
+    = f.input :comment, as: :text, input_html: { rows: 5 }, label: 'Contact comment'
     = f.input :mailing_list_consent, as: :boolean, hint_html: { class: 'd-block ms-1' }

--- a/app/views/admin/sponsors/show.html.haml
+++ b/app/views/admin/sponsors/show.html.haml
@@ -58,6 +58,9 @@
                 %li.mt-1
                   = mail_to(contact.email, contact.full_name)
                   %i.fas{ class: contact.mailing_list_subscription_class }
+                  - if contact.comment.present?
+                    %br
+                    %small.text-muted= contact.comment
 
     .col-12.col-lg-9
       %h2.h3.mb-3= t('.map_preview')

--- a/db/migrate/20260618152101_add_comment_to_contacts.rb
+++ b/db/migrate/20260618152101_add_comment_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddCommentToContacts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :contacts, :comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_081352) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_152101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -119,6 +119,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_081352) do
   end
 
   create_table "contacts", id: :serial, force: :cascade do |t|
+    t.text "comment"
     t.datetime "created_at", precision: nil
     t.string "email"
     t.boolean "mailing_list_consent", default: false

--- a/spec/fabricators/contact_fabricator.rb
+++ b/spec/fabricators/contact_fabricator.rb
@@ -4,5 +4,6 @@ Fabricator(:contact) do
   email { Faker::Internet.email }
   mailing_list_consent { true }
   token { 'random-token' }
+  comment { Faker::Lorem.sentence }
   sponsor
 end

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -100,12 +100,14 @@ RSpec.feature 'Managing sponsors', type: :feature do
           fill_in 'Name', with: 'Jane'
           fill_in 'Surname', with: 'Doe'
           fill_in 'Email', with: 'jane@codebar.io'
+          fill_in 'Contact comment', with: 'Main contact - Office manager'
         end
 
         click_on 'Save changes'
 
         within '#contacts' do
           expect(page).to have_content 'Jane Doe'
+          expect(page).to have_content 'Main contact - Office manager'
         end
       end
     end


### PR DESCRIPTION
Closes #2473

## Summary

Adds an optional "contact comment" text field to sponsor contacts, allowing chapter organisers to store notes like job titles, roles, or main contact flags.

<img width="654" height="714" alt="image" src="https://github.com/user-attachments/assets/70d301f6-9e93-4308-9b5b-0e83a4570d24" />

## Changes

- **Migration:** Adds `comment:text` column to `contacts` table (nullable, no default)
- **Controller:** Permits `:comment` in `contacts_attributes` for sponsor params
- **Form:** Textarea input (5 rows, labelled "Contact comment") in contact fields partial
- **Show page:** Displays comment below contact name when present
- **Fabricator:** Adds default `comment` to contact factory
- **Spec:** Extends contact feature spec to fill in and verify comment display
- **Design doc:** `docs/plans/2026-06-18-sponsor-contact-comment-design.md`

## Notes

- Admin-only field — not exposed on public pages
- HAML auto-escapes output (XSS-safe)
- No validations — fully optional free-text