### PR TITLE
fix: remove invalid semver key from dependabot cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
   open-pull-requests-limit: 10
   cooldown:
     default-days: 7
-    semver:
-      major: 14
-      minor: 7
-      patch: 3
   groups:
     ruby-deps:
       update-types:


### PR DESCRIPTION
Dependabot schema only allows `default-days` under `cooldown`. The `semver` sub-properties are rejected by Dependabot validator, causing all PRs to fail the dependabot check.