### PR TITLE
Update volunteer section on codebar website

### DIFF
--- a/app/views/pages/volunteer.html.haml
+++ b/app/views/pages/volunteer.html.haml
@@ -52,4 +52,5 @@
         %p.lead.text-center.mb-5
           = t('pages.how_to_support_us.volunteer.volunteer.description')
         .text-center
-          = mail_to 'hello@codebar.io', t('pages.how_to_support_us.volunteer.volunteer.link'), subject: "I'd like to volunteer with codebar", class: 'btn btn-primary btn-lg text-decoration-none'
+          = link_to "https://docs.google.com/document/d/1mA8_XL6zjGK2omyvSIwpl2Wyvdnd3519itd1tY94Y5w/edit?usp=sharing", class: 'btn btn-primary btn-lg text-decoration-none' do
+            = t('pages.how_to_support_us.volunteer.volunteer.link')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -526,8 +526,8 @@ de:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -643,8 +643,8 @@ en:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/en_AU.yml
+++ b/config/locales/en_AU.yml
@@ -483,8 +483,8 @@ en-AU:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -482,7 +482,7 @@ en-GB:
           title: Become a coach
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
-          title: Other skills
+          title: Otfffher skills
           description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
           link: Email us to become a volunteer
       fundraise:

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -481,8 +481,8 @@ en-US:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -550,8 +550,8 @@ es:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward. 
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -484,8 +484,8 @@ fi:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -484,8 +484,8 @@ fr:
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -484,8 +484,8 @@
           description: Affect change as a volunteer coach with codebar - your expertise and guidance will pave the way for aspiring developers, unlocking the world of coding and creating opportunities for folks from groups under represented in the tech industry.
         volunteer:
           title: Other skills
-          description: Your unique abilities could be our missing piece in the codebar puzzle. Having a diverse range of skills in our team is necessary to enrich our community. From fundraising to event coordination to marketing, we always welcome new talent to drive our mission forward.
-          link: Email us to become a volunteer
+          description: Your skills could be the missing piece in the codebar puzzle. Having a diverse range of skills, and extra help, in our team is necessary to enrich our community. From fundraising and event coordination to marketing, we always welcome extra help to support our community members.
+          link: Take a look at our Volunteer Opportunities here
       fundraise:
         title: Fundraise
         description_html: "Join the codebar team with a physical challenge event. Whether you are a runner, swimmer, or cyclist, sign up with our registration form for your desired event and raise vital funds to help keep our events running. If your event does not appear below, feel free to <a href='mailto:%{email}'>drop us an email</a> and we would be happy to coordinate with you."


### PR DESCRIPTION
We're slightly amending how we announce **Volunteer Opportunities** at codebar. I have created a read only Google Doc that has a list of specific tasks people can help us with.

My thought with an external doc is that we can easily add/remove opportunites as they arise without needing to update and deploy the website