### PR TITLE
Remove mailer callbacks from FeedbackRequest, AttendanceWarning, EligibilityInquiry

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -48,6 +48,7 @@ class Admin::MembersController < Admin::ApplicationController
 
   def send_eligibility_email
     @member.eligibility_inquiries.create!(issued_by: current_user)
+    MemberMailer.eligibility_check(@member, @member.email).deliver_now
 
     redirect_to [:admin, @member], notice: t('.success')
   end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -54,6 +54,7 @@ class Admin::MembersController < Admin::ApplicationController
 
   def send_attendance_email
     @member.attendance_warnings.create!(issued_by: current_user)
+    MemberMailer.attendance_warning(@member, @member.email).deliver_now
 
     redirect_to [:admin, @member], notice: t('.success')
   end

--- a/app/models/attendance_warning.rb
+++ b/app/models/attendance_warning.rb
@@ -3,12 +3,4 @@ class AttendanceWarning < ApplicationRecord
   belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id', inverse_of: false, optional: true
 
   scope :last_six_months, -> { where(created_at: 6.months.ago...Time.zone.now) }
-
-  before_save :send_email
-
-  private
-
-  def send_email
-    MemberMailer.attendance_warning(member, member.email).deliver_now
-  end
 end

--- a/app/models/eligibility_inquiry.rb
+++ b/app/models/eligibility_inquiry.rb
@@ -1,12 +1,4 @@
 class EligibilityInquiry < ApplicationRecord
   belongs_to :member
   belongs_to :issued_by, class_name: 'Member', foreign_key: 'sent_by_id', inverse_of: false
-
-  before_save :send_email
-
-  private
-
-  def send_email
-    MemberMailer.eligibility_check(member, member.email).deliver_now
-  end
 end

--- a/app/models/feedback_request.rb
+++ b/app/models/feedback_request.rb
@@ -8,7 +8,6 @@ class FeedbackRequest < ApplicationRecord
   validates :submited, inclusion: { in: [true, false] }
 
   before_validation :set_token
-  after_create :email
 
   private
 
@@ -19,7 +18,4 @@ class FeedbackRequest < ApplicationRecord
     end
   end
 
-  def email
-    FeedbackRequestMailer.request_feedback(workshop, member, self).deliver_now
-  end
 end

--- a/lib/tasks/feedback.rake
+++ b/lib/tasks/feedback.rake
@@ -4,8 +4,9 @@ namespace :feedback do
     workshops = Workshop.completed_since_yesterday
     Rails.logger.info 'Sending Feedback request emails' if workshops.any?
     workshops.each do |workshop|
-      WorkshopInvitation.accepted.where(workshop: workshop, role: 'Student').map do |invitation|
-        FeedbackRequest.create(member: invitation.member, workshop: workshop, submited: false)
+      WorkshopInvitation.accepted.where(workshop: workshop, role: 'Student').each do |invitation|
+        feedback_request = FeedbackRequest.create(member: invitation.member, workshop: workshop, submited: false)
+        FeedbackRequestMailer.request_feedback(workshop, invitation.member, feedback_request).deliver_now
       end
       Rails.logger.info "Feedback requests sent for #{workshop.chapter.name}'s #{workshop}: \
                          #{FeedbackRequest.where(workshop: workshop).count}"

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -67,4 +67,45 @@ RSpec.describe Admin::MembersController, type: :controller do
       end
     end
   end
+
+  describe 'GET #send_attendance_email' do
+    let(:member) { Fabricate(:member) }
+    let(:admin) { Fabricate(:member) }
+
+    before do
+      admin.add_role(:admin)
+      login_as_admin(admin)
+    end
+
+    it 'creates an attendance warning' do
+      expect {
+        get :send_attendance_email, params: { member_id: member.id }
+      }.to change(AttendanceWarning, :count).by(1)
+    end
+
+    it 'sends an attendance warning email' do
+      mailer = double(deliver_now: true)
+      expect(MemberMailer).to receive(:attendance_warning)
+        .with(member, member.email)
+        .and_return(mailer)
+
+      get :send_attendance_email, params: { member_id: member.id }
+    end
+
+    it 'redirects to the member page' do
+      get :send_attendance_email, params: { member_id: member.id }
+
+      expect(response).to redirect_to([:admin, member])
+    end
+
+    context 'when not authenticated' do
+      before { login(Fabricate(:member)) }
+
+      it 'redirects to login' do
+        get :send_attendance_email, params: { member_id: member.id }
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -108,4 +108,45 @@ RSpec.describe Admin::MembersController, type: :controller do
       end
     end
   end
+
+  describe 'GET #send_eligibility_email' do
+    let(:member) { Fabricate(:member) }
+    let(:admin) { Fabricate(:member) }
+
+    before do
+      admin.add_role(:admin)
+      login_as_admin(admin)
+    end
+
+    it 'creates an eligibility inquiry' do
+      expect {
+        get :send_eligibility_email, params: { member_id: member.id }
+      }.to change(EligibilityInquiry, :count).by(1)
+    end
+
+    it 'sends an eligibility check email' do
+      mailer = double(deliver_now: true)
+      expect(MemberMailer).to receive(:eligibility_check)
+        .with(member, member.email)
+        .and_return(mailer)
+
+      get :send_eligibility_email, params: { member_id: member.id }
+    end
+
+    it 'redirects to the member page' do
+      get :send_eligibility_email, params: { member_id: member.id }
+
+      expect(response).to redirect_to([:admin, member])
+    end
+
+    context 'when not authenticated' do
+      before { login(Fabricate(:member)) }
+
+      it 'redirects to login' do
+        get :send_eligibility_email, params: { member_id: member.id }
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
 end

--- a/spec/lib/tasks/feedback_rake_spec.rb
+++ b/spec/lib/tasks/feedback_rake_spec.rb
@@ -11,16 +11,20 @@ RSpec.describe 'rake feedback:request', type: :task do
       end
     end
 
-    it 'generates a FeedbackRequest' do
+    it 'generates a FeedbackRequest and sends the feedback email' do
       travel_to(Time.current) do
         workshop = Fabricate(:workshop, date_and_time: 23.hours.ago)
         student = Fabricate(:member)
         Fabricate(:attending_workshop_invitation, role: 'Student', member: student, workshop: workshop)
 
         expect(Workshop).to receive(:completed_since_yesterday).and_return([workshop])
-        expect(FeedbackRequest).to receive(:create).with(member: student, workshop: workshop, submited: false)
 
-        task.execute
+        mailer = double(deliver_now: true)
+        expect(FeedbackRequestMailer).to receive(:request_feedback)
+          .with(workshop, student, an_instance_of(FeedbackRequest))
+          .and_return(mailer)
+
+        expect { task.execute }.to change(FeedbackRequest, :count).by(1)
       end
     end
 

--- a/spec/models/attendance_warning_spec.rb
+++ b/spec/models/attendance_warning_spec.rb
@@ -9,13 +9,6 @@ RSpec.describe AttendanceWarning do
       expect(attendance_warning.issued_by).to eq(admin)
     end
 
-    it 'sends an attendance warning email' do
-      described_class.create(member: member, issued_by: admin)
-
-      email = ActionMailer::Base.deliveries.find { |e| e.to.include?(member.email) && e.subject.include?('Attendance') }
-      expect(email).not_to be_nil
-    end
-
     describe '.scopes' do
       describe 'last_six_months' do
         it 'returns all attendance warnings issues in the last six months' do

--- a/spec/models/eligibility_inquiry_spec.rb
+++ b/spec/models/eligibility_inquiry_spec.rb
@@ -9,14 +9,5 @@ RSpec.describe EligibilityInquiry do
       expect(eligibility_inquiry.issued_by).to eq(admin)
     end
 
-    it 'sends an eligibility check email' do
-      expect {
-        described_class.create(member: member, issued_by: admin)
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
-
-      email = ActionMailer::Base.deliveries.last
-      expect(email.to).to include(member.email)
-      expect(email.subject).to include('Eligibility')
-    end
   end
 end

--- a/spec/models/feedback_request_spec.rb
+++ b/spec/models/feedback_request_spec.rb
@@ -24,14 +24,4 @@ RSpec.describe FeedbackRequest do
     end
   end
 
-  context 'after create hook' do
-    it 'sends request feedback email' do
-      expect {
-        Fabricate(:feedback_request)
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
-
-      email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to include('Feedback')
-    end
-  end
 end


### PR DESCRIPTION
I'm trying to tidy up the internals in the codebase to make it easier to reason about, following layered Rails architecture principles, with my limited understanding.

## Problem

Three models had callbacks that dispatched mailers synchronously on every record creation. This is a layer violation — domain models should not trigger infrastructure side-effects.

| Model | Callback | Mailer |
|-------|----------|--------|
| `FeedbackRequest` | `after_create :email` | `FeedbackRequestMailer.request_feedback` |
| `AttendanceWarning` | `before_save :send_email` | `MemberMailer.attendance_warning` |
| `EligibilityInquiry` | `before_save :send_email` | `MemberMailer.eligibility_check` |

This meant surprise emails from the console, no escape hatch to skip them, and test pollution from fabricators.

## Solution

Move each mailer dispatch from the model callback to the caller. The model creates the record; the caller decides what happens next.

- `FeedbackRequest` — mailer inline in `lib/tasks/feedback.rake`
- `AttendanceWarning` — mailer inline in `Admin::MembersController#send_attendance_email`
- `EligibilityInquiry` — mailer inline in `Admin::MembersController#send_eligibility_email`

## Changes

| Commit | Files | Δ |
|--------|-------|---|
| `34f01374` Move mailer dispatch from FeedbackRequest callback to rake task caller | 4 | +10 −19 |
| `83d295b6` Remove AttendanceWarning before_save callback, dispatch mailer from controller | 4 | +42 −15 |
| `a7ee0b83` Remove EligibilityInquiry before_save callback, dispatch mailer from controller | 4 | +42 −17 |

## Testing

`bundle exec rake spec` — 1046 examples, 0 failures.