### PR TITLE
refactor: extract contact mailing list callbacks to service

### DIFF
--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -30,6 +30,7 @@ class Admin::SponsorsController < Admin::ApplicationController
     authorize @sponsor
 
     if @sponsor.valid? && @sponsor.save
+      @sponsor.contacts.each { |c| ContactMailingListService.sync(c) }
       return redirect_to [:admin, @sponsor], notice: "Sponsor #{@sponsor.name} created"
     end
 
@@ -49,6 +50,7 @@ class Admin::SponsorsController < Admin::ApplicationController
 
     if @sponsor.valid? && @sponsor.save
       @sponsor.contacts.each do |contact|
+        ContactMailingListService.sync(contact)
         audit_contact_subscription(contact)
       end
 

--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -30,7 +30,7 @@ class Admin::SponsorsController < Admin::ApplicationController
     authorize @sponsor
 
     if @sponsor.valid? && @sponsor.save
-      @sponsor.contacts.each { |c| ContactMailingListService.sync(c) }
+      @sponsor.contacts.each { ContactMailingListService.sync(it) }
       return redirect_to [:admin, @sponsor], notice: "Sponsor #{@sponsor.name} created"
     end
 

--- a/app/controllers/contact_preferences_controller.rb
+++ b/app/controllers/contact_preferences_controller.rb
@@ -10,6 +10,7 @@ class ContactPreferencesController < ApplicationController
   def update
     contact = Contact.find_by!(token: contact_preferences[:token])
     contact.update(mailing_list_consent: mailing_list_consent)
+    ContactMailingListService.sync(contact)
     audit_contact_subscription(contact)
 
     redirect_to contact_preferences_path(token: contact_preferences[:token],

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,25 +1,9 @@
-require 'services/mailing_list'
 class Contact < ApplicationRecord
   belongs_to :sponsor, optional: true
 
   validates :name, :surname, :email, presence: true
 
   before_create :set_token
-  after_commit :unsubscribe_from_mailing_list, if: proc { |c| !c.mailing_list_consent }
-  after_commit :subscribe_to_mailing_list, if: proc { |c| c.mailing_list_consent }
-
-  def subscribe_to_mailing_list
-    mailing_list.subscribe(email, name, surname)
-    ContactMailer.subscription_notification(self).deliver
-  end
-
-  def unsubscribe_from_mailing_list
-    mailing_list.unsubscribe(email)
-  end
-
-  def mailing_list
-    @mailing_list ||= Services::MailingList.new(ENV['SPONSOR_NEWSLETTER_ID'])
-  end
 
   private
 

--- a/app/services/contact_mailing_list_service.rb
+++ b/app/services/contact_mailing_list_service.rb
@@ -1,0 +1,28 @@
+class ContactMailingListService
+  def self.sync(contact)
+    new.sync(contact)
+  end
+
+  def sync(contact)
+    if contact.mailing_list_consent
+      subscribe(contact)
+    else
+      unsubscribe(contact)
+    end
+  end
+
+  private
+
+  def subscribe(contact)
+    mailing_list.subscribe(contact.email, contact.name, contact.surname)
+    ContactMailer.subscription_notification(contact).deliver_now
+  end
+
+  def unsubscribe(contact)
+    mailing_list.unsubscribe(contact.email)
+  end
+
+  def mailing_list
+    @mailing_list ||= Services::MailingList.new(ENV['SPONSOR_NEWSLETTER_ID'])
+  end
+end

--- a/app/services/contact_mailing_list_service.rb
+++ b/app/services/contact_mailing_list_service.rb
@@ -4,10 +4,9 @@ class ContactMailingListService
   end
 
   def sync(contact)
-    if contact.mailing_list_consent
-      subscribe(contact)
-    else
-      unsubscribe(contact)
+    case contact.mailing_list_consent
+    when true then subscribe(contact)
+    when false then unsubscribe(contact)
     end
   end
 

--- a/spec/services/contact_mailing_list_service_spec.rb
+++ b/spec/services/contact_mailing_list_service_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ContactMailingListService do
+  subject(:service) { described_class.new }
+
+  let(:contact) { Fabricate.build(:contact, mailing_list_consent: consent) }
+  let(:mailing_list) { instance_spy(Services::MailingList) }
+
+  before do
+    allow(Services::MailingList).to receive(:new).and_return(mailing_list)
+    allow(ContactMailer).to receive_message_chain(:subscription_notification, :deliver_now)
+  end
+
+  describe '#sync' do
+    context 'when consent is true' do
+      let(:consent) { true }
+
+      it 'subscribes to mailing list and sends notification' do
+        service.sync(contact)
+
+        expect(mailing_list).to have_received(:subscribe).with(contact.email, contact.name, contact.surname)
+        expect(ContactMailer).to have_received(:subscription_notification).with(contact)
+      end
+    end
+
+    context 'when consent is false' do
+      let(:consent) { false }
+
+      it 'unsubscribes from mailing list' do
+        service.sync(contact)
+
+        expect(mailing_list).to have_received(:unsubscribe).with(contact.email)
+        expect(ContactMailer).not_to have_received(:subscription_notification)
+      end
+    end
+  end
+end

--- a/spec/services/contact_mailing_list_service_spec.rb
+++ b/spec/services/contact_mailing_list_service_spec.rb
@@ -33,5 +33,17 @@ RSpec.describe ContactMailingListService do
         expect(ContactMailer).not_to have_received(:subscription_notification)
       end
     end
+
+    context 'when consent is nil' do
+      let(:consent) { nil }
+
+      it 'does nothing' do
+        service.sync(contact)
+
+        expect(mailing_list).not_to have_received(:subscribe)
+        expect(mailing_list).not_to have_received(:unsubscribe)
+        expect(ContactMailer).not_to have_received(:subscription_notification)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation

`Contact` model had two `after_commit` callbacks that called `Services::MailingList` (Flodesk API) and `ContactMailer` directly — infrastructure concerns embedded in the domain layer via operation callbacks (score 1/5).

This is a **layer violation** per *Layered Design for Ruby on Rails Applications* (Vladimir Dementyev, 2024):

- Domain layer (`app/models/`) should not call mailers or external API services via callbacks
- Application layer (`app/services/`) is the correct home for orchestration
- Operation callbacks should be explicit, not implicit side effects of save

The [layered-rails skill](https://github.com/palkan/skills) from the [palkan-skills](https://github.com/palkan/skills) registry flagged this during an architecture analysis.

## Changes

- **Create** `app/services/contact_mailing_list_service.rb` — orchestrates Flodesk subscribe/unsubscribe + email notification
- **Remove** both `after_commit` callbacks and `#subscribe_to_mailing_list`, `#unsubscribe_from_mailing_list`, `#mailing_list` methods from `Contact` model
- **Keep** `before_create :set_token` (transformer callback, score 5/5)
- **Update** `Admin::SponsorsController#create` and `#update` — call `ContactMailingListService.sync(contact)` explicitly after save
- **Update** `ContactPreferencesController#update` — same explicit call

### Edge case fix (separate commit)

`nil` `mailing_list_consent` previously mapped to unsubscribe (same as `false`). Changed to a no-op using explicit `case` — only `true` subscribes, only `false` unsubscribes.

## Testing

1045 examples, 0 failures (3 new service specs covering true/false/nil paths).
