### PR TITLE
refactor: extract subscription mailing list callbacks to service

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -39,6 +39,7 @@ class Admin::MembersController < Admin::ApplicationController
 
   def update_subscriptions
     subscription = @member.subscriptions.find_by(group_id: params[:group])
+    SubscriptionMailingListService.unsubscribe(subscription)
     flash[:notice] = t('.unsubscribe', member: @member.full_name,
                                        chapter: subscription.group.chapter.city,
                                        group: subscription.group.name)

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -38,7 +38,7 @@ class Admin::MembersController < Admin::ApplicationController
   end
 
   def update_subscriptions
-    subscription = @member.subscriptions.find_by(group_id: params[:group])
+    subscription = @member.subscriptions.find_by!(group_id: params[:group])
     SubscriptionMailingListService.unsubscribe(subscription)
     flash[:notice] = t('.unsubscribe', member: @member.full_name,
                                        chapter: subscription.group.chapter.city,

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -8,15 +8,15 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
-    @subscription = Subscription.new(group_id: group_id, member: current_user)
+    subscription = Subscription.new(group_id: group_id, member: current_user)
 
-    if @subscription.save
-      SubscriptionMailingListService.subscribe(@subscription)
-      send_welcome_email(current_user, @subscription)
-      flash[:notice] = I18n.t('subscriptions.messages.group.subscribe', chapter: @subscription.group.chapter.city,
-                                                                        role: @subscription.group.name)
+    if subscription.save
+      SubscriptionMailingListService.subscribe(subscription)
+      send_welcome_email(current_user, subscription)
+      flash[:notice] = I18n.t('subscriptions.messages.group.subscribe', chapter: subscription.group.chapter.city,
+                                                                        role: subscription.group.name)
     else
-      flash[:notice] = @subscription.errors.inspect
+      flash[:notice] = subscription.errors.inspect
     end
     redirect_back fallback_location: root_path
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -11,6 +11,7 @@ class SubscriptionsController < ApplicationController
     @subscription = Subscription.new(group_id: group_id, member: current_user)
 
     if @subscription.save
+      SubscriptionMailingListService.subscribe(@subscription)
       send_welcome_email(current_user, @subscription)
       flash[:notice] = I18n.t('subscriptions.messages.group.subscribe', chapter: @subscription.group.chapter.city,
                                                                         role: @subscription.group.name)
@@ -23,6 +24,7 @@ class SubscriptionsController < ApplicationController
   def destroy
     # Don't error if subscription is not found
     subscription = current_user.subscriptions.find_by(group_id: group_id)
+    SubscriptionMailingListService.unsubscribe(subscription) if subscription
     subscription&.destroy
 
     # Instead, rely on the group's existence (rather than the subscription)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,3 @@
-require 'services/mailing_list'
-
 class Subscription < ApplicationRecord
   belongs_to :group
   belongs_to :member
@@ -8,24 +6,11 @@ class Subscription < ApplicationRecord
   validates :group, uniqueness: { scope: :member_id }
   scope :ordered, -> { order(created_at: :desc) }
 
-  after_create :subscribe_to_mailing_list
-  after_destroy :unsubscribe_from_mailing_list
-
   def student?
     group.name.casecmp('students').zero?
   end
 
   def coach?
     group.name.casecmp('coaches').zero?
-  end
-
-  private
-
-  def subscribe_to_mailing_list
-    Services::MailingList.new(group.mailing_list_id).subscribe(member.email, member.name, member.surname)
-  end
-
-  def unsubscribe_from_mailing_list
-    Services::MailingList.new(group.mailing_list_id).unsubscribe(member.email)
   end
 end

--- a/app/services/subscription_mailing_list_service.rb
+++ b/app/services/subscription_mailing_list_service.rb
@@ -1,0 +1,26 @@
+class SubscriptionMailingListService
+  def self.subscribe(subscription)
+    new.subscribe(subscription)
+  end
+
+  def self.unsubscribe(subscription)
+    new.unsubscribe(subscription)
+  end
+
+  def subscribe(subscription)
+    list = mailing_list(subscription.group.mailing_list_id)
+    list.subscribe(subscription.member.email, subscription.member.name, subscription.member.surname)
+  end
+
+  def unsubscribe(subscription)
+    list = mailing_list(subscription.group.mailing_list_id)
+    list.unsubscribe(subscription.member.email)
+  end
+
+  private
+
+  def mailing_list(list_id)
+    @mailing_lists ||= {}
+    @mailing_lists[list_id] ||= Services::MailingList.new(list_id)
+  end
+end

--- a/spec/services/subscription_mailing_list_service_spec.rb
+++ b/spec/services/subscription_mailing_list_service_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe SubscriptionMailingListService do
+  subject(:service) { described_class.new }
+
+  let(:subscription) { Fabricate.build(:subscription) }
+  let(:mailing_list) { instance_spy(Services::MailingList) }
+
+  before do
+    allow(Services::MailingList).to receive(:new).and_return(mailing_list)
+  end
+
+  describe '#subscribe' do
+    it 'subscribes the member to the group mailing list' do
+      service.subscribe(subscription)
+
+      expect(Services::MailingList).to have_received(:new)
+        .with(subscription.group.mailing_list_id)
+      expect(mailing_list).to have_received(:subscribe)
+        .with(subscription.member.email, subscription.member.name, subscription.member.surname)
+    end
+  end
+
+  describe '#unsubscribe' do
+    it 'unsubscribes the member from the group mailing list' do
+      service.unsubscribe(subscription)
+
+      expect(Services::MailingList).to have_received(:new)
+        .with(subscription.group.mailing_list_id)
+      expect(mailing_list).to have_received(:unsubscribe)
+        .with(subscription.member.email)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

`Subscription` model had `after_create` and `after_destroy` callbacks calling `Services::MailingList` (Flodesk API) directly — infrastructure concerns embedded in the domain layer via operation callbacks (score 1/5). This is the same pattern fixed in #2663 for `Contact`.

This is a **layer violation** per *Layered Design for Ruby on Rails Applications* (Vladimir Dementyev, 2024):

- Domain layer (`app/models/`) should not call external API services via callbacks
- Application layer (`app/services/`) is the correct home for orchestration
- Operation callbacks should be explicit, not implicit side effects of save/destroy

The [layered-rails skill](https://github.com/palkan/skills) from the [palkan-skills](https://github.com/palkan/skills) registry flagged this during an architecture analysis.

## Changes

- **Create** `app/services/subscription_mailing_list_service.rb` — `subscribe` and `unsubscribe` class methods delegating to `Services::MailingList`
- **Remove** `require 'services/mailing_list'`, `after_create`, `after_destroy`, and both private callback methods from `Subscription` model
- **Update** `SubscriptionsController#create` — call `SubscriptionMailingListService.subscribe` after save
- **Update** `SubscriptionsController#destroy` — call `SubscriptionMailingListService.unsubscribe` before destroy
- **Update** `Admin::MembersController#update_subscriptions` — call `SubscriptionMailingListService.unsubscribe` before destroy

## Testing

1044 examples, 0 failures. New service unit test covers both subscribe and unsubscribe paths. Existing feature specs cover all controller paths.
