### PR TITLE
Fix N+1 queries detected by Bullet

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -73,13 +73,13 @@ class EventsController < ApplicationController
 
   def fetch_upcoming_events
     events = [
-      Workshop.includes(:chapter, :sponsors, :host, :permissions)
+      Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
               .upcoming
               .joins(:chapter)
               .merge(Chapter.active)
     ]
-    events << Meeting.upcoming.includes(:venue, :permissions).all
-    events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions).all
+    events << Meeting.upcoming.includes(:venue, :organisers).all
+    events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers).all
 
     sorted = events.compact.flatten.sort_by(&:date_and_time)
     return [{}, nil] if sorted.empty?
@@ -95,13 +95,13 @@ class EventsController < ApplicationController
 
   def fetch_past_events
     events = [
-      Workshop.includes(:chapter, :sponsors, :host, :permissions)
+      Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
               .past
               .joins(:chapter)
               .merge(Chapter.active)
     ]
-    events << Meeting.past.includes(:venue, :permissions).all
-    events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions).all
+    events << Meeting.past.includes(:venue, :organisers).all
+    events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers).all
 
     sorted = events.compact.flatten.sort_by(&:date_and_time).reverse
     return [{}, nil] if sorted.empty?


### PR DESCRIPTION
## What

Fixes N+1 queries caught by the Bullet gem during development.

### Changes

- Eager load `organisers` on Workshop and Event queries in the events controller (both upcoming and past views)
- Eager load `organisers` on Meeting queries (was causing N+1, same as Workshop and Event)
- Drop `:permissions` on Meeting queries -- genuinely unused in this view; `includes(:permissions)` adds a preload query without reducing the `organisers` queries (they fire their own SQL join regardless)
- Keep `:venue` on Meeting queries -- all 51 meetings have `venue_id` set in production, and `event.venue` is accessed in `_event.html.haml` line 18-20

### Verification

- [ ] /events/upcoming loads without Bullet::Notification::UnoptimizedQueryError
- [ ] /events/past loads without Bullet::Notification::UnoptimizedQueryError