### PR TITLE
perf: paginate combined events with DB-level UNION ALL instead of in-memory sort

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -72,46 +72,104 @@ class EventsController < ApplicationController
   end
 
   def fetch_upcoming_events
-    events = [
-      Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
-              .upcoming
-              .joins(:chapter)
-              .merge(Chapter.active)
-    ]
-    events << Meeting.upcoming.all
-    events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers).all
+    result = paginated_events(upcoming: true)
+    return [{}, nil] if result.nil?
 
-    sorted = events.compact.flatten.sort_by(&:date_and_time)
-    return [{}, nil] if sorted.empty?
-
-    pagy, paginated = pagy(sorted, items: 20)
-    paginated ||= []
-
-    grouped = paginated.group_by(&:date)
+    rows, pagy = result
+    events = load_events(rows)
+    grouped = events.group_by(&:date)
     decorated = grouped.transform_values { |items| EventPresenter.decorate_collection(items) }
 
     [decorated, pagy]
   end
 
   def fetch_past_events
-    events = [
-      Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
-              .past
-              .joins(:chapter)
-              .merge(Chapter.active)
-    ]
-    events << Meeting.past.all
-    events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers).all
+    result = paginated_events(upcoming: false)
+    return [{}, nil] if result.nil?
 
-    sorted = events.compact.flatten.sort_by(&:date_and_time).reverse
-    return [{}, nil] if sorted.empty?
-
-    pagy, paginated = pagy(sorted, items: 20)
-    paginated ||= []
-
-    grouped = paginated.group_by(&:date)
+    rows, pagy = result
+    events = load_events(rows)
+    grouped = events.group_by(&:date)
     decorated = grouped.transform_values { |items| EventPresenter.decorate_collection(items) }
 
     [decorated, pagy]
+  end
+
+  # Builds a UNION ALL query across Workshops, Meetings, and Events,
+  # paginates at the database level, and returns (id, event_type) pairs
+  # for the current page. Only the 20 visible rows come back from the DB.
+  def paginated_events(upcoming:)
+    now = Time.zone.now
+    page = (params[:page] || 1).to_i
+    direction = upcoming ? "ASC" : "DESC"
+    comparator = upcoming ? :gteq : :lt
+
+    # Pure Arel subqueries — no ActiveRecord relation bind params to leak
+    w = Arel::Table.new(:workshops)
+    ch = Arel::Table.new(:chapters)
+    ws = Arel::SelectManager.new(w)
+    ws.project(w[:id], w[:date_and_time], Arel.sql("'Workshop' AS event_type"))
+    ws.join(ch).on(w[:chapter_id].eq(ch[:id]))
+    ws.where(ch[:active].eq(true).and(w[:date_and_time].public_send(comparator, now)))
+
+    m = Arel::Table.new(:meetings)
+    ms = Arel::SelectManager.new(m)
+    ms.project(m[:id], m[:date_and_time], Arel.sql("'Meeting' AS event_type"))
+    ms.where(m[:date_and_time].public_send(comparator, now))
+
+    e = Arel::Table.new(:events)
+    es = Arel::SelectManager.new(e)
+    es.project(e[:id], e[:date_and_time], Arel.sql("'Event' AS event_type"))
+    es.where(e[:date_and_time].public_send(comparator, now))
+
+    union = Arel::Nodes::UnionAll.new(
+      Arel::Nodes::UnionAll.new(ws, ms), es
+    )
+
+    # COUNT at DB level — single query
+    count_query = Arel::SelectManager.new
+    count_query.from(union.as("events"))
+    count_query.project(Arel.star.count)
+    total = ActiveRecord::Base.connection.select_value(count_query.to_sql).to_i
+    return nil if total.zero?
+
+    pagy_opts = { count: total, page: page, limit: 20, request: request }
+    pagy_opts[:request] = Pagy::Request.new(pagy_opts)
+    pagy = Pagy::Offset.new(**pagy_opts)
+
+    # Only 20 rows leave the database
+    pagination_query = Arel::SelectManager.new
+    pagination_query.from(union.as("events"))
+    pagination_query.project(:id, :event_type)
+    pagination_query.order(Arel.sql("date_and_time #{direction}"))
+    pagination_query.skip(pagy.offset).take(pagy.limit)
+
+    rows = ActiveRecord::Base.connection.select_all(pagination_query.to_sql)
+    [rows, pagy]
+  end
+
+  # Loads full ActiveRecord objects for the paginated (id, event_type) pairs
+  # with eager loading, preserving the UNION order.
+  def load_events(rows)
+    grouped = rows.each_with_object({}) do |row, hash|
+      (hash[row["event_type"]] ||= []) << row["id"].to_i
+    end
+
+    workshops = Workshop.includes(:chapter, :sponsors, :permissions, :organisers, :workshop_host)
+                        .where(id: grouped["Workshop"])
+                        .to_a.index_by(&:id)
+    meetings = Meeting.where(id: grouped["Meeting"])
+                      .to_a.index_by(&:id)
+    events = Event.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers)
+                  .where(id: grouped["Event"])
+                  .to_a.index_by(&:id)
+
+    rows.filter_map do |row|
+      case row["event_type"]
+      when "Workshop" then workshops[row["id"].to_i]
+      when "Meeting" then meetings[row["id"].to_i]
+      when "Event" then events[row["id"].to_i]
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Past events page loads ALL workshops (~1100), meetings, and events into ActiveRecord objects, then sorts and paginates to 20 in Ruby via `#sort_by(&:date_and_time).reverse` + `pagy(sorted, items: 20)`. The remaining ~1080 rows are instantiated and immediately discarded.

Same pattern exists for upcoming events, though less impactful at lower volumes.

This cost grows linearly with total records regardless of page size.

## Solution

Replace the in-memory merge with a `UNION ALL` at the database level:

1. `paginated_events(upcoming:)` — builds three Arel subqueries (workshops x chapters.active, meetings, events), combines them with UNION ALL, runs a COUNT(*) for Pagy, then fetches only 20 (id, event_type) rows via LIMIT/OFFSET.
2. `load_events(rows)` — dispatches the 20 IDs to their respective model queries with full eager loading (includes), preserving the UNION's sort order via filter_map.

Pure Arel AST nodes (not extracted `.arel` from scopes) to avoid bind parameter numbering issues in UNION context.

Both `fetch_upcoming_events` and `fetch_past_events` share the same machinery; the `upcoming:` flag controls sort direction and date comparison.

## Benchmark

Tested on `GET /events/past` (1056 past workshops in DB):

| Metric | Master (in-memory) | UNION ALL (cached) |
|--------|:-:|:-:|
| Total time | ~10s | 1.3s |
| DB runtime | ~230ms | 201ms |
| View runtime | ~1.8s | 893ms |
| Queries | 119 | 118 |
| Allocations | ~25M | 2.9M |

The DB runtime is stable because LIMIT 20 fetches 20 rows regardless of total data volume — this scales to 10k, 100k, or more.

The remaining ~118 queries come from per-workshop N+1s in the view layer (sponsors, host, permissions, organisers) — unchanged between both versions, so comparison is apples-to-apples.

## Tech Notes

- Uses `Pagy::Offset.new` (Pagy v43.5 API) with a manual Pagy::Request for URL generation
- Removed `:host` from Workshop includes (Bullet AVOID warning); uses `:workshop_host` instead
- Rebased on `origin/bullet-n-plus-one-fixes` (PR #2665) for fair benchmarking — excludes N+1 query noise from the comparison