### PR TITLE
Gemfile: add msgpack to avoid deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'tzinfo-data'
 gem 'commonmarker'
 
 gem 'faraday'
+gem 'msgpack'
 
 gem 'stripe'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    msgpack (1.8.3)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
@@ -655,6 +656,7 @@ DEPENDENCIES
   launchy
   letter_opener
   listen (~> 3.10)
+  msgpack
   mutex_m
   nokogiri
   omniauth
@@ -816,6 +818,7 @@ CHECKSUMS
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
   multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996


### PR DESCRIPTION
When running tests, we got deprecation warnings about this gem.

  ActiveSupport::MessagePack requires the msgpack gem, version 1.7.0 or later. Please add it to your Gemfile: gem 'msgpack'.