### PR TITLE
Make test target fail fast on pending migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,5 @@ serve:
 	rm -f ./tmp/pids/server.pid && bundle exec rails server --binding=0.0.0.0 --port=3000
 
 test:
+	bundle exec rake parallel:setup
 	bundle exec parallel_rspec spec/ -n 3


### PR DESCRIPTION
Add `parallel:setup` guard before `parallel_rspec` so `make test` bails out early instead of letting parallel processes blow up with cryptic `PendingMigrationError`.