### PR TITLE
fix: only load Plausible analytics in production

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,11 +30,12 @@
     = csrf_meta_tags
     = csp_meta_tag
 
-    <!-- Privacy-friendly analytics by Plausible -->
-    %script{ async: true, src: '/js/script.js' }
-    %script
-      window.plausible = window.plausible || function() { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function(i) { plausible.o = i || {} };
-      plausible.init({ endpoint: '/api/event' })
+    - if Rails.env.production?
+      <!-- Privacy-friendly analytics by Plausible -->
+      %script{ async: true, src: '/js/script.js' }
+      %script
+        window.plausible = window.plausible || function() { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function(i) { plausible.o = i || {} };
+        plausible.init({ endpoint: '/api/event' })
 
   %body.no-js{ 'class': "#{params[:controller]}-#{params[:action]}", 'data-bs-no-jquery': 'true' }
     #top


### PR DESCRIPTION
The Plausible script at `/js/script.js` is proxied through nginx in production (to bypass adblockers) but doesn't exist in development, causing a `ActionController::RoutingError: No route matches [GET] "/js/script.js"` on every page load.

Fix: wrap the script block in a `Rails.env.production?` guard so it only loads in production.
