### PR TITLE
fix: eliminate flaky address presenter test due to unescaped HTML entities

### DIFF
--- a/spec/presenters/address_presenter_spec.rb
+++ b/spec/presenters/address_presenter_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe AddressPresenter do
 
   describe '#to_html' do
     it 'returns the address in HTML with lines separated with <br/> tags' do
-      html_address = "#{address.flat}<br/>#{address.street}<br/>#{address.city}, #{address.postal_code}"
+      escape = ERB::Util.method(:html_escape)
+      html_address = "#{escape.call(address.flat)}<br/>#{escape.call(address.street)}<br/>#{escape.call(address.city)}, #{escape.call(address.postal_code)}"
 
       expect(presenter.to_html).to eq(html_address)
     end


### PR DESCRIPTION
## Problem

The `AddressPresenter#to_html` spec builds an expected string from Faker-generated data. Faker cities can contain apostrophes (e.g. `O'Connerstad`), and `ERB::Util.html_escape` escapes `'` to `&#39;`. The expected string used raw characters, so the test passed or failed depending on which random city Faker returned — a classic flake.

## Fix

Wrap each component in `ERB::Util.html_escape` when building the expected value, matching what the presenter does internally.

## Verification

Ran the test with 12 different seeds (including the CI seed `32568`). All pass.