### PR TITLE
fix: bump crass 1.0.6 → 1.0.7 for 4 DoS advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     css_parser (2.2.0)
       addressable
     csv (3.3.5)
@@ -756,7 +756,7 @@ CHECKSUMS
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   css_parser (2.2.0) sha256=23d1b247d7bc78cb2f2fe54629fb755e68d3004f1d1bd5c66d5096d42bff6325
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   database_cleaner (2.1.0) sha256=1dcba26e3b1576da692fc6bac10136a4744da5bcc293d248aae19640c65d89cd


### PR DESCRIPTION
## Problem

`bundler-audit` fails on `crass 1.0.6` with 4 new advisories (all DoS via deep nesting / large exponents / non-ASCII chars / many adjacent comments). These were added to the advisory DB since the last bundle update.

`crass` is a transitive dependency — `loofah` (pulled in by `rails-html-sanitizer`/ActionView) depends on it with `~> 1.0.2`. We cannot drop it, but the bump is safe and minimal.

## Fix

`bundle update crass --conservative` — crass 1.0.6 → 1.0.7.

## Verification

- `bundler-audit check` — No vulnerabilities found
- `rspec spec/presenters/address_presenter_spec.rb --seed 32568` — passes