### PR TITLE
fix: sanitize workshop description in invitation emails

### DIFF
--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -40,7 +40,7 @@
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 10px;' }
                     %strong Description:
-                    = @workshop.description
+                    = sanitize(@workshop.description)
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -35,7 +35,7 @@
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 10px;' }
                     %strong Description:
-                    = @workshop.description
+                    = sanitize(@workshop.description)
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -41,7 +41,7 @@
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 15px;' }
                     %strong Description:
-                    = @workshop.description
+                    = sanitize(@workshop.description)
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4
                   Venue

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -38,7 +38,7 @@
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 15px;' }
                     %strong Description:
-                    = @workshop.description
+                    = sanitize(@workshop.description)
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4
                   Venue

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -71,14 +71,15 @@ RSpec.describe VirtualWorkshopInvitationMailer do
     expect(email.body.encoded).to match('Accept the invitation')
   end
 
-  it '#attending includes the workshop description' do
-    description = "This is a test workshop description."
+  it '#attending renders workshop description as HTML, not escaped' do
+    description = '<strong>Important notice:</strong> Please bring a laptop.'
     workshop = Fabricate(:workshop, description: description)
     invitation = Fabricate(:workshop_invitation, workshop: workshop, member: member)
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 
-    expect(email.body.encoded).to include(description)
+    expect(email.body.encoded).to include('Please bring a laptop.')
+    expect(email.body.encoded).not_to include('&lt;strong&gt;Important')
   end
 
   it '#invite_coach' do

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -110,13 +110,14 @@ RSpec.describe WorkshopInvitationMailer do
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
-  it '#attending includes the workshop description' do
-    description = "This is a test workshop description."
+  it '#attending renders workshop description as HTML, not escaped' do
+    description = '<strong>Important notice:</strong> Please bring a laptop.'
     workshop = Fabricate(:workshop, description: description)
     invitation = Fabricate(:workshop_invitation, workshop: workshop, member: member)
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 
-    expect(email.body.encoded).to include(description)
+    expect(email.body.encoded).to include('Please bring a laptop.')
+    expect(email.body.encoded).not_to include('&lt;strong&gt;Important')
   end
 end

--- a/spec/presenters/address_presenter_spec.rb
+++ b/spec/presenters/address_presenter_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe AddressPresenter do
 
   describe '#to_html' do
     it 'returns the address in HTML with lines separated with <br/> tags' do
-      html_address = "#{address.flat}<br/>#{address.street}<br/>#{address.city}, #{address.postal_code}"
+      escape = ERB::Util.method(:html_escape)
+      html_address = "#{escape.call(address.flat)}<br/>#{escape.call(address.street)}<br/>#{escape.call(address.city)}, #{escape.call(address.postal_code)}"
 
       expect(presenter.to_html).to eq(html_address)
     end


### PR DESCRIPTION
This PR is branched from #2674 to inherit its fix for the flaky tests. Please review and merge that one first, then rebase this one.

---

## Problem

Norwich chapter organisers reported that workshop invitation emails contain escaped HTML, including `<!DOCTYPE html>`. The email shows raw HTML source like `&lt;!DOCTYPE html&gt;&lt;html&gt;...` instead of rendered content.

<img width="1410" height="848" alt="image" src="https://github.com/user-attachments/assets/5419adc6-5dc8-4877-a80a-e3025fae3e87" />


## Root Cause

Two things combined:

1. **Data**: Norwich organisers have been pasting full HTML documents (`<!DOCTYPE html>...`) into the `workshops.description` field via the admin form. This started April 2026 — all 5 subsequent Norwich workshops (IDs 3687, 3688, 3735, 3736, 3761) contain full `<html>` documents in their descriptions. The `description` column is `text` with no format validation.

2. **Rendering mismatch**: The mailer views render the description with HAML's default escaped output (`=`), which HTML-escapes the entire value. On the web, the description is rendered with `sanitize()` (allows safe HTML through). Other chapters also use HTML tags like `<strong>`, `<p>`, `<b>` in descriptions (278 workshops across all chapters contain HTML-like content), which were also being escaped in emails.

The description was added to invitation emails in commit `47c7a900` (Aug 2025, "feat: add description to invitation emails") and has always used escaped rendering — this isn't a regression, just the first time a chapter pasted a full document.

## Change

Wrap `@workshop.description` with `sanitize()` in all four mailer templates, matching how the web views render it:

- `app/views/workshop_invitation_mailer/invite_student.html.haml`
- `app/views/workshop_invitation_mailer/invite_coach.html.haml`
- `app/views/workshop_invitation_mailer/attending.html.haml`
- `app/views/workshop_invitation_mailer/attending_reminder.html.haml`

## Testing

Updated both `#attending renders workshop description as HTML, not escaped` tests to use HTML content in the description and assert the tags are rendered, not escaped — they would catch a revert back to `=`.

27 examples, 0 failures