### PR TITLE
Improve CI configuration: eliminate duplicate runs, add concurrency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [ master ]

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [ push, pull_request ]
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## What

Three changes to the CI workflow that reduce wasted compute and speed up iteration:

**1. Scope workflow trigger to pull_request only**

The previous `on: [push, pull_request]` triggered CI twice on every PR — once from the push event on the branch head, and once from the pull_request event. By scoping to PRs against master, each PR runs CI exactly once.

Also adds `workflow_dispatch` so CI can be triggered manually when needed (e.g., re-running after an infrastructure failure without a new push).

**2. Add concurrency group with cancel-in-progress**

When iterating on a PR, only the latest commit's CI result matters. The concurrency group (keyed on git ref) cancels any in-progress run before starting a new one. No more waiting for a stale run to finish before seeing the result you actually care about.

**3. Removed push-to-master CI** (part of commit 1)

Once branch protection requiring green builds is in place, every merge to master is guaranteed clean — making push-triggered CI on master redundant.

## Benefits

- **No more duplicate CI runs** — PRs run CI once instead of twice, cutting total CI minutes by roughly half
- **Fast iteration** — pushing to a PR cancels the stale run immediately
- **Green master guaranteed** — branch protection ensures only passing code reaches master, making push-to-master CI unnecessary
- **Faster deploys** — no wait for redundant CI runs on master after merging

## Setting up branch protection

After this merges, configure the repo to require green CI on master:

1. Go to **Settings > Branches > Add rule** (or edit the default)
2. Set **Branch name pattern** to `master`
3. Check **Require status checks to pass before merging**
4. Check **Require branches to be up to date**
5. Search and select the status checks — look for "Tests (Group *)" jobs (they appear after this workflow runs once)
6. Check **Include administrators** — admins can still bypass via the "Merge without waiting for requirements to be met" checkbox on the merge confirmation dialog
7. Ensure **Allow force pushes** and **Allow deletions** are unchecked
8. Save

## Commits

| Commit | Change |
|--------|--------|
| 993ae65 | scope workflow to pull_request only, eliminating duplicate runs |
| e74c52c | cancel in-progress CI on new commits |
