### PR TITLE
Fix broken organisers eager load on Event and Meeting queries

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -78,8 +78,8 @@ class EventsController < ApplicationController
               .joins(:chapter)
               .merge(Chapter.active)
     ]
-    events << Meeting.upcoming.includes(:venue, :organisers).all
-    events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers).all
+    events << Meeting.upcoming.includes(:venue).all
+    events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions).all
 
     sorted = events.compact.flatten.sort_by(&:date_and_time)
     return [{}, nil] if sorted.empty?
@@ -100,8 +100,8 @@ class EventsController < ApplicationController
               .joins(:chapter)
               .merge(Chapter.active)
     ]
-    events << Meeting.past.includes(:venue, :organisers).all
-    events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions, :organisers).all
+    events << Meeting.past.includes(:venue).all
+    events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions).all
 
     sorted = events.compact.flatten.sort_by(&:date_and_time).reverse
     return [{}, nil] if sorted.empty?


### PR DESCRIPTION
Remove broken organisers eager load on Event and Meeting queries. includes(:organisers) generates broken SQL — Rails preloader applies WHERE permissions.name = 'organiser' without joining the permissions table, causing PG::UndefinedTable on production data. Workshop works because its complex associations force eager_load (LEFT JOINs) which includes the permissions table. The original Bullet report only flagged Workshop#organisers and Event#organisers, Meeting was never reported. The Event fix only worked in development (light data).