### PR TITLE
perf: restore UNION ALL pagination for /events/past

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -72,46 +72,104 @@ class EventsController < ApplicationController
   end
 
   def fetch_upcoming_events
-    events = [
-      Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
-              .upcoming
-              .joins(:chapter)
-              .merge(Chapter.active)
-    ]
-    events << Meeting.upcoming.includes(:venue).all
-    events << Event.upcoming.includes(:venue, :sponsors, :sponsorships, :permissions).all
+    result = paginated_events(upcoming: true)
+    return [{}, nil] if result.nil?
 
-    sorted = events.compact.flatten.sort_by(&:date_and_time)
-    return [{}, nil] if sorted.empty?
-
-    pagy, paginated = pagy(sorted, items: 20)
-    paginated ||= []
-
-    grouped = paginated.group_by(&:date)
+    rows, pagy = result
+    events = load_events(rows)
+    grouped = events.group_by(&:date)
     decorated = grouped.transform_values { |items| EventPresenter.decorate_collection(items) }
 
     [decorated, pagy]
   end
 
   def fetch_past_events
-    events = [
-      Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
-              .past
-              .joins(:chapter)
-              .merge(Chapter.active)
-    ]
-    events << Meeting.past.includes(:venue).all
-    events << Event.past.includes(:venue, :sponsors, :sponsorships, :permissions).all
+    result = paginated_events(upcoming: false)
+    return [{}, nil] if result.nil?
 
-    sorted = events.compact.flatten.sort_by(&:date_and_time).reverse
-    return [{}, nil] if sorted.empty?
-
-    pagy, paginated = pagy(sorted, items: 20)
-    paginated ||= []
-
-    grouped = paginated.group_by(&:date)
+    rows, pagy = result
+    events = load_events(rows)
+    grouped = events.group_by(&:date)
     decorated = grouped.transform_values { |items| EventPresenter.decorate_collection(items) }
 
     [decorated, pagy]
+  end
+
+  # Builds a UNION ALL query across Workshops, Meetings, and Events,
+  # paginates at the database level, and returns (id, event_type) pairs
+  # for the current page. Only the 20 visible rows come back from the DB.
+  def paginated_events(upcoming:)
+    now = Time.zone.now
+    page = (params[:page] || 1).to_i
+    direction = upcoming ? "ASC" : "DESC"
+    comparator = upcoming ? :gteq : :lt
+
+    # Pure Arel subqueries — no ActiveRecord relation bind params to leak
+    w = Arel::Table.new(:workshops)
+    ch = Arel::Table.new(:chapters)
+    ws = Arel::SelectManager.new(w)
+    ws.project(w[:id], w[:date_and_time], Arel.sql("'Workshop' AS event_type"))
+    ws.join(ch).on(w[:chapter_id].eq(ch[:id]))
+    ws.where(ch[:active].eq(true).and(w[:date_and_time].public_send(comparator, now)))
+
+    m = Arel::Table.new(:meetings)
+    ms = Arel::SelectManager.new(m)
+    ms.project(m[:id], m[:date_and_time], Arel.sql("'Meeting' AS event_type"))
+    ms.where(m[:date_and_time].public_send(comparator, now))
+
+    e = Arel::Table.new(:events)
+    es = Arel::SelectManager.new(e)
+    es.project(e[:id], e[:date_and_time], Arel.sql("'Event' AS event_type"))
+    es.where(e[:date_and_time].public_send(comparator, now))
+
+    union = Arel::Nodes::UnionAll.new(
+      Arel::Nodes::UnionAll.new(ws, ms), es
+    )
+
+    # COUNT at DB level — single query
+    count_query = Arel::SelectManager.new
+    count_query.from(union.as("events"))
+    count_query.project(Arel.star.count)
+    total = ActiveRecord::Base.connection.select_value(count_query.to_sql).to_i
+    return nil if total.zero?
+
+    pagy_opts = { count: total, page: page, limit: 20, request: request }
+    pagy_opts[:request] = Pagy::Request.new(pagy_opts)
+    pagy = Pagy::Offset.new(**pagy_opts)
+
+    # Only 20 rows leave the database
+    pagination_query = Arel::SelectManager.new
+    pagination_query.from(union.as("events"))
+    pagination_query.project(:id, :event_type)
+    pagination_query.order(Arel.sql("date_and_time #{direction}"))
+    pagination_query.skip(pagy.offset).take(pagy.limit)
+
+    rows = ActiveRecord::Base.connection.select_all(pagination_query.to_sql)
+    [rows, pagy]
+  end
+
+  # Loads full ActiveRecord objects for the paginated (id, event_type) pairs
+  # with eager loading, preserving the UNION order.
+  def load_events(rows)
+    grouped = rows.each_with_object({}) do |row, hash|
+      (hash[row["event_type"]] ||= []) << row["id"].to_i
+    end
+
+    workshops = Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
+                        .where(id: grouped["Workshop"])
+                        .to_a.index_by(&:id)
+    meetings = Meeting.includes(:venue).where(id: grouped["Meeting"])
+                      .to_a.index_by(&:id)
+    events = Event.includes(:venue, :sponsors, :sponsorships, :permissions)
+                  .where(id: grouped["Event"])
+                  .to_a.index_by(&:id)
+
+    rows.filter_map do |row|
+      case row["event_type"]
+      when "Workshop" then workshops[row["id"].to_i]
+      when "Meeting" then meetings[row["id"].to_i]
+      when "Event" then events[row["id"].to_i]
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

The `/events/past` page times out on Heroku (503) because it loads **all** past workshops (~2,500), events (~250), and meetings (~50) into ActiveRecord objects, sorts them in Ruby, then paginates. This is the same issue described in the original #2666.

## What happened to the original fix

PR #2666 built a database-level UNION ALL + LIMIT/OFFSET pagination approach, which reduced the page from **11.3s to 1.3s**. However, it was accidentally lost during branch cleanup — it was merged into `bullet-n-plus-one-fixes` via #2666, but then that branch was force-pushed before merging to `master`, dropping the UNION ALL commit. The `bullet-n-plus-one-fixes` branch that eventually merged only contained the smaller organisers eager-load fix.

## This fix

Cherry-picks the original UNION ALL commit (`f775e3bd`) from the surviving `arel-union-pagination` branch, then applies the production fix that was learned later:

- **Removed** `:organisers` from `Event.includes` and `Meeting.includes` in `load_events`, because those models' `organisers` scope generates SQL without properly joining `permissions`, causing `PG::UndefinedTable` on production data (fixed in `39da6926` on master).
- **Preserved** `:organisers` on `Workshop.includes`, because Workshop's complex associations force `eager_load` (LEFT JOINs), which correctly includes the permissions table.
- **Added** `:venue` to `Meeting.includes` and `:host` to `Workshop.includes` to match the current master's eager loading pattern.

## How it works

- `paginated_events(upcoming:)` — builds an Arel UNION ALL query across Workshops, Meetings, and Events with LIMIT/OFFSET at the database level. Only 20 `(id, event_type)` pairs leave the database.
- `load_events(rows)` — fetches full ActiveRecord objects for just those 20 rows with eager loading, preserving the UNION sort order.

## Verification

- `spec/controllers/events_controller_spec.rb` — 4 examples, all passing
- `spec/features/listing_events_spec.rb` — 4 examples, all passing
- Pagination at 20 per page works for past workshops, meetings, and events
