### PR TITLE
fix: remove broken organisers eager load on Workshop queries

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -155,7 +155,7 @@ class EventsController < ApplicationController
       (hash[row["event_type"]] ||= []) << row["id"].to_i
     end
 
-    workshops = Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
+    workshops = Workshop.includes(:chapter, :sponsors, :host, :permissions)
                         .where(id: grouped["Workshop"])
                         .to_a.index_by(&:id)
     meetings = Meeting.includes(:venue).where(id: grouped["Meeting"])


### PR DESCRIPTION
## Problem

PR #2682 introduced a `load_events` method that eagerly loads `:organisers` on Workshop:

```ruby
Workshop.includes(:chapter, :sponsors, :host, :permissions, :organisers)
```

The `organisers` association has a scope condition on the join table:

```ruby
has_many :organisers, -> { where('permissions.name' => 'organiser') }, through: :permissions, source: :members
```

When Rails preloads this with the separate-query strategy (which it does here because `.where(id: [...])` is a simple query), it generates:

```sql
SELECT "members".* FROM "members" WHERE "permissions"."name" = 'organiser' AND "members"."id" IN (...)
```

This references `permissions.name` without joining `permissions`, causing `PG::UndefinedTable: missing FROM-clause entry for table "permissions"`.

## Context

PR #2679 already fixed this exact same bug for Event and Meeting by removing `:organisers` from their eager loads. PR #2682 reintroduced it on Workshop in the new `load_events` method, under the old assumption that Workshop's complex associations still forced Rails to use `eager_load` (LEFT JOINs). The `.where(id: [...])` pattern in `load_events` triggers preloading instead, so the broken SQL resurfaces.

## Fix

Remove `:organisers` from the Workshop `includes` in `load_events`.

## Verification

- Tests pass
- Deployed to staging and verified `/events/past` loads successfully (was returning 500 before)
