### PR TITLE
fix: include invited coaches who never RSVPed in feedback dropdown

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -40,7 +40,8 @@ class FeedbackController < ApplicationController
   end
 
   def set_coaches(workshop)
-    @coaches = workshop.invitations.to_coaches.accepted_or_attended
+    @coaches = workshop.invitations.to_coaches
+      .where('attending IS NULL OR attending = ? OR attended = ?', true, true)
       .order(Arel.sql('attended DESC NULLS LAST'))
       .map(&:member)
   end

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -57,6 +57,25 @@ RSpec.feature 'member feedback', type: :feature do
       expect(page).to have_select('feedback_coach_id', with_options: [coach_not_yet_verified.full_name])
     end
 
+    scenario 'I can see coaches who were invited but never RSVPed (Issue #2633)' do
+      # This reproduces the real-world scenario where:
+      # 1. Coach is invited to workshop but never responds (attending = nil)
+      # 2. Coach shows up anyway
+      # 3. Organizer hasn't yet marked attendance (attended = nil)
+      # 4. Student receives feedback form and should still be able to select the coach
+      walk_in_coach = Fabricate(:coach)
+      Fabricate(:coach_workshop_invitation,
+        workshop: feedback_request.workshop,
+        member: walk_in_coach,
+        attending: nil,
+        attended: nil)
+
+      visit feedback_path(valid_token)
+
+      # Coach should appear in the list even though they never RSVPed
+      expect(page).to have_select('feedback_coach_id', with_options: [walk_in_coach.full_name])
+    end
+
     scenario 'verified coaches appear before unverified coaches in the list' do
       # Create two coaches: one verified (attended=true), one not yet (attended=nil)
       verified_coach = Fabricate(:coach, name: 'Alice', surname: 'Verified')


### PR DESCRIPTION
Closes #2633

## Problem

The feedback form dropdown only showed coaches with `attending=true` or `attended=true`. This excluded new coaches who were invited to a workshop but never RSVPed (`attending=nil`) and then showed up anyway.

Because these coaches are invisible in the admin attendance UI (which only renders `@attending_coaches`, i.e. `attending=true`), organisers often could not mark them as attended. Students were then unable to submit feedback when their coach was missing from the required dropdown.

## Fix

`FeedbackController#set_coaches` now also includes coaches with `attending=nil`, so any invited coach can be selected for feedback.

## What changed

- `app/controllers/feedback_controller.rb`: broadened the coach query from `accepted_or_attended` to `attending IS NULL OR attending = true OR attended = true`
- `spec/features/member_feedback_spec.rb`: added a feature test covering the walk-in coach scenario (Issue #2633)

## Test evidence

```
bundle exec rspec spec/features/member_feedback_spec.rb
# 10 examples, 0 failures

bundle exec rspec spec/controllers/feedback_controller_spec.rb
# 5 examples, 0 failures
```
