### PR TITLE
fix: RuboCop: avoid configuration that fails at start

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,10 +9,6 @@ AllCops:
     - bin/**/*
     - vendor/bundle/**/*
 
-Lint/Syntax:
-  Exclude:
-    - app/views/**/*.haml
-
 plugins:
   - rubocop-capybara
   - rubocop-performance

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -177,9 +177,9 @@ namespace :setup do
 
     def check_database_migrated
       
-        if ActiveRecord::Base.connection.execute("SELECT 1 FROM schema_migrations LIMIT 1")
+        if ActiveRecord::Base.connection.execute('SELECT 1 FROM schema_migrations LIMIT 1')
           latest = ActiveRecord::Base.connection.execute(
-            "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1"
+            'SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1'
           ).first
           if latest
             ok('Database migrations', "up to date (latest: #{latest['version']})")
@@ -218,12 +218,12 @@ namespace :setup do
       warnings = @results.count { |r| r[:status] == :warn }
 
       if errors.zero? && warnings.zero?
-        puts "✅ All checks passed! Your environment is ready for development."
+        puts '✅ All checks passed! Your environment is ready for development.'
         puts
-        puts "Next steps:"
-        puts "  bundle exec rails server       # Start the app"
-        puts "  bundle exec rspec              # Run the test suite"
-        puts "  bundle exec rake db:seed       # (Optional) Add sample data"
+        puts 'Next steps:'
+        puts '  bundle exec rails server       # Start the app'
+        puts '  bundle exec rspec              # Run the test suite'
+        puts '  bundle exec rake db:seed       # (Optional) Add sample data'
       elsif errors.zero?
         puts "⚠️  #{warnings} warning(s). You can probably start developing, but review the warnings above."
       else

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -151,17 +151,17 @@ namespace :setup do
     end
 
     def check_database_connection
-      begin
+      
         ActiveRecord::Base.connection.execute('SELECT 1')
         ok('Database connection', 'can connect to PostgreSQL')
       rescue StandardError => e
         error('Database connection', "cannot connect (#{e.class}: #{e.message})",
               'Check PostgreSQL is running and credentials in config/database.yml are correct.')
-      end
+      
     end
 
     def check_database_exists
-      begin
+      
         ActiveRecord::Base.connection.execute('SELECT 1')
         if ActiveRecord::Base.connection.execute("SELECT 1 FROM pg_database WHERE datname = 'planner_development'").any?
           ok('Development database', 'planner_development exists')
@@ -172,11 +172,11 @@ namespace :setup do
       rescue StandardError => e
         error('Development database', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:create')
-      end
+      
     end
 
     def check_database_migrated
-      begin
+      
         if ActiveRecord::Base.connection.execute("SELECT 1 FROM schema_migrations LIMIT 1")
           latest = ActiveRecord::Base.connection.execute(
             "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1"
@@ -191,7 +191,7 @@ namespace :setup do
       rescue StandardError => e
         error('Database migrations', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:migrate')
-      end
+      
     end
 
     def check_test_database

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -151,17 +151,17 @@ namespace :setup do
     end
 
     def check_database_connection
-      
+
         ActiveRecord::Base.connection.execute('SELECT 1')
         ok('Database connection', 'can connect to PostgreSQL')
     rescue StandardError => e
         error('Database connection', "cannot connect (#{e.class}: #{e.message})",
               'Check PostgreSQL is running and credentials in config/database.yml are correct.')
-      
+
     end
 
     def check_database_exists
-      
+
         ActiveRecord::Base.connection.execute('SELECT 1')
         if ActiveRecord::Base.connection.execute("SELECT 1 FROM pg_database WHERE datname = 'planner_development'").any?
           ok('Development database', 'planner_development exists')
@@ -172,11 +172,11 @@ namespace :setup do
     rescue StandardError => e
         error('Development database', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:create')
-      
+
     end
 
     def check_database_migrated
-      
+
         if ActiveRecord::Base.connection.execute('SELECT 1 FROM schema_migrations LIMIT 1')
           latest = ActiveRecord::Base.connection.execute(
             'SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1'
@@ -191,7 +191,7 @@ namespace :setup do
     rescue StandardError => e
         error('Database migrations', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:migrate')
-      
+
     end
 
     def check_test_database

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -216,7 +216,6 @@ namespace :setup do
       puts
       errors = @results.count { |r| r[:status] == :error }
       warnings = @results.count { |r| r[:status] == :warn }
-      ok_count = @results.count { |r| r[:status] == :ok }
 
       if errors.zero? && warnings.zero?
         puts "✅ All checks passed! Your environment is ready for development."

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -154,7 +154,7 @@ namespace :setup do
       
         ActiveRecord::Base.connection.execute('SELECT 1')
         ok('Database connection', 'can connect to PostgreSQL')
-      rescue StandardError => e
+    rescue StandardError => e
         error('Database connection', "cannot connect (#{e.class}: #{e.message})",
               'Check PostgreSQL is running and credentials in config/database.yml are correct.')
       
@@ -169,7 +169,7 @@ namespace :setup do
           error('Development database', 'planner_development does not exist',
                 'Run: bundle exec rake db:create')
         end
-      rescue StandardError => e
+    rescue StandardError => e
         error('Development database', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:create')
       
@@ -188,7 +188,7 @@ namespace :setup do
                   'Run: bundle exec rake db:migrate')
           end
         end
-      rescue StandardError => e
+    rescue StandardError => e
         error('Database migrations', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:migrate')
       

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -151,17 +151,14 @@ namespace :setup do
     end
 
     def check_database_connection
-
         ActiveRecord::Base.connection.execute('SELECT 1')
         ok('Database connection', 'can connect to PostgreSQL')
     rescue StandardError => e
         error('Database connection', "cannot connect (#{e.class}: #{e.message})",
               'Check PostgreSQL is running and credentials in config/database.yml are correct.')
-
     end
 
     def check_database_exists
-
         ActiveRecord::Base.connection.execute('SELECT 1')
         if ActiveRecord::Base.connection.execute("SELECT 1 FROM pg_database WHERE datname = 'planner_development'").any?
           ok('Development database', 'planner_development exists')
@@ -172,11 +169,9 @@ namespace :setup do
     rescue StandardError => e
         error('Development database', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:create')
-
     end
 
     def check_database_migrated
-
         if ActiveRecord::Base.connection.execute('SELECT 1 FROM schema_migrations LIMIT 1')
           latest = ActiveRecord::Base.connection.execute(
             'SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1'
@@ -191,7 +186,6 @@ namespace :setup do
     rescue StandardError => e
         error('Database migrations', "cannot check (#{e.class}: #{e.message})",
               'Run: bundle exec rake db:migrate')
-
     end
 
     def check_test_database

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -9,18 +9,18 @@ namespace :setup do
   end
 
   class SetupChecker
-    CHECKS = [
-      :check_ruby_version,
-      :check_bundler,
-      :check_mise,
-      :check_postgresql,
-      :check_imagemagick,
-      :check_github_credentials,
-      :check_bundle,
-      :check_database_connection,
-      :check_database_exists,
-      :check_database_migrated,
-      :check_test_database
+    CHECKS = %i[
+      check_ruby_version
+      check_bundler
+      check_mise
+      check_postgresql
+      check_imagemagick
+      check_github_credentials
+      check_bundle
+      check_database_connection
+      check_database_exists
+      check_database_migrated
+      check_test_database
     ].freeze
 
     def initialize


### PR DESCRIPTION
> Error: configuration for Lint/Syntax cop found in .rubocop.yml
> It's not possible to disable this cop.

This ended the whole execution.