### PR TITLE
feat: add RSVP close time to workshops

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,12 +30,12 @@
 $(function() {
   $("body").removeClass("no-js");
 
-  $('#event_local_date, #meeting_local_date, #workshop_local_date, #workshop_rsvp_open_local_date').pickadate({
+  $('#event_local_date, #meeting_local_date, #workshop_local_date, #workshop_rsvp_open_local_date, #workshop_rsvp_close_local_date').pickadate({
     format: 'dd/mm/yyyy'
   });
   $('#announcement_expires_at, #ban_expires_at').pickadate();
   $(
-    "#meeting_local_time, #meeting_local_end_time, #event_local_time, #event_local_end_time, #workshop_local_time, #workshop_local_end_time, #workshop_rsvp_open_local_time"
+    "#meeting_local_time, #meeting_local_end_time, #event_local_time, #event_local_end_time, #workshop_local_time, #workshop_local_end_time, #workshop_rsvp_open_local_time, #workshop_rsvp_close_local_time"
   ).pickatime({
     format: "HH:i",
   });

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -121,6 +121,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
       :local_date, :local_time, :local_end_time, :chapter_id,
       :invitable, :seats, :virtual, :slack_channel, :slack_channel_link,
       :rsvp_open_local_date, :rsvp_open_local_time, :description,
+      :rsvp_close_local_date, :rsvp_close_local_time,
       :coach_spaces, :student_spaces,
       { sponsor_ids: [] }
     ])

--- a/app/controllers/workshop_invitation_controller.rb
+++ b/app/controllers/workshop_invitation_controller.rb
@@ -52,7 +52,9 @@ class WorkshopInvitationController < ApplicationController
   # Inline reject from InvitationControllerConcerns
   def reject
     @workshop = WorkshopPresenter.decorate(@invitation.workshop)
-    if @invitation.workshop.date_and_time - 3.5.hours >= Time.zone.now
+    closes_at = @invitation.workshop.rsvp_closes_at
+    rsvp_deadline = [@invitation.workshop.date_and_time - 3.5.hours, closes_at].compact.min
+    if rsvp_deadline >= Time.zone.now
       if @invitation.attending.eql? false
         redirect_back(fallback_location: invitation_path(@invitation),
                       notice: t('messages.not_attending_already'))

--- a/app/controllers/workshop_invitation_controller.rb
+++ b/app/controllers/workshop_invitation_controller.rb
@@ -27,6 +27,7 @@ class WorkshopInvitationController < ApplicationController
     user = current_user || @invitation.member
     workshop = @invitation.workshop
     return back_with_message(t('messages.already_rsvped')) if @invitation.attending?
+    return back_with_message(t('messages.invitations.closed')) unless workshop.rsvp_available?
 
     @invitation.assign_attributes(invitation_params.merge!(attending: true, rsvp_time: Time.zone.now))
     return back_with_message(@invitation.errors.full_messages) unless @invitation.valid?

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -3,7 +3,8 @@ class Workshop < ApplicationRecord
   include Invitable
   include Listable
 
-  attr_accessor :local_date, :local_time, :local_end_time, :rsvp_open_local_date, :rsvp_open_local_time
+  attr_accessor :local_date, :local_time, :local_end_time, :rsvp_open_local_date, :rsvp_open_local_time,
+              :rsvp_close_local_date, :rsvp_close_local_time
 
   resourcify :permissions, role_cname: 'Permission', role_table_name: :permission
 
@@ -34,6 +35,8 @@ class Workshop < ApplicationRecord
 
   before_validation :set_date_and_time, :set_end_date_and_time, if: proc { |model| model.chapter_id.present? }
   before_validation :set_opens_at
+  before_validation :set_closes_at
+  validate :rsvp_close_before_workshop_start
 
   def host
     workshop_host&.sponsor
@@ -78,7 +81,7 @@ class Workshop < ApplicationRecord
   end
 
   def available_for_rsvp?
-    invitable_yet? && date_and_time.future?
+    invitable_yet? && rsvp_available?
   end
 
   # Is this person attending this event?
@@ -117,10 +120,27 @@ class Workshop < ApplicationRecord
     super.in_time_zone(time_zone)
   end
 
+  def rsvp_closes_at
+    return nil unless super
+
+    super.in_time_zone(time_zone)
+  end
+
   private
 
   def set_opens_at
     new_opens_at = datetime_from_fields(rsvp_open_local_date, rsvp_open_local_time)
     self.rsvp_opens_at = new_opens_at if new_opens_at
+  end
+
+  def set_closes_at
+    new_closes_at = datetime_from_fields(rsvp_close_local_date, rsvp_close_local_time)
+    self.rsvp_closes_at = new_closes_at if new_closes_at
+  end
+
+  def rsvp_close_before_workshop_start
+    return unless rsvp_closes_at && date_and_time
+    return if rsvp_closes_at < date_and_time
+    errors.add(:rsvp_close_local_date, "must be before the workshop start time")
   end
 end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -36,6 +36,7 @@ class Workshop < ApplicationRecord
   before_validation :set_date_and_time, :set_end_date_and_time, if: proc { |model| model.chapter_id.present? }
   before_validation :set_opens_at
   before_validation :set_closes_at
+  validate :rsvp_date_time_fields_must_be_paired
   validate :rsvp_close_before_workshop_start
 
   def host
@@ -136,6 +137,24 @@ class Workshop < ApplicationRecord
   def set_closes_at
     new_closes_at = datetime_from_fields(rsvp_close_local_date, rsvp_close_local_time)
     self.rsvp_closes_at = new_closes_at if new_closes_at
+  end
+
+  def rsvp_date_time_fields_must_be_paired
+    %i[rsvp_open rsvp_close].each do |prefix|
+      date_field = :"#{prefix}_local_date"
+      time_field = :"#{prefix}_local_time"
+      date_val = send(date_field)
+      time_val = send(time_field)
+
+      next if date_val.blank? && time_val.blank?
+      next if date_val.present? && time_val.present?
+
+      if date_val.blank?
+        errors.add(date_field, "must be provided together with #{prefix.to_s.humanize.downcase} time")
+      else
+        errors.add(time_field, "must be provided together with #{prefix.to_s.humanize.downcase} date")
+      end
+    end
   end
 
   def rsvp_close_before_workshop_start

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -143,8 +143,8 @@ class Workshop < ApplicationRecord
     %i[rsvp_open rsvp_close].each do |prefix|
       date_field = :"#{prefix}_local_date"
       time_field = :"#{prefix}_local_time"
-      date_val = send(date_field)
-      time_val = send(time_field)
+      date_val = public_send(date_field)
+      time_val = public_send(time_field)
 
       next if date_val.blank? && time_val.blank?
       next if date_val.present? && time_val.present?

--- a/app/views/admin/workshops/_shared_form.html.haml
+++ b/app/views/admin/workshops/_shared_form.html.haml
@@ -20,6 +20,10 @@
   .col-12
     .card.bg-light.border-info.mb-3
       .card-body
-        %p= t('admin.workshop.form.rsvp_details')
-        = f.input :rsvp_open_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
-        = f.input :rsvp_open_local_time, as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }
+        %h6.card-title RSVP Timing
+        %p.small.text-muted= t('admin.workshop.form.rsvp_details')
+        .row
+          .col-12.col-md-6
+            = f.input :rsvp_open_local_date, label: 'Open date', as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
+          .col-12.col-md-6
+            = f.input :rsvp_open_local_time, label: 'Open time', as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }

--- a/app/views/admin/workshops/_shared_form.html.haml
+++ b/app/views/admin/workshops/_shared_form.html.haml
@@ -27,3 +27,8 @@
             = f.input :rsvp_open_local_date, label: 'Open date', as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:strftime, '%d/%m/%Y') } }
           .col-12.col-md-6
             = f.input :rsvp_open_local_time, label: 'Open time', as: :string, input_html: { data: { value: @workshop.rsvp_opens_at.try(:time).try(:strftime, '%H:%M') } }
+        .row
+          .col-12.col-md-6
+            = f.input :rsvp_close_local_date, label: 'Close date', as: :string, input_html: { data: { value: @workshop.rsvp_closes_at.try(:strftime, '%d/%m/%Y') } }
+          .col-12.col-md-6
+            = f.input :rsvp_close_local_time, label: 'Close time', as: :string, input_html: { data: { value: @workshop.rsvp_closes_at.try(:time).try(:strftime, '%H:%M') } }

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -46,6 +46,10 @@
           - else
             RSVPs will open at
           = @workshop.rsvp_opens_at.strftime('%H:%M on %d/%m/%Y.')
+      - if @workshop.rsvp_closes_at
+        %div.mb-2
+          RSVPs will close at
+          = @workshop.rsvp_closes_at.strftime('%H:%M on %d/%m/%Y.')
       - if @workshop.venue.present? || @workshop.virtual?
         %span.badge.bg-info #{@workshop.student_spaces} student spots, #{@workshop.coach_spaces} coach spots
         - unless @workshop.spaces?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,7 @@ en:
       spot_confirmed: "Your spot has been confirmed for %{event}! We look forward to seeing you there."
       spot_not_confirmed: "Your spot has not yet been confirmed. We will verify your attendance after you complete the questionnaire."
       updated_details: "Invitation details successfully updated."
+      closed: "RSVPs for this workshop are now closed."
     invalid_format: "The requested format is invalid: %{invalid_format}"
   notifications:
     provider_already_connected: "You are already signed in!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -665,7 +665,7 @@ en:
         failure: "Workshop cannot be deleted. This is because it has invitees and/or workshop information is on the website for a while long enough that it cannot be deleted."
       form:
         virtual_info: To create a virtual workshop you must check the box and fill in the below fields. The slack channel will be available on the invitation page for anyone who successfuly RSVPs.
-        rsvp_details: Fill out these fields if you want RSVPs to open automatically at a future time. Leave blank if you'll handle it manually later.
+        rsvp_details: Set a date and time (in the chapter's timezone) for RSVPs to open and close automatically. Leave blank to handle manually.
       not_invitable: "The workshop is not invitable"
       virtual:
         details:

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
     end
   end
 
+  describe 'POST #create' do
+    it 'permits rsvp_close_local_date and rsvp_close_local_time' do
+      expect do
+        post :create, params: { workshop: { rsvp_close_local_date: '01/12/2020', rsvp_close_local_time: '15:00', host: '' } }
+      end.not_to raise_error
+    end
+  end
+
   describe 'DELETE #destroy' do
     context 'workshop invitations have been sent' do
       before do

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -22,6 +22,18 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
 
     it_behaves_like 'invitation route'
 
+    context 'when RSVPs are closed' do
+      scenario 'cannot accept an invitation after the close time' do
+        invitation.workshop.update(rsvp_closes_at: 1.hour.ago)
+
+        visit invitation_route
+        click_on 'Attend'
+
+        expect(page).to have_content('RSVPs for this workshop are now closed.')
+        expect(invitation.reload.attending).not_to be(true)
+      end
+    end
+
     context 'amend invitation details' do
       context 'a student' do
         scenario 'cannot accept an invitation  without a tutorial' do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -46,6 +46,75 @@ RSpec.describe Workshop do
       it { is_expected.to validate_numericality_of(:coach_spaces).is_greater_than(0) }
     end
 
+    context '#rsvp_date_time_fields_must_be_paired' do
+      shared_examples_for 'date_time_fields_must_be_paired' do |prefix|
+        let(:date_field) { :"#{prefix}_local_date" }
+        let(:time_field) { :"#{prefix}_local_time" }
+
+        context 'when both fields are blank' do
+          before do
+            workshop.public_send(:"#{prefix}_local_date=", nil)
+            workshop.public_send(:"#{prefix}_local_time=", nil)
+          end
+
+          it 'is valid' do
+            workshop.valid?
+            expect(workshop.errors[date_field]).to be_empty
+            expect(workshop.errors[time_field]).to be_empty
+          end
+        end
+
+        context 'when both fields are present' do
+          before do
+            workshop.public_send(:"#{prefix}_local_date=", '12/06/2015')
+            workshop.public_send(:"#{prefix}_local_time=", '18:30')
+          end
+
+          it 'is valid' do
+            workshop.valid?
+            expect(workshop.errors[date_field]).to be_empty
+            expect(workshop.errors[time_field]).to be_empty
+          end
+        end
+
+        context 'when only date is missing' do
+          before do
+            workshop.public_send(:"#{prefix}_local_date=", nil)
+            workshop.public_send(:"#{prefix}_local_time=", '18:30')
+          end
+
+          it 'is invalid' do
+            workshop.valid?
+            expect(workshop.errors[date_field]).to include(
+              "must be provided together with #{prefix.humanize.downcase} time"
+            )
+          end
+        end
+
+        context 'when only time is missing' do
+          before do
+            workshop.public_send(:"#{prefix}_local_date=", '12/06/2015')
+            workshop.public_send(:"#{prefix}_local_time=", nil)
+          end
+
+          it 'is invalid' do
+            workshop.valid?
+            expect(workshop.errors[time_field]).to include(
+              "must be provided together with #{prefix.humanize.downcase} date"
+            )
+          end
+        end
+      end
+
+      context 'with rsvp_open' do
+        it_should_behave_like 'date_time_fields_must_be_paired', 'rsvp_open'
+      end
+
+      context 'with rsvp_close' do
+        it_should_behave_like 'date_time_fields_must_be_paired', 'rsvp_close'
+      end
+    end
+
     context '#rsvp_closes_at' do
       it 'must be before the workshop start time' do
         workshop.date_and_time = Time.zone.now + 1.hour

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -45,6 +45,28 @@ RSpec.describe Workshop do
       it { is_expected.to validate_numericality_of(:student_spaces).is_greater_than(0) }
       it { is_expected.to validate_numericality_of(:coach_spaces).is_greater_than(0) }
     end
+
+    context '#rsvp_closes_at' do
+      it 'must be before the workshop start time' do
+        workshop.date_and_time = Time.zone.now + 1.hour
+        workshop.rsvp_closes_at = Time.zone.now + 2.hours
+
+        workshop.valid?
+        expect(workshop.errors[:rsvp_close_local_date]).to include("must be before the workshop start time")
+      end
+
+      it 'is valid when close time is before workshop start' do
+        workshop.date_and_time = Time.zone.now + 2.hours
+        workshop.rsvp_closes_at = Time.zone.now + 1.hour
+
+        expect(workshop.valid?).to be(true)
+      end
+
+      it 'is valid when no close time is set' do
+        workshop.rsvp_closes_at = nil
+        expect(workshop.valid?).to be(true)
+      end
+    end
   end
 
   context 'time zone fields' do
@@ -85,6 +107,24 @@ RSpec.describe Workshop do
 
         expect(workshop.rsvp_opens_at).to eq(pacific_time)
         expect(workshop.rsvp_opens_at.zone).to eq('PDT')
+      end
+    end
+
+    context 'rsvp_closes_at' do
+      it 'saves the local time in UTC' do
+        workshop.update!(
+          rsvp_close_local_date: '12/06/2015',
+          rsvp_close_local_time: '18:30'
+        )
+
+        expect(workshop.read_attribute(:rsvp_closes_at)).to eq(utc_time)
+      end
+
+      it 'retrieves the local time from the saved UTC value' do
+        workshop.update_attribute(:rsvp_closes_at, utc_time)
+
+        expect(workshop.rsvp_closes_at).to eq(pacific_time)
+        expect(workshop.rsvp_closes_at.zone).to eq('PDT')
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/codebar/planner/issues/2687

## What

Add RSVP closing date/time to workshops, mirroring the existing "Open RSVPs at" pattern. Organisers can set when RSVPs close automatically — nil means RSVPs stay open until the workshop starts.

<img width="660" height="322" alt="image" src="https://github.com/user-attachments/assets/58ebe4ed-d07a-455d-9613-88ff39d39242" />

## Changes

- **Model**: `rsvp_closes_at` virtual attrs (`rsvp_close_local_date`/`rsvp_close_local_time`) via `datetime_from_fields`, timezone-aware getter, validation that close time is before workshop start
- **Controller**: `WorkshopInvitationController#accept` gated by `rsvp_available?`; admin attendance management unaffected
- **Form**: close date/time fields in "RSVP Timing" card with pickadate selectors, side-by-side column layout
- **Detail page**: shows RSVP close time on admin workshop view when set
- **Form layout**: improved open date/time fields to side-by-side columns with clear labels and card title

## Verification

- `rsvp_closes_at` nil → RSVPs stay open (current default)
- Close time before workshop start → valid
- Close time after workshop start → validation error
- RSVPs closed → member sees "RSVPs for this workshop are now closed."
- Organisers bypass via admin invitation management