### PR TITLE
fix: update websocket-driver to 0.8.2 (security audit)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,7 +600,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -942,7 +942,7 @@ CHECKSUMS
   view_component (4.12.0) sha256=b9a5979d1c43eba2aa21a06a86f661aab3990104855f2909ef7c3779acdcdcb4
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942


### PR DESCRIPTION
## Problem

Security audit failing with 4 CVEs in `websocket-driver` 0.8.0:

| CVE / GHSA | Issue | Fixed in |
|------------|-------|----------|
| CVE-2026-54464 / GHSA-33ph-fccm-39pj | Resource limit bypass via compression | ≥0.8.1 |
| CVE-2026-54467 / GHSA-8j3g-f24p-4mpw | Memory exhaustion in HTTP header parser | ≥0.8.2 |
| CVE-2026-54468 | Unspecified DoS | ≥0.8.1 |
| (unnamed) | Memory exhaustion in WebSocket frame parser | ≥0.8.1 |

## Change

`bundle update websocket-driver --conservative` — only the version and checksum changed in `Gemfile.lock`. No code changes, no dependency additions.

## Verification

- `bundle exec rspec` passes
- `bundler-audit` (security audit) now passes