### PR TITLE
fix: address presenter spec flake from Faker apostrophe in flat

### DIFF
--- a/spec/presenters/address_presenter_spec.rb
+++ b/spec/presenters/address_presenter_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe AddressPresenter do
 
     it 'escapes HTML in address elements' do
       address.street = '<script>alert("XSS");</script>'
-      html_address = "#{address.flat}<br/>&lt;script&gt;alert(&quot;XSS&quot;);&lt;/script&gt;<br/>" +
-        "#{address.city}, #{address.postal_code}"
+      escape = ERB::Util.method(:html_escape)
+      html_address = "#{escape.call(address.flat)}<br/>&lt;script&gt;alert(&quot;XSS&quot;);&lt;/script&gt;<br/>" +
+        "#{escape.call(address.city)}, #{escape.call(address.postal_code)}"
 
       expect(presenter.to_html).to eq(html_address)
     end


### PR DESCRIPTION
## Problem

"escapes HTML in address elements" test in `AddressPresenter` flakes on CI when Faker generates a street name with an apostrophe (e.g. "O'Kon Land", "D'Amore Mill").

The expected value used `address.flat`, `address.city`, and `address.postal_code` raw (unescaped), but the presenter applies `ERB::Util.html_escape` to all fields. An apostrophe gets escaped to `&#39;`, causing a mismatch.

## Change

Use `html_escape` for all components in the expected value of the XSS test, consistent with the first test in the same `describe` block. Only the expected-value construction changed — test intent is unchanged.

## Verification

- `bundle exec rspec spec/presenters/address_presenter_spec.rb --seed 44342` passes
- 10x random-seed runs pass locally