### PR TITLE
fix: escape venue/sponsor names with apostrophes in CSS selectors

### DIFF
--- a/spec/components/event_card_component_spec.rb
+++ b/spec/components/event_card_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe EventCardComponent, type: :component do
 
     it "renders venue image for meetings" do
       render_inline(described_class.new(event_card: presenter))
-      expect(page).to have_css("img[alt='#{meeting.venue.name}']")
+      expect(page).to have_css(%(img[alt="#{meeting.venue.name}"]))
     end
 
     it "does not render sponsor logos for meetings" do
@@ -64,7 +64,7 @@ RSpec.describe EventCardComponent, type: :component do
       sponsor = Fabricate(:sponsor)
       event.sponsors << sponsor
       render_inline(described_class.new(event_card: presenter))
-      expect(page).to have_css("img[alt='#{sponsor.name}']")
+      expect(page).to have_css(%(img[alt="#{sponsor.name}"]))
     end
   end
 


### PR DESCRIPTION
## What

Fix a test flake in `EventCardComponent` where Faker-generated venue or sponsor names with apostrophes (e.g. `Simon O'Connell`) break CSS attribute selectors using single quotes: `img[alt='Simon O'Connell']`.

## Root cause

The CSS selector `have_css("img[alt='#{name}'"])` uses single-quote delimiters for the attribute value. An apostrophe in the name closes the string early, producing a `Nokogiri::CSS::SyntaxError`.

## Fix

Switch to double-quoted CSS attribute selectors using Ruby `%(...)` literal syntax: `have_css(%(img[alt="#{name}"]))`. Double quotes handle apostrophes in values without escaping.

Applies to both occurrences of this pattern in the spec (meeting venue image, sponsor logo image).

## CI context

Flake observed in PR #2705 (Group 3, seed 3843): `EventCardComponent with a meeting renders venue image for meetings`

## Testing

`spec/components/event_card_component_spec.rb` — 10 examples, 0 failures
