### PR TITLE
refactor: inline address formatting in EventCalendar to remove layer violation

### DIFF
--- a/lib/services/event_calendar.rb
+++ b/lib/services/event_calendar.rb
@@ -13,14 +13,22 @@ class Services::EventCalendar
   private
 
   def setup_event
-    address = AddressPresenter.new(event.venue.address) if event.venue.present?
     calendar.event do |e|
       e.organizer = event.email.to_s
       e.dtstart = event.date_and_time
       e.dtend = event.ends_at
       e.summary = event.name
-      e.location = address&.to_s
+      e.location = address_string
       e.ip_class = 'PRIVATE'
     end
+  end
+
+  def address_string
+    address = event.venue&.address
+    return unless address
+
+    [address.flat, address.street, address.city, address.postal_code]
+      .delete_if(&:empty?)
+      .join(', ')
   end
 end


### PR DESCRIPTION
## Problem

`Services::EventCalendar` in `lib/services/` (infrastructure layer) depends on `AddressPresenter` in `app/presenters/` (presentation layer). This breaks the layered architecture rule that lower layers must not depend on higher layers.

## Solution

Inline the address formatting directly in the service. The `AddressPresenter#to_s` method does a simple join of `[flat, street, city, postal_code]` — no presenter needed.

## Verification

- Behaviour preserved: same field selection, same empty-filtering, same separator
- Only caller is `EventInvitationMailer#attending`, which still passes the same event object
- No test exists for EventCalendar (pre-existing)

## Layer analysis context

This was identified by a full layered-architecture audit of the codebase. The audit found no other critical layer violations.