### PR TITLE
Add uniqueness validation for contact email scoped to sponsor

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -2,6 +2,7 @@ class Contact < ApplicationRecord
   belongs_to :sponsor, optional: true
 
   validates :name, :surname, :email, presence: true
+  validates :email, uniqueness: { scope: :sponsor_id }
 
   before_create :set_token
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Contact do
+  subject(:contact) { Fabricate.build(:contact) }
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:surname) }
+    it { is_expected.to validate_presence_of(:email) }
+
+    it do
+      Fabricate(:contact)
+      is_expected.to validate_uniqueness_of(:email).scoped_to(:sponsor_id)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`ActiveRecord::RecordNotUnique` (PG::UniqueViolation) raised when a duplicate contact email is submitted for the same sponsor. The DB has a unique index on `(email, sponsor_id)`, but there is no model-level validation, so `valid?` passes and `save` blows up with a 500.

Root cause: double-submit on the sponsor edit form — two POSTs arrive, both carrying the same new contact (no `id`). First INSERT succeeds, second hits the unique constraint.

https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/705#detail


## Fix

Added `validates :email, uniqueness: { scope: :sponsor_id }` to Contact. Now `valid?` catches the duplicate before reaching the DB, and the controller re-renders the form with a validation error instead of a 500.

## Changes

- `app/models/contact.rb` — add uniqueness validation
- `spec/models/contact_spec.rb` — new model spec for Contact validations