### PR TITLE
chore: remove unused Google Fonts links

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,8 +21,6 @@
     = favicon_link_tag 'favicon.ico'
     = stylesheet_link_tag('application', media: 'all', data: { turbo_track: 'reload' })
     = javascript_include_tag('application', data: { turbo_track: 'reload' })
-    %link{ href: 'https://fonts.googleapis.com/css?family=Open+Sans:400,300', rel: 'stylesheet', type: 'text/css' }
-    %link{ href: 'https://fonts.googleapis.com/icon?family=Material+Icons', rel: 'stylesheet', type: 'text/css' }
 
     // this gets any content from page templates
     = content_for :head


### PR DESCRIPTION
In preparing for adopting better security headers, I discovered that these fonts are unused and dead weight (and a privacy concern).

## Problem

Two Google Fonts are loaded from `fonts.googleapis.com` in `app/views/layouts/application.html.haml`:

- **Open Sans** (`/css?family=Open+Sans:400,300`)
- **Material Icons** (`/icon?family=Material+Icons`)

This triggers requests to `fonts.googleapis.com` (serves `@font-face` CSS) and `fonts.gstatic.com` (serves the actual font files), which is a GDPR concern — user IPs and user-agent data are sent to Google without consent.

We investigated whether Fontsource or another approach was needed, but the fonts turned out to be fully unused.

## Investigation

### Both fonts are unreferenced in any CSS

| Check | Result |
|---|---|
| `font-family: 'Open Sans'` in SCSS/CSS | Not found |
| `font-family: 'Material Icons'` in SCSS/CSS | Not found |
| `@font-face` declarations | None |
| Referenced in JavaScript | Not found |
| Referenced by any gem (Bootstrap, etc.) | Not found |

Bootstrap 5 uses a **system font stack** (`system-ui, -apple-system, ...`). No custom `$font-family-*` overrides exist in the project SCSS.

### Git history confirms they're dead

**Open Sans**
- **Apr 2015** — Added to layout and used as `$body-font-family` in Foundation (`foundation_and_overrides.scss`)
- **Sep 2022** — Entire Foundation file deleted during Bootstrap 5 migration (`36758d5e`). **Last CSS reference removed.**
- **Dead for ~4 years.**

**Material Icons**
- **Feb 2019** — `<link>` added to layout (`15a70da3`)
- **Never referenced in any CSS in the project's entire history.**
- **Dead for ~7.5 years.**

**Font Awesome 5** is already self-hosted via the `font_awesome5_rails` gem — no CDN issue.
**Plausible analytics** is also self-hosted (`/js/script.js`, `/api/event`) — no GDPR concern.

## Change

Removed two `<link>` tags from `app/views/layouts/application.html.haml`. That's it — no visual change, no regression risk on the rendering front.

## GDPR Risk Resolved

| Domain | Purpose | After this PR |
|---|---|---|
| `fonts.googleapis.com` | Serves `@font-face` CSS | No longer requested |
| `fonts.gstatic.com` | Serves `.woff2` font files | No longer requested (triggered by the CSS above) |
