### PR TITLE
Switch sign-in flow from GitHub to codebar auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,7 +109,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :redirect_path
   def redirect_path
-    '/auth/github'
+    '/auth/codebar'
   end
 
   def authenticate_admin!

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -4,7 +4,7 @@ class AuthServicesController < ApplicationController
     if Rails.application.routes.recognize_path(referer_path)[:controller].in?(%w[workshops events meetings])
       session[:referer_path] = referer_path
     end
-    redirect_to '/auth/github'
+    redirect_to '/auth/codebar'
   end
 
   def create

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -13,7 +13,7 @@ class TermsAndConditionsController < ApplicationController
     # The show action skips accept_terms, but unauthenticated users can still
     # POST directly to update. Redirect to login to avoid NoMethodError on nil.
     unless logged_in?
-      redirect_to '/auth/github'
+      redirect_to '/auth/codebar'
       return
     end
 

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -43,7 +43,7 @@
             Job Board
         - if !logged_in?
           %li.nav-item
-            = link_to '/auth/github', class: 'nav-link border-0' do
+            = link_to redirect_path, class: 'nav-link border-0' do
               Sign in
         - else
           - if current_user.is_admin? || current_user.organiser? || current_user.monthlies_organiser?

--- a/app/views/terms_and_conditions/show.html.haml
+++ b/app/views/terms_and_conditions/show.html.haml
@@ -15,7 +15,7 @@
         %p
           = t('terms_and_conditions.login_required_html')
           %br
-          = link_to t('terms_and_conditions.login_link_text'), '/auth/github'
+          = link_to t('terms_and_conditions.login_link_text'), redirect_path
 
   - if logged_in? && !current_user.accepted_toc_at?
     = simple_form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
     not_logged_in: "You must be logged in to access this page."
     signing_up: "Thanks for signing up. Please fill in your details to complete the registration process."
     authentication_error: "Authentication failed. Please try again."
-    email_missing_from_provider: "We could not retrieve your email address from GitHub. Please make sure your GitHub account has a public email address and try again."
+    email_missing_from_provider: "We could not retrieve your email address. Please make sure your account has a public email address and try again."
   navigation:
     dashboard: "Dashboard"
     code_of_conduct: "Code of Conduct"
@@ -361,7 +361,7 @@ en:
     accept: "Accept"
     already_accepted_html: "You have already accepted our Code of Conduct on %{date}."
     login_required_html: "Please log in to accept our Code of Conduct."
-    login_link_text: "Log in with GitHub"
+    login_link_text: "Log in with codebar"
     messages:
       notice: "You have to accept the Terms and Conditions before you are able to proceed."
   footer:

--- a/spec/controllers/auth_services_controller_spec.rb
+++ b/spec/controllers/auth_services_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AuthServicesController do
       request.env['HTTP_REFERER'] = expected_referer_path
 
       get :new
-      expect(response).to redirect_to('/auth/github')
+      expect(response).to redirect_to('/auth/codebar')
       expect(session[:referer_path]).to eq(expected_referer_path)
     end
 
@@ -14,7 +14,7 @@ RSpec.describe AuthServicesController do
       request.env['HTTP_REFERER'] = expected_referer_path
 
       get :new
-      expect(response).to redirect_to('/auth/github')
+      expect(response).to redirect_to('/auth/codebar')
       expect(session[:referer_path]).to eq(expected_referer_path)
     end
   end

--- a/spec/fabricators/auth_service_fabricator.rb
+++ b/spec/fabricators/auth_service_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:auth_service) do
-  provider { Faker::Company.name }
+  provider 'codebar'
   uid { Fabricate.sequence(:uid) { |n| "sq#{n}" } }
 end

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature 'Accepting Terms and Conditions', type: :feature do
   context 'when a user signs up to codebar' do
     before do
-      mock_github_auth
+      mock_codebar_auth
     end
 
     scenario "they can't proceed unless they accept the ToCs" do
@@ -85,7 +85,7 @@ RSpec.feature 'Accepting Terms and Conditions', type: :feature do
       visit terms_and_conditions_path
 
       expect(page).to have_text('Please log in to accept our Code of Conduct.')
-      expect(page).to have_link('Log in with GitHub')
+      expect(page).to have_link('Log in with codebar')
     end
 
     scenario 'they see a disabled form' do

--- a/spec/features/member/login_spec.rb
+++ b/spec/features/member/login_spec.rb
@@ -3,7 +3,7 @@ RSpec.feature 'Member logging in', type: :feature do
 
   describe 'Sign up' do
     describe 'when not all required details are set' do
-      it 'handles the registration when a user does not have a name set on github' do
+      it 'handles the registration when a user does not have a name set' do
         mock_auth_hash(name: nil)
 
         visit root_path

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature 'A new student signs up', type: :feature do
   before do
-    mock_github_auth
+    mock_codebar_auth
   end
 
   scenario 'A visitor can access signups through the landing page' do

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Member portal', type: :feature do
     end
 
     it 'is redirected to sign_in page when they attempt not access the profile page' do
-      mock_github_auth
+      mock_codebar_auth
       visit profile_path
 
       expect(page).to have_current_path(terms_and_conditions_path)

--- a/spec/features/member_updating_details_spec.rb
+++ b/spec/features/member_updating_details_spec.rb
@@ -1,6 +1,6 @@
 RSpec.feature 'Update your details', type: :feature do
   before do
-    mock_github_auth
+    mock_codebar_auth
   end
 
   scenario 'A member adds a dietary restriction' do

--- a/spec/features/subscribing_to_newsletter_spec.rb
+++ b/spec/features/subscribing_to_newsletter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature 'Subscribing to the newsletter', type: :feature do
   before do
-    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
-      provider: 'github',
+    OmniAuth.config.mock_auth[:codebar] = OmniAuth::AuthHash.new(
+      provider: 'codebar',
       uid: '42',
       credentials: { token: 'Fake token' },
       info: {

--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -14,7 +14,7 @@ module LoginHelpers
       visit '/logout'
       mock_auth_hash(provider: member.auth_services.first.provider,
                      uid: member.auth_services.first.uid)
-      visit '/auth/github'
+      visit '/auth/codebar'
     else
       ApplicationController.prepend(LoginStub) unless ApplicationController < LoginStub
       LoginStub.current_user = member
@@ -37,8 +37,8 @@ module LoginHelpers
     login(member)
   end
 
-  def mock_github_auth
-    mock_auth_hash
+  def mock_codebar_auth
+    mock_auth_hash(provider: 'codebar')
   end
 
   def accept_toc

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,8 +1,8 @@
 require 'omniauth'
 
 module OmniauthMacros
-  def mock_auth_hash(name: Faker::Name.name, email: Faker::Internet.email, provider: 'github', uid: 'uid')
-    OmniAuth.config.mock_auth[:github] = {
+  def mock_auth_hash(name: Faker::Name.name, email: Faker::Internet.email, provider: 'codebar', uid: 'uid')
+    OmniAuth.config.mock_auth[provider.to_sym] = {
       provider: provider,
       uid: uid,
       info: {


### PR DESCRIPTION
## What

Now that `/auth/codebar` has been proven in production, this change routes all user-facing sign-in entry points to the codebar auth provider instead of GitHub.

## Changes

- `ApplicationController#redirect_path` now returns `/auth/codebar`.
- Navigation "Sign in" link and the Terms & Conditions login link use the helper instead of a hardcoded GitHub path.
- Remaining hardcoded redirects in `AuthServicesController#new` and `TermsAndConditionsController#update` point to `/auth/codebar`.
- Updated user-facing copy in `config/locales/en.yml` from "GitHub" to "codebar".
- Updated specs, fabricators, and OmniAuth test mocks to exercise the codebar provider.

## Verification

- `make test` passes: 1153 examples, 0 failures.
- RuboCop and HAML lint offences are pre-existing only.

## Notes

- `AuthServicesController#destroy` is intentionally unchanged; it overrides `redirect_path` to return `:services`.
- No new routes, constants, or helpers were introduced.