### PR TITLE
Update rails-html-sanitizer and loofah to fix security audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'msgpack'
 
 gem 'stripe'
 
-gem 'rails-html-sanitizer', '~> 1.7.0'
+gem 'rails-html-sanitizer', '~> 1.7.1'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -429,8 +429,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails_semantic_logger (5.0.0)
       rack
@@ -684,7 +684,7 @@ DEPENDENCIES
   pundit
   rack-mini-profiler (~> 4.0)
   rails (~> 8.1.2)
-  rails-html-sanitizer (~> 1.7.0)
+  rails-html-sanitizer (~> 1.7.1)
   rails_semantic_logger
   readline
   reline
@@ -820,7 +820,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -882,7 +882,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.2.1) sha256=93ebf1efc792c9bc47e9795259c920312d3920008dad3ae634b7a0457ffe0af8
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   rails_semantic_logger (5.0.0) sha256=0ac433d4acab1fd7c36b5b810caced6204bbaca3b52827ab7a236931869c74fc
   railties (8.1.2.1) sha256=f4d902869541af4e5b5552d726062fa59ec0fd9078f7ab87720dbd93f22c43ee
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a


### PR DESCRIPTION
## What

Fixes the Security Audit CI failure caused by known vulnerabilities in `loofah` and `rails-html-sanitizer`.

## Changes

- Bumped `rails-html-sanitizer` from `~> 1.7.0` to `~> 1.7.1` in the Gemfile.
- Updated `Gemfile.lock` so `loofah` resolves to `2.25.2` and `rails-html-sanitizer` to `1.7.1`.

## Vulnerabilities addressed

- GHSA-5qhf-9phg-95m2
- GHSA-8whx-365g-h9vv
- GHSA-9wjq-cp2p-hrgf
- GHSA-cj75-f6xr-r4g7

## Verification

- `bundle exec bundle-audit check --update` passes with no vulnerabilities found.
- `make test` passes: 1153 examples, 0 failures.