### PR TITLE
Add "Event" to all chapter pages

### DIFF
--- a/app/assets/javascripts/add-all-chapters.js
+++ b/app/assets/javascripts/add-all-chapters.js
@@ -1,0 +1,23 @@
+// "Add to all" option at the top of the chapters dropdown on the admin event
+// form. Selects every chapter so organisers don't have to pick each one.
+// Chosen only renders <option>s, so the row is injected into its dropdown.
+
+/* global $ */
+
+$(() => {
+  const $chapters = $("#event_chapter_ids");
+
+  $chapters.on("chosen:ready", () => {
+    const $addAll = $('<div class="add-all-chapters">Add to all</div>');
+    $chapters.next(".chosen-container").find(".chosen-drop").prepend($addAll);
+
+    // mousedown fires before Chosen's blur handling closes the dropdown;
+    // stopPropagation keeps Chosen's container handler from reopening it
+    $addAll.on("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      $chapters.find("option").prop("selected", true);
+      $chapters.trigger("change").trigger("chosen:updated").trigger("chosen:close");
+    });
+  });
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require pickadate/picker.date
 //= require pickadate/picker.time
 //= require subscriptions-toggle
+//= require add-all-chapters
 //= require invitations
 //= require dietary-restrictions
 //= require cocoon

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -26,6 +26,16 @@ form .hint {
   margin-bottom: 1.14286rem;
 }
 
+.add-all-chapters {
+  cursor: pointer;
+  font-weight: bold;
+  padding: 8px 6px 4px;
+}
+
+.add-all-chapters:hover {
+  color: #1e90ff;
+}
+
 .small-image {
   max-height: 100px;
 }

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -17,6 +17,20 @@ RSpec.feature 'Managing events', type: :feature do
     expect(page).to have_text event.venue.name
   end
 
+  scenario 'adding all chapters to an event with one click', :js do
+    Fabricate.times(2, :chapter)
+    visit edit_admin_event_path(event)
+
+    find_by_id('event_chapter_ids_chosen').click
+    find('.add-all-chapters', text: 'Add to all').click
+    expect(page).to have_no_css('#event_chapter_ids_chosen.chosen-with-drop')
+
+    click_on 'Save'
+
+    expect(page).to have_text('You have just updated the event')
+    expect(event.reload.chapter_ids).to match_array(Chapter.ids)
+  end
+
   scenario 'verifying an attendance' do
     invitation = Fabricate(:invitation, event: event, attending: true)
     visit admin_event_path(event)
@@ -34,7 +48,7 @@ RSpec.feature 'Managing events', type: :feature do
     click_on 'Cancel'
 
     expect(page).to have_text "You have cancelled #{invitation.member.full_name}'s attendance."
-    expect(invitation.reload.attending).to eq(false)
+    expect(invitation.reload.attending).to be(false)
   end
 
   scenario 'accessing a list of attendee emails' do


### PR DESCRIPTION
## Description

Adds an "Add to all" option at the top of the Chapters dropdown on the admin event form, so organisers can invite every chapter with one click instead of ticking each chapter individually.

This implements option 2 from the discussion on the issue (the in-dropdown "Add to all" entry), which @KimberleyCook preferred.

Closes #2490

## Changes

- New `add-all-chapters.js`: injects a bold "Add to all" row at the top of the Chosen dropdown for the chapters field. Clicking it selects every chapter, refreshes the widget, and closes the dropdown.
- Small style block in `main.scss` for the new row (bold, pointer cursor, hover highlight).
- Playwright feature spec covering the flow end-to-end: open the dropdown, click "Add to all", verify the dropdown closes, save, and assert the event is linked to every chapter.

## How to test

1. Sign in as an admin and open `/admin/events/new` (or edit an existing event).
2. Scroll to **Invitation details → Chapters** and click into the field.
3. Click the bold **Add to all** entry at the top of the dropdown.
4. All chapters are selected and the dropdown closes.

Or run the spec:

```
bundle exec rspec spec/features/admin/manage_event_spec.rb
```
