### PR TITLE
Background colour on social links in emails not working

### DIFF
--- a/app/views/shared_mailers/_social.html.haml
+++ b/app/views/shared_mailers/_social.html.haml
@@ -8,12 +8,14 @@
           %td
 
             %h5 Connect with us:
+            -# background-color is inlined on each link because email clients only
+            -# reliably render inline styles; see issue #2634
             %p
-              %a{ href: "https://slack.codebar.io/", class: 'soc-btn sl'} Join us on Slack
-              %a{ href: "https://www.linkedin.com/company/codebarcommunity", class: "soc-btn li" } Follow us on LinkedIn
-              %a{ href: "https://www.facebook.com/codebarHQ", class: 'soc-btn fb'} Follow us on Facebook
-              %a{ href: "https://bsky.app/profile/codebar.bsky.social", class: "soc-btn bs" } Follow us on Bluesky
-              %a{ href: "https://www.youtube.com/channel/UCEYz232agE47GHUq8wneBCA", class: "soc-btn yt" } Follow us on YouTube
+              %a{ href: "https://slack.codebar.io/", class: 'soc-btn sl', style: 'background-color: #2EB67D;' } Join us on Slack
+              %a{ href: "https://www.linkedin.com/company/codebarcommunity", class: "soc-btn li", style: 'background-color: #0077B5;' } Follow us on LinkedIn
+              %a{ href: "https://www.facebook.com/codebarHQ", class: 'soc-btn fb', style: 'background-color: #3B5998;' } Follow us on Facebook
+              %a{ href: "https://bsky.app/profile/codebar.bsky.social", class: "soc-btn bs", style: 'background-color: #1daced;' } Follow us on Bluesky
+              %a{ href: "https://www.youtube.com/channel/UCEYz232agE47GHUq8wneBCA", class: "soc-btn yt", style: 'background-color: #FF0000;' } Follow us on YouTube
              
 
 

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -110,6 +110,17 @@ RSpec.describe WorkshopInvitationMailer do
     expect(email.body.encoded).to match(workshop.chapter.email)
   end
 
+  it '#invite_student renders social links with inline background colours' do
+    # asserts on the template output before premailer runs, so the colours
+    # don't depend on email.css being resolved (see issue #2634)
+    mail = described_class.invite_student(workshop, member, invitation)
+
+    html = mail.body.decoded
+    ['#2EB67D', '#0077B5', '#3B5998', '#1daced', '#FF0000'].each do |colour|
+      expect(html).to include("background-color: #{colour}")
+    end
+  end
+
   it '#attending renders workshop description as HTML, not escaped' do
     description = '<strong>Important notice:</strong> Please bring a laptop.'
     workshop = Fabricate(:workshop, description: description)


### PR DESCRIPTION
## Description

Inlines the `background-color` on each social link in `shared_mailers/_social.html.haml`, so the buttons in email footers render with their colours regardless of which version of `email.css` gets inlined by premailer.

Closes #2634

## Root cause

Production emails have been inlining a **stale copy of `/assets/email.css`** — the undigested URL that was hard-coded in the mailer header until #2715. codebar.io still serves a pre-November-2024 version of that file (verified byte-for-byte against git history), cached with `Cache-Control: public, max-age=31556952`. That version only has background rules for `a.fb` and `a.tw`, so only the Facebook button gets a colour with today's markup  exactly what the screenshots on #2634 and #2437 show. This is also why the fix in #2437 didn't take effect: it changed the source file, but emails kept inlining the stale cached copy.

Full write-up in [this comment on the issue](https://github.com/codebar/planner/issues/2634#issuecomment-5070822261).

## Why inline styles

Email clients only reliably render inline styles, and critical visual styles in emails shouldn't depend on a separately fetched stylesheet. With the colours inline in the template, the buttons are correct even if `email.css` resolution fails or serves stale content. The CSS rules remain as a fallback.

## How this was tested

- Reproduced the production bug locally: rendered the mailer preview against the actual stale CSS downloaded from codebar.io, only Facebook got a background, matching the issue screenshots.
- Re-rendered with this fix against the **same stale CSS**,  all five buttons get their colours.
- Added a mailer spec asserting the rendered template carries an inline `background-color` for each social link (it asserts pre-premailer output, so it fails if the colours ever move back to being stylesheet-only).
- `bundle exec rspec spec/mailers/workshop_invitation_mailer_spec.rb` 14 examples, 0 failures. RuboCop clean on the changed lines.
