### PR TITLE
fix(js): use Bootstrap 5 vanilla API for tooltips

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -152,5 +152,7 @@ $(function() {
     no_results_text: 'No results matched'
   });
 
-  $('[data-bs-toggle="tooltip"]').tooltip();
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+    new bootstrap.Tooltip(el);
+  });
 });

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -58,8 +58,8 @@ RSpec.feature 'Managing meetings', type: :feature do
       click_on 'Save'
 
       expect(page).to have_text('You have successfully updated the details of this meeting')
-      expect(page).to have_css(%(span[title="#{permissions.members.last.full_name}"]))
-      expect(page).to have_no_css(%(span[title="#{permissions.members.first.full_name}"]))
+      expect(page).to have_css(%(img[alt="#{permissions.members.last.full_name}"]))
+      expect(page).to have_no_css(%(img[alt="#{permissions.members.first.full_name}"]))
     end
 
     scenario 'adding an organiser', :js do
@@ -71,7 +71,7 @@ RSpec.feature 'Managing meetings', type: :feature do
 
       click_on 'Save'
 
-      expect(page).to have_css(%(span[title="#{new_organiser.full_name}"]))
+      expect(page).to have_css(%(img[alt="#{new_organiser.full_name}"]))
     end
   end
 


### PR DESCRIPTION
Unblocks local verification of #2721.

## Problem

`$('[data-bs-toggle="tooltip"]').tooltip()` is not a function in Bootstrap 5, because the `bootstrap` gem ships vanilla JS rather than jQuery plugins. The resulting `TypeError` aborts the `$(function() {...})` callback in `application.js` before Chosen is initialised, which breaks any feature that depends on Chosen (e.g. the admin event chapters dropdown).

## Change

- Replace the jQuery tooltip call with Bootstrap 5's vanilla API in `app/assets/javascripts/application.js`.
- Update `spec/features/admin/meeting_spec.rb` to assert the organiser avatar's `alt` text instead of the tooltip `title` attribute. Bootstrap 5's Tooltip constructor moves `title` to `data-bs-original-title` and removes the original attribute, so the previous assertion only passed while tooltips were broken.

## Verification

- JS syntax check passes.
- `bundle exec rspec spec/features/admin/meeting_spec.rb --seed 6016` — 9 examples, 0 failures.
- `bundle exec parallel_rspec spec/ -n 6 --only-group 4 --test-options '--seed 6016'` — 175 examples, 0 failures.
- All CI groups pass.

## Related

- Unblocks local verification of #2721.
- Fixes the CI failure where `span[title="..."]` could no longer be found after tooltips were correctly initialised.
