### PR TITLE
test: make TomSelect helper more robust against focus races

### DIFF
--- a/spec/support/select_from_tom_select.rb
+++ b/spec/support/select_from_tom_select.rb
@@ -12,9 +12,11 @@ module SelectFromTomSelect
     # CDN script (loaded in the page head) defines the TomSelect global.
     expect(page).to have_css('.ts-wrapper', wait: 15)
 
-    # Open dropdown and type search query
+    # Open dropdown and focus the input. The click on .ts-control opens the
+    # dropdown; a second click on the input guarantees focus before typing.
     find('.ts-control').click
     input = find('.ts-control input')
+    input.click
 
     # Type first 3 characters to trigger search (shouldLoad requires >= 3)
     input.send_keys(item_text[0, 3])


### PR DESCRIPTION
This PR hardens `select_from_tom_select` against the flaky failure seen in CI:

```
expected to find css ".ts-dropdown .option" but there were no matches
```

The helper now clicks the input explicitly after opening the dropdown, so the search keys are sent to a focused field. This should remove the race where the dropdown was opened but the input had not received focus before typing.

Verification:
- `spec/features/admin/meeting_spec.rb:65` (the failing example) passes with the CI seed `54204` and five additional seeds.
- All specs that use `select_from_tom_select` pass locally.
