### PR TITLE
fix: switch event invitations to async delivery to prevent timeout on large chapters

### DIFF
--- a/app/services/invitation_manager.rb
+++ b/app/services/invitation_manager.rb
@@ -4,6 +4,9 @@ class InvitationManager
 
     invite_coaches_to_event(event, chapter) unless event.audience.eql?('Students')
     invite_students_to_event(event, chapter) unless event.audience.eql?('Coaches')
+  rescue StandardError => e
+    Rollbar.error(e, event_id: event.id, chapter_id: chapter.id)
+    raise
   end
   handle_asynchronously :send_event_emails
 
@@ -120,7 +123,7 @@ class InvitationManager
       invitation = Invitation.new(event: event, member: student, role: 'Student')
       next unless invitation.save
 
-      EventInvitationMailer.invite_student(event, student, invitation).deliver_now
+      EventInvitationMailer.invite_student(event, student, invitation).deliver_later
     rescue StandardError => e
       log_event_meeting_invitation_failure("event_id=#{event.id}", student, e)
     end
@@ -131,7 +134,7 @@ class InvitationManager
       invitation = Invitation.new(event: event, member: coach, role: 'Coach')
       next unless invitation.save
 
-      EventInvitationMailer.invite_coach(event, coach, invitation).deliver_now
+      EventInvitationMailer.invite_coach(event, coach, invitation).deliver_later
     rescue StandardError => e
       log_event_meeting_invitation_failure("event_id=#{event.id}", coach, e)
     end

--- a/spec/services/invitation_manager_spec.rb
+++ b/spec/services/invitation_manager_spec.rb
@@ -112,6 +112,27 @@ RSpec.describe InvitationManager do
 
       manager.send_event_emails(event, chapter)
     end
+
+    it 'sends invitation emails for all eligible members' do
+      event = Fabricate(:event, chapters: [chapter])
+
+      expect do
+        manager.send_event_emails(event, chapter)
+      end.to change { ActionMailer::Base.deliveries.count }.by(students.count + coaches.count)
+    end
+
+    it 'reports batch-level failures to Rollbar' do
+      event = Fabricate(:event, chapters: [chapter])
+      allow(event).to receive(:invitable?).and_raise(StandardError.new('DB connection error'))
+
+      expect(Rollbar).to receive(:error).with(
+        an_instance_of(StandardError),
+        event_id: event.id,
+        chapter_id: chapter.id
+      )
+
+      expect { manager.send_event_emails(event, chapter) }.to raise_error(StandardError, 'DB connection error')
+    end
   end
 
   describe '#send_monthly_attendance_reminder_emails' do


### PR DESCRIPTION
## Description

Fixes #2758

`InvitationManager#send_event_emails` sends one email at a time using `deliver_now` in a synchronous loop. For a chapter like London (~4,300 eligible members), this takes ~40 minutes — past both DelayedJob's 9-minute max run time and the Heroku Scheduler dyno timeout.

This PR switches to `deliver_later` (matching the existing workshop pattern), so each email becomes its own DJ job with an independent 9-minute timeout. The outer job finishes in seconds (just creating records + enqueuing).

## Changes

- `app/services/invitation_manager.rb`: `deliver_now` to `deliver_later` in both `invite_students_to_event` and `invite_coaches_to_event`; wrap outer method in Rollbar rescue for production visibility
- `spec/services/invitation_manager_spec.rb`: add tests for email delivery count and Rollbar error reporting

## Test coverage

1158 examples, 0 failures across the full suite.