### PR TITLE
style: remove redundant rubocop disable comment

### DIFF
--- a/spec/support/shared_examples/behaves_like_email_with_social_links.rb
+++ b/spec/support/shared_examples/behaves_like_email_with_social_links.rb
@@ -1,5 +1,4 @@
 RSpec.shared_examples 'email with social link colours' do
-  # rubocop:disable RSpec/MultipleExpectations
   it 'inlines social link background colours from the stylesheet' do
     send_email
 
@@ -12,5 +11,4 @@ RSpec.shared_examples 'email with social link colours' do
     expect(html).to match(/background-color: (red|#FF0000)/i)
     expect(html).not_to include('/assets/email.css')
   end
-  # rubocop:enable RSpec/MultipleExpectations
 end


### PR DESCRIPTION
Fixes a pre-existing RuboCop violation on master.

`Lint/RedundantCopDisableDirective` flagged `spec/support/shared_examples/behaves_like_email_with_social_links.rb` — the `RSpec/MultipleExpectations` disable was unnecessary because the test has 6 expectations, below the configured max of 8.