### PR TITLE
Add Gravatar hint to email field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -709,7 +709,7 @@ en:
         note: "e.g. I am a Junior and would prefer to not be paired on advanced projects"
     hints:
       member:
-        email: "This is needed so we can email you invitations to our events"
+        email: "This is needed so we can email you invitations to our events. codebar uses Gravatar for profile pictures — if you change your email, add your new email to your Gravatar account to keep your photo."
         skill_list: "Enter as a comma separated list"
       workshop_invitation:
         note: "Pairing preferences or anything else you think we should know."


### PR DESCRIPTION
## What

When a user changes their email address in profile settings, their avatar disappears because Gravatar links avatars to email addresses. The system works correctly, but this confuses members.

## Change

Updated the hint text on the email input field (both `/member/edit` and `/member/details/edit`) to explain this:

> codebar uses Gravatar for profile pictures — if you change your email, add your new email to your Gravatar account to keep your photo.

This is a one-line locale change in `config/locales/en.yml` — Simple Form renders it automatically on both forms. No view changes needed.

## Screenshots

<img width="1185" height="1844" alt="member-details-edit-page" src="https://github.com/user-attachments/assets/00fce44a-7631-432c-8fb6-738860ba3f93" />

<img width="1185" height="1529" alt="member-edit-page" src="https://github.com/user-attachments/assets/ae118a58-04b3-48b4-9f35-67d37f4c4087" />

## Issue

Closes #2755