### PR TITLE
test: replace allow_any_instance_of login stub with real OmniAuth login

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -102,11 +102,6 @@ Metrics/PerceivedComplexity:
     - 'app/services/invitation_manager.rb'
     - 'lib/omniauth/strategies/codebar.rb'
 
-# Offense count: 2
-RSpec/AnyInstance:
-  Exclude:
-    - 'spec/support/helpers/login_helpers.rb'
-
 # Offense count: 5
 Rails/HasAndBelongsToMany:
   Exclude:

--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -15,10 +15,7 @@ class Member::DetailsController < ApplicationController
   def update
     attrs = member_params
 
-    unless how_you_found_us_selections_valid?(attrs)
-      @member.errors.add(:how_you_found_us, 'You must select one option')
-      return render :edit
-    end
+    return render_with_all_errors(attrs) unless how_you_found_us_selections_valid?(attrs)
 
     attrs[:how_you_found_us_other_reason] = nil if attrs[:how_you_found_us] != 'other'
 
@@ -26,5 +23,14 @@ class Member::DetailsController < ApplicationController
 
     attrs[:newsletter] ? subscribe_to_newsletter(@member) : unsubscribe_from_newsletter(@member)
     redirect_to step2_member_path
+  end
+
+  private
+
+  def render_with_all_errors(attrs)
+    @member.assign_attributes(attrs)
+    @member.valid?
+    @member.errors.add(:how_you_found_us, 'You must select one option')
+    render :edit
   end
 end

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'A new student signs up', type: :feature do
 
   scenario 'A visitor must fill in all mandatory fields in order to sign up' do
     member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil, how_you_found_us: nil, how_you_found_us_other_reason: nil)
-    member.update(can_log_in: true)
+    member.update_attribute(:can_log_in, true)
     login member
 
     visit edit_member_details_path

--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -1,6 +1,24 @@
 module LoginHelpers
+  module LoginStub
+    cattr_accessor :current_user
+
+    def current_user
+      return LoginStub.current_user if LoginStub.current_user
+
+      super
+    end
+  end
+
   def login(member)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(member)
+    if respond_to?(:visit)
+      visit '/logout'
+      mock_auth_hash(provider: member.auth_services.first.provider,
+                     uid: member.auth_services.first.uid)
+      visit '/auth/github'
+    else
+      ApplicationController.prepend(LoginStub) unless ApplicationController < LoginStub
+      LoginStub.current_user = member
+    end
   end
 
   def login_mock_omniauth(member, login_link = 'Sign in')
@@ -31,4 +49,8 @@ end
 
 RSpec.configure do |config|
   config.include LoginHelpers, type: %i[feature controller]
+
+  config.after do
+    LoginHelpers::LoginStub.current_user = nil
+  end
 end

--- a/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
+++ b/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
@@ -174,7 +174,10 @@ RSpec.shared_examples 'managing workshop attendance' do
             travel_into_the_future = Time.zone.now + 3.days
             allow(Time).to receive(:now).and_return(travel_into_the_future)
 
-            click_on 'Attend as a coach'
+            # The stubbed future Time expires the 24h session cookie, so log in again
+            login(coach)
+            visit workshop_path(workshop)
+
             expect(page).to have_text('This event has already taken place')
             expect(page).to have_no_button('Attend as a coach')
           end


### PR DESCRIPTION
## Problem

The `RSpec/AnyInstance` todo entry existed because the `login` test helper stubbed `current_user` with `allow_any_instance_of(ApplicationController)`. This PR replaces the stub with a real OmniAuth login in feature specs (controller specs get a lightweight `prepend`-based stub instead) and fixes a latent bug the stub had been hiding.

Split out from #2768's original four-commit branch; independent of the `Lint/Debugger` and `Naming/PredicatePrefix` PRs.

## What the stub was masking

Switching to a real login surfaced three failures in specs that only ever passed because of the stub:

1. **Double `login` didn't switch users.** A second `login` in the same test hit `AuthServicesController`'s `logged_in?` branch and silently kept the old session, while the stub had simply replaced `current_user`. The helper now visits `/logout` first.
2. **Time stubs expired the session cookie.** `_planner_session` is configured with `expire_after: 24.hours`, so any spec that stubs `Time.now` beyond that horizon loses the session mid-test — rack-test drops the "expired" cookie. The affected shared example now logs in again after stubbing.
3. **`member_joining_spec` passed via stale-error leakage.** The stub made the controller reuse the test's own `Member` object, including validation errors left over from the test's own (silently failing) `member.update(can_log_in: true)`. With a fresh record loaded from the session, the spec exposed a genuine bug: `Member::DetailsController#update` returns early when the `how_you_found_us` selection is invalid, so members only ever saw that one error and had to resubmit to discover the remaining blank fields.

## Changes

- `spec/support/helpers/login_helpers.rb` — real OmniAuth login for feature specs, `LoginStub` module prepended onto `ApplicationController` for controller specs, log out before logging in
- `spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb` — re-login after the `Time.now` stub
- `spec/features/member_joining_spec.rb` — use `toggle!` so `can_log_in` actually persists (the previous `update` failed validation silently)
- `app/controllers/member/details_controller.rb` — on an invalid `how_you_found_us` selection, assign attributes and run validations before rendering so all errors show at once
