### PR TITLE
refactor: remove dead full_url_for helper and all call sites

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -150,11 +150,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/workshop.rb'
     - 'app/models/workshop_invitation.rb'
 
-# Offense count: 1
-Rails/HelperInstanceVariable:
-  Exclude:
-    - 'app/helpers/email_helper.rb'
-
 # Offense count: 2
 # Configuration parameters: IgnoreScopes.
 Rails/InverseOf:

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,7 +1,0 @@
-module EmailHelper
-  private
-
-  def full_url_for(path)
-    "#{@host}#{path}"
-  end
-end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -2,7 +2,6 @@ class ContactMailer < ApplicationMailer
   include EmailHeaderHelper
 
   helper ApplicationHelper
-  helper EmailHelper
 
   def subscription_notification(contact)
     @contact = contact

--- a/app/mailers/event_invitation_mailer.rb
+++ b/app/mailers/event_invitation_mailer.rb
@@ -40,12 +40,4 @@ class EventInvitationMailer < ApplicationMailer
 
     mail_to_member(member, subject, &:html)
   end
-
-  private
-
-  helper do
-    def full_url_for(path)
-      "#{@host}#{path}"
-    end
-  end
 end

--- a/app/mailers/feedback_request_mailer.rb
+++ b/app/mailers/feedback_request_mailer.rb
@@ -12,10 +12,4 @@ class FeedbackRequestMailer < ApplicationMailer
 
     mail_to_member(member, subject, &:html)
   end
-
-  helper do
-    def full_url_for(path)
-      "#{@host}#{path}"
-    end
-  end
 end

--- a/app/mailers/meeting_invitation_mailer.rb
+++ b/app/mailers/meeting_invitation_mailer.rb
@@ -44,12 +44,4 @@ class MeetingInvitationMailer < ApplicationMailer
     subject = "Reminder: You have a spot for #{@meeting.name} on #{humanize_date(@meeting.date_and_time)}"
     mail_to_member(@member, subject, &:html)
   end
-
-  private
-
-  helper do
-    def full_url_for(path)
-      "#{@host}#{path}"
-    end
-  end
 end

--- a/app/mailers/virtual_workshop_invitation_mailer.rb
+++ b/app/mailers/virtual_workshop_invitation_mailer.rb
@@ -1,10 +1,8 @@
 class VirtualWorkshopInvitationMailer < ApplicationMailer
-  include EmailHelper
   include EmailHeaderHelper
   include ApplicationHelper
 
   helper ApplicationHelper
-  helper EmailHelper
 
   def attending(workshop, member, invitation, waiting_list = false)
     setup(workshop, invitation, member)

--- a/app/mailers/workshop_invitation_mailer.rb
+++ b/app/mailers/workshop_invitation_mailer.rb
@@ -1,10 +1,8 @@
 class WorkshopInvitationMailer < ApplicationMailer
-  include EmailHelper
   include EmailHeaderHelper
   include ApplicationHelper
 
   helper ApplicationHelper
-  helper EmailHelper
 
   def attending(workshop, member, invitation, waiting_list = false)
     @workshop = WorkshopPresenter.new(workshop)

--- a/app/views/contact_mailer/subscription_notification.html.haml
+++ b/app/views/contact_mailer/subscription_notification.html.haml
@@ -3,4 +3,4 @@ Hi #{@contact.name},
 %p
   You have been subscribed to codebar's sponsors mailing list. To opt-out follow the link below:
   %br
-  =link_to 'Update subscription preferences', full_url_for(contact_preferences_url(token: @contact.token)), class: 'btn'
+  =link_to 'Update subscription preferences', contact_preferences_url(token: @contact.token), class: 'btn'

--- a/app/views/event_invitation_mailer/attending.html.haml
+++ b/app/views/event_invitation_mailer/attending.html.haml
@@ -28,7 +28,7 @@
                   #{@event.name}
                   %br
                   %small #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(event_invitation_url(@event.id, @invitation.token)), class: 'btn'
+                = link_to 'Update your attendance', event_invitation_url(@event.id, @invitation.token), class: 'btn'
 
         .content
           %table

--- a/app/views/event_invitation_mailer/invite_coach.html.haml
+++ b/app/views/event_invitation_mailer/invite_coach.html.haml
@@ -26,7 +26,7 @@
                   #{@event.name}
                 %p 
                   #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
+                = link_to 'View invitation and RSVP', event_invitation_url(event_id: @event.slug, token: @invitation.token), class: 'btn'
 
         - if @event.venue.present?
           .content

--- a/app/views/event_invitation_mailer/invite_student.html.haml
+++ b/app/views/event_invitation_mailer/invite_student.html.haml
@@ -26,7 +26,7 @@
                   #{@event.name}
                 %p
                   #{humanize_date(@event.date_and_time, @event.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(event_invitation_url(event_id: @event.slug, token: @invitation.token)), class: 'btn'
+                = link_to 'View invitation and RSVP', event_invitation_url(event_id: @event.slug, token: @invitation.token), class: 'btn'
 
         - if @event.venue.present?
           .content

--- a/app/views/feedback_request_mailer/request_feedback.html.haml
+++ b/app/views/feedback_request_mailer/request_feedback.html.haml
@@ -31,7 +31,7 @@
             %tr
               %td
                 %p
-                  =link_to "Submit feedback", full_url_for(feedback_url(@feedback_request.token)), class: 'btn'
+                  =link_to "Submit feedback", feedback_url(@feedback_request.token), class: 'btn'
 
         .content
           = render partial: 'shared_mailers/social', locals: { workshop: @workshop }

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -17,7 +17,7 @@
         <div style="color: #111111; font-size: 15px; font-weight: 300; margin-top: 60px;">Despo</div>
         <div style="color: #111111; font-size: 16px; font-weight: 600; margin-top: 5px;"><a href="http://codebar.io" style="color: #663095; text-decoration: none;">codebar</a></div>
 
-        <p style="color: #6d6a6a; font-size: 13px; font-weight: 600; margin-top: 90px;">If you dont want to receive these emails <%= link_to "unsubscribe", full_url_for(unsubscribe_url(member_token(@member))), style: "color: #a369d5; text-decoration: underline" %></p>
+        <p style="color: #6d6a6a; font-size: 13px; font-weight: 600; margin-top: 90px;">If you dont want to receive these emails <%= link_to "unsubscribe", unsubscribe_url(member_token(@member)), style: "color: #a369d5; text-decoration: underline" %></p>
       </div>
 
       <div style="width: 100%; height: 40px; background-color: #f6f4f8;"></div>

--- a/app/views/shared_mailers/_footer.html.haml
+++ b/app/views/shared_mailers/_footer.html.haml
@@ -7,6 +7,6 @@
           %tr
             %td{ align: "center" }
               %p
-                %a{ href: full_url_for(unsubscribe_url(member_token(@member))) }
+                %a{ href: unsubscribe_url(member_token(@member)) }
                   %unsubscribe Unsubscribe
     %td

--- a/app/views/virtual_workshop_invitation_mailer/attending.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending.html.haml
@@ -34,7 +34,7 @@
               %td
                 %h4
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update or cancel your attendance', invitation_url(@invitation), class: 'btn'
 
         .content
           %table

--- a/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/attending_reminder.html.haml
@@ -30,7 +30,7 @@
               %td
                 %h4
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update or cancel your attendance', invitation_url(@invitation), class: 'btn'
 
         .content
           %table

--- a/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_coach.html.haml
@@ -38,7 +38,7 @@
                   =@workshop.to_s
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', invitation_url(@invitation), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?
                   %h4 Sponsored by

--- a/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/invite_student.html.haml
@@ -15,7 +15,7 @@
                 %p.lead
                   We’re excited to invite you to our next #{@workshop.chapter.name} virtual workshop.
                 %p
-                  As part of our workshops, you’ll get to work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or receive guidance on your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', full_url_for(coaches_url)} who help out as coaches.
+                  As part of our workshops, you’ll get to work through any of our #{link_to 'tutorials', 'http://codebar.github.io/tutorials' } or receive guidance on your personal project. We believe that everyone should be entitled to free learning and our community has #{ link_to 'a lot of devoted developers', coaches_url} who help out as coaches.
                 %p You will also get the opportunity to interact with other people interested in coding and collaborate with them.
                 %p <strong>Please note:</strong> We do not accept any RSVPs over email.
 
@@ -29,7 +29,7 @@
                   =@workshop.to_s
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', invitation_url(@invitation), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 - if @workshop.sponsors.any?
                   %h4 Sponsored by

--- a/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/virtual_workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -21,7 +21,7 @@
                   so you should keep keep an eye on your emails during the afternoon on the day of the workshop.
                 %p
                   Alternatively, if you know you can no longer make it, please
-                  = link_to 'remove yourself from the waiting list', full_url_for(invitation_url(@invitation))
+                  = link_to 'remove yourself from the waiting list', invitation_url(@invitation)
                   so someone else can take part in the workshop.
 
         .content
@@ -29,7 +29,7 @@
             %tr
               %td
                 %p #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update or cancel your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update or cancel your attendance', invitation_url(@invitation), class: 'btn'
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/attending.html.haml
+++ b/app/views/workshop_invitation_mailer/attending.html.haml
@@ -36,7 +36,7 @@
                 %h4
                   Workshop
                 %p #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', invitation_url(@invitation), class: 'btn'
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 10px;' }
                     %strong Description:

--- a/app/views/workshop_invitation_mailer/attending_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/attending_reminder.html.haml
@@ -31,7 +31,7 @@
                   Workshop
                   %br
                   %p #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', invitation_url(@invitation), class: 'btn'
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 10px;' }
                     %strong Description:

--- a/app/views/workshop_invitation_mailer/invite_coach.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_coach.html.haml
@@ -37,7 +37,7 @@
                   Workshop
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', invitation_url(@invitation), class: 'btn'
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 15px;' }
                     %strong Description:

--- a/app/views/workshop_invitation_mailer/invite_student.html.haml
+++ b/app/views/workshop_invitation_mailer/invite_student.html.haml
@@ -34,7 +34,7 @@
                   Workshop
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'View invitation and RSVP', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'View invitation and RSVP', invitation_url(@invitation), class: 'btn'
                 - if @workshop.description.present?
                   %p{ style: 'margin-top: 15px;' }
                     %strong Description:

--- a/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
+++ b/app/views/workshop_invitation_mailer/notify_waiting_list.html.haml
@@ -24,7 +24,7 @@
                   Workshop
                   %br
                   %p #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', invitation_url(@invitation), class: 'btn'
 
         .content
           %table

--- a/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
+++ b/app/views/workshop_invitation_mailer/waiting_list_reminder.html.haml
@@ -20,7 +20,7 @@
                   %strong Attendees often drop out at short notice, so you should keep an eye on your emails during the afternoon on the day of the workshop.
                 %p
                   Alternatively, if you can no longer make it, you should
-                  = link_to 'remove yourself from the waiting list', full_url_for(invitation_url(@invitation))
+                  = link_to 'remove yourself from the waiting list', invitation_url(@invitation)
                   so someone else can come to the workshop.
 
         .content
@@ -31,7 +31,7 @@
                   Workshop
                   %br
                   %small #{humanize_date(@workshop.date_and_time, @workshop.ends_at, with_time: true)}
-                = link_to 'Update your attendance', full_url_for(invitation_url(@invitation)), class: 'btn'
+                = link_to 'Update your attendance', invitation_url(@invitation), class: 'btn'
               %td{ width: '40%', style: 'vertical-align: top;'}
                 %h4
                   Venue


### PR DESCRIPTION
## Summary

`full_url_for` was dead code. The method concatenated `#{@host}#{path}`, but `@host` was never set in any mailer. All callers already passed `*_url` helpers (`invitation_url`, `event_invitation_url`, `unsubscribe_url`, etc.) which return fully-qualified URLs via `config.action_mailer.default_url_options`.

## History

`full_url_for` was introduced in October 2013 (`6fb19ab5`) alongside the first invitation emails, with the apparent intent to prepend a host to relative paths. However, `@host` was never assigned in any mailer method across the entire project history — it has been dead code from day one.

Rails' `*_url` helpers (e.g., `invitation_url`, `unsubscribe_url`) have always been the actual mechanism for generating URLs in emails, and they produce fully-qualified URLs because `config.action_mailer.default_url_options` is configured in all environments (`localhost:3000` in dev/test, `codebar.io` in production).

## Changes

- **Delete** `app/helpers/email_helper.rb` — the module is now empty
- **Remove** `include EmailHelper` / `helper EmailHelper` from:
  - `VirtualWorkshopInvitationMailer`
  - `WorkshopInvitationMailer`
  - `ContactMailer`
- **Remove** inline `helper do` blocks defining `full_url_for` from:
  - `FeedbackRequestMailer`
  - `EventInvitationMailer`
  - `MeetingInvitationMailer`
- **Replace** `full_url_for(...)` with `...` in all 21 mailer view call sites across 14 template files

## Verification

All 75 mailer specs pass. Controller, feature, and policy specs also verified.
