### PR TITLE
style(rubocop): resolve Lint/Debugger todo entry

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Configuration parameters: DebuggerMethods, DebuggerRequires.
-Lint/Debugger:
-  Exclude:
-    - 'spec/spec_helper.rb'
-
 # Offense count: 32
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
 Metrics/AbcSize:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,7 +106,9 @@ RSpec.configure do |config|
       screenshot_filename = "#{filename}:#{line_number}.png"
 
       # Save the screenshot using the custom filename
+      # rubocop:disable Lint/Debugger
       page.save_screenshot(screenshot_filename)
+      # rubocop:enable Lint/Debugger
     end
   end
 


### PR DESCRIPTION
## Problem

The `Lint/Debugger` todo entry excluded all of `spec/spec_helper.rb` because the cop flags `page.save_screenshot` — a false positive, since Capybara's `save_screenshot` matches the cop's default `DebuggerMethods` pattern (`save_screenshot` is a pry-family method name).

## Solution

Drop the file-wide exclusion from `.rubocop_todo.yml` and disable the cop inline around the single call site instead, so the rest of `spec_helper.rb` gets linted again.

Split out from #2768; independent of the other RuboCop PRs.