### PR TITLE
style(rubocop): resolve Naming/PredicatePrefix todo entry

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -108,21 +108,6 @@ Metrics/PerceivedComplexity:
     - 'app/services/invitation_manager.rb'
     - 'lib/omniauth/strategies/codebar.rb'
 
-# Offense count: 10
-# Configuration parameters: NamePrefix, ForbiddenPrefixes, AllowedMethods, MethodDefinitionMacros, UseSorbetSigs.
-# NamePrefix: is_, has_, have_, does_
-# ForbiddenPrefixes: is_, has_, have_, does_
-# AllowedMethods: is_a?
-# MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicatePrefix:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/models/workshop.rb'
-    - 'app/policies/application_policy.rb'
-    - 'app/policies/chapter_policy.rb'
-    - 'app/policies/event_policy.rb'
-    - 'app/policies/workshop_policy.rb'
-
 # Offense count: 2
 RSpec/AnyInstance:
   Exclude:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -127,15 +127,15 @@ class ApplicationController < ActionController::Base
   helper_method :manager?
   helper_method :admin_namespace?
 
-  def is_logged_in?
+  def require_login
     unless logged_in?
       flash[:notice] = t('notifications.not_logged_in')
       redirect_to root_path
     end
   end
 
-  def has_access?
-    is_logged_in?
+  def require_access
+    require_login
   end
 
   def admin_namespace?

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,5 @@
 class DashboardController < ApplicationController
-  before_action :is_logged_in?, only: %i[dashboard]
+  before_action :require_login, only: %i[dashboard]
   skip_before_action :accept_terms, except: %i[dashboard show]
 
   helper_method :year_param

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 require 'services/ticket'
 
 class EventsController < ApplicationController
-  before_action :is_logged_in?, only: %i[student coach]
+  before_action :require_login, only: %i[student coach]
 
   def index
     redirect_to upcoming_events_path

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,5 +1,5 @@
 class InvitationsController < ApplicationController
-  before_action :is_logged_in?, only: [:index]
+  before_action :require_login, only: [:index]
   before_action :set_invitation, only: %i[show attend reject]
 
   def index

--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -1,7 +1,7 @@
 class MailingListsController < ApplicationController
   include MailingListConcerns
 
-  before_action :has_access?
+  before_action :require_access
 
   def create
     subscribe_to_newsletter(current_user)

--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -4,7 +4,7 @@ class Member::DetailsController < ApplicationController
 
   before_action :set_member
   before_action :suppress_notices
-  before_action :is_logged_in?, only: %i[edit]
+  before_action :require_login, only: %i[edit]
 
   def edit
     accept_terms

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,5 +1,5 @@
 class PaymentsController < ApplicationController
-  before_action :is_logged_in?
+  before_action :require_login
 
   def new; end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,5 @@
 class SubscriptionsController < ApplicationController
-  before_action :has_access?
+  before_action :require_access
 
   def index
     @mailing_list = MailingListForm.new

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -59,12 +59,12 @@ class Workshop < ApplicationRecord
     waiting_list.select(&:for_coach?)
   end
 
-  def has_host?
+  def host?
     WorkshopSponsor.exists?(host: true, workshop: self)
   end
 
-  def has_valid_host?
-    has_host? && host.address.present?
+  def valid_host?
+    host? && host.address.present?
   end
 
   def rsvp_available?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -40,13 +40,13 @@ class ApplicationPolicy
 
   private
 
-  def is_admin_or_chapter_organiser?
+  def admin_or_chapter_organiser?
     return false unless user
 
-    user.is_admin? || user.has_role?(:organiser) || is_chapter_organiser?
+    user.is_admin? || user.has_role?(:organiser) || chapter_organiser?
   end
 
-  def is_chapter_organiser?
+  def chapter_organiser?
     Chapter.find_roles(:organiser, user).any?
   end
 end

--- a/app/policies/chapter_policy.rb
+++ b/app/policies/chapter_policy.rb
@@ -4,28 +4,28 @@ class ChapterPolicy < ApplicationPolicy
   end
 
   def create?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   def show?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   def edit?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   def update?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   def members?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   private
 
-  def is_admin_or_organiser?
+  def admin_or_organiser?
     user.is_admin? || user.has_role?(:organiser, record) || user.has_role?(:organiser)
   end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -1,15 +1,15 @@
 class EventPolicy < ApplicationPolicy
   def invite?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   def show?
-    is_admin_or_organiser?
+    admin_or_organiser?
   end
 
   private
 
-  def is_admin_or_organiser?
+  def admin_or_organiser?
     return false unless user
 
     user.is_admin? || user.has_role?(:organiser, record)

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -4,6 +4,6 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def show?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 end

--- a/app/policies/invitation_log_policy.rb
+++ b/app/policies/invitation_log_policy.rb
@@ -1,9 +1,9 @@
 class InvitationLogPolicy < ApplicationPolicy
   def index?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def show?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 end

--- a/app/policies/sponsor_policy.rb
+++ b/app/policies/sponsor_policy.rb
@@ -1,21 +1,21 @@
 class SponsorPolicy < ApplicationPolicy
   def index?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def create?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def show?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def edit?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def update?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 end

--- a/app/policies/workshop_policy.rb
+++ b/app/policies/workshop_policy.rb
@@ -8,24 +8,24 @@ class WorkshopPolicy < ApplicationPolicy
   end
 
   def show?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def invite?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def update?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   def destroy?
-    is_admin_or_chapter_organiser?
+    admin_or_chapter_organiser?
   end
 
   private
 
-  def is_chapter_organiser?
+  def chapter_organiser?
     user.has_role?(:organiser, record) ||
       user.has_role?(:organiser, record.chapter) ||
       user.has_role?(:organiser, Chapter)

--- a/app/views/admin/workshops/show.html.haml
+++ b/app/views/admin/workshops/show.html.haml
@@ -6,7 +6,7 @@
     = link_to '#', class: 'btn btn-primary py-3 disabled', title: t('messages.already_taken_place') do
       %i.fas.fa-paper-plane
       %label.text-white Invite
-  - elsif (@workshop.has_valid_host? || @workshop.virtual?) and @workshop.invitable?
+  - elsif (@workshop.valid_host? || @workshop.virtual?) and @workshop.invitable?
     = link_to admin_workshop_send_invites_path(@workshop), class: 'btn btn-primary py-3' do
       %i.fas.fa-paper-plane
       %label.text-white Invite


### PR DESCRIPTION
## Problem

The `Naming/PredicatePrefix` todo entry excluded six files so that predicate methods could keep their `is_`/`has_` prefixes.

## Solution

Rename the offenders and remove the exclusions. Purely mechanical, no behaviour changes:

- `is_logged_in?` → `require_login` and `has_access?` → `require_access` in `ApplicationController` (these redirect rather than return a boolean, so the predicate prefix was misleading anyway)
- `Workshop#has_host?` → `host?`, `Workshop#has_valid_host?` → `valid_host?`
- Policy predicates drop their `is_` prefix, e.g. `is_admin_or_organiser?` → `admin_or_organiser?`, `is_chapter_organiser?` → `chapter_organiser?`

`user.is_admin?` calls are untouched: that method is generated dynamically by Rolify, so there is no definition for the cop to flag.

Split out from #2768; independent of the other RuboCop PRs.