### PR TITLE
fix(events): clamp page param to >= 1 so junk pagination params don't 500

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -100,7 +100,8 @@ class EventsController < ApplicationController
   # for the current page. Only the 20 visible rows come back from the DB.
   def paginated_events(upcoming:)
     now = Time.zone.now
-    page = (params[:page] || 1).to_i
+    # Clamp to >= 1 (mirrors Pagy's own resolve_page); .to_s also handles array params
+    page = [1, params[:page].to_s.to_i].max
     direction = upcoming ? 'ASC' : 'DESC'
     comparator = upcoming ? :gteq : :lt
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -14,4 +14,40 @@ RSpec.describe EventsController do
       end
     end
   end
+
+  describe '#past' do
+    before { Fabricate(:event, date_and_time: 2.weeks.ago) }
+
+    context 'when the page param is invalid' do
+      it 'clamps page 0 to page 1' do
+        get :past, params: { page: 0 }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'handles SQL injection probes' do
+        get :past, params: { page: "' OR '1'='1" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'handles empty page params' do
+        get :past, params: { page: '' }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'handles negative pages' do
+        get :past, params: { page: -3 }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'handles array params' do
+        get :past, params: { page: ['1'] }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it 'renders the requested page' do
+      get :past, params: { page: 1 }
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
This PR is about saving maintainer attention by not throwing 500 errors when security scanners try to hit the application.

## Problem

[Rollbar item codebar-production/709](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/709): a security scanner hit `/events/past?page=' OR '1'='1` and got a `Pagy::OptionError: expected :page >= 1; got 0` 500. `(params[:page] || 1).to_i` converts the probe string to `0`, and `Pagy::Offset.new` rejects `page < 1`. The same junk input also 500s via `?page=`, `?page=-3`, and `?page[]=1` (the latter as `NoMethodError` on `Array#to_i`).

## Fix

`EventsController#paginated_events` is the only manual `Pagy::Offset` path in the app — every other paginated endpoint uses the standard `pagy` helper, which clamps the page via `Pagy::Request#resolve_page` (`[page.to_s.to_i, 1].max`). This mirrors that exact clamp:

```ruby
page = [1, params[:page].to_s.to_i].max
```

The `.to_s` also handles array params (`?page[]=1`). Junk input now renders page 1 (200) instead of a 500, so no more Rollbar notifications from these probes.

## Tests

Added request specs covering `page=0`, SQL injection probe, empty, negative, array, and valid page params. All green; rubocop clean.