### PR TITLE
fix(schema.rb): remove unbacked columns added by self-check-in migrations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -201,7 +201,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_151201) do
   create_table "events", id: :serial, force: :cascade do |t|
     t.boolean "announce_only"
     t.string "audience"
-    t.string "check_in_code"
     t.text "coach_description"
     t.string "coach_questionnaire"
     t.integer "coach_spaces"
@@ -229,7 +228,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_151201) do
     t.string "url"
     t.integer "venue_id"
     t.boolean "virtual", default: false, null: false
-    t.index ["check_in_code"], name: "index_events_on_check_in_code", unique: true
     t.index ["date_and_time"], name: "index_events_on_date_and_time"
     t.index ["slug"], name: "index_events_on_slug", unique: true
     t.index ["venue_id"], name: "index_events_on_venue_id"
@@ -341,7 +339,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_151201) do
     t.integer "member_id"
     t.text "note"
     t.string "role"
-    t.string "source"
     t.string "token"
     t.datetime "updated_at", precision: nil
     t.boolean "verified"
@@ -595,7 +592,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_151201) do
     t.datetime "reminded_at", precision: nil
     t.string "role"
     t.datetime "rsvp_time", precision: nil
-    t.string "source"
     t.string "token"
     t.text "tutorial"
     t.datetime "updated_at", precision: nil
@@ -620,7 +616,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_151201) do
 
   create_table "workshops", id: :serial, force: :cascade do |t|
     t.integer "chapter_id"
-    t.string "check_in_code"
     t.integer "coach_spaces", default: 0
     t.datetime "created_at", precision: nil
     t.datetime "date_and_time", precision: nil
@@ -637,7 +632,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_151201) do
     t.datetime "updated_at", precision: nil
     t.boolean "virtual", default: false
     t.index ["chapter_id"], name: "index_workshops_on_chapter_id"
-    t.index ["check_in_code"], name: "index_workshops_on_check_in_code", unique: true
     t.index ["date_and_time"], name: "index_workshops_on_date_and_time"
   end
 


### PR DESCRIPTION
## What

Removes `check_in_code` and `source` columns/indexes from `db/schema.rb` that are not backed by any migration file on `master`.

## Why

The only migrations that add these columns live on `feature/self-check-in` (`commit 1ed1a544`), which has not been merged to `master`. Having them in `db/schema.rb` without corresponding migrations makes the schema inconsistent with `db/migrate` and breaks the ability to replay migrations from scratch.

This is a prerequisite for the migration-squash work in `feature/squash-pre-2026-migrations`.

## Verification

- `ruby -c db/schema.rb` passes.
- Hiding `db/schema.rb` and running `RAILS_ENV=test TEST_ENV_NUMBER=fixverify bundle exec rails db:create db:migrate` reproduces the committed `db/schema.rb` exactly (`diff` is empty).

## Removed

- `events.check_in_code` + unique index
- `workshops.check_in_code` + unique index
- `invitations.source`
- `workshop_invitations.source`
