### PR TITLE
fix(auth): handle concurrent OAuth callback creating the same auth service

### DIFF
--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -44,13 +44,26 @@ class AuthServicesController < ApplicationController
           uid: omnihash[:uid]
         )
 
-        member.save!
+        created = false
+        begin
+          member.save!
+          created = true
+        rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+          # Concurrent OAuth callback for the same account: another request just
+          # created this member/auth_service (both email and (uid, provider) are
+          # unique), so our insert/validation collided with it. Reuse the winner
+          # instead of erroring. find_by! is the guard: if no winner exists this
+          # isn't a race and we surface the real error.
+          member_service = AuthService.find_by!(provider: omnihash[:provider],
+                                                uid: omnihash[:uid])
+          member = member_service.member
+        end
 
         # Set, not Toggle: toggling would flip can_log_in off for a member who
         # links a second auth service. Skip the conditional profile validations
         # here on purpose — a brand-new member completes name/about_you on the
         # next (details) page, and running them now aborts the signup callback.
-        member.update_column(:can_log_in, true) # rubocop:disable Rails/SkipsModelValidations
+        member.update_column(:can_log_in, true) if created # rubocop:disable Rails/SkipsModelValidations
 
         session[:member_id]          = member.id
         session[:service_id]         = member_service.id

--- a/spec/requests/auth_services_callback_spec.rb
+++ b/spec/requests/auth_services_callback_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'AuthServices callback', type: :request do
+RSpec.describe 'AuthServices callback' do
   it 'reuses the winner when a concurrent callback just created the same auth service' do
     winner = Fabricate(:member, email: 'winner@example.com')
     winner_service = Fabricate(:auth_service, member: winner,

--- a/spec/requests/auth_services_callback_spec.rb
+++ b/spec/requests/auth_services_callback_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'AuthServices callback', type: :request do
+  it 'reuses the winner when a concurrent callback just created the same auth service' do
+    winner = Fabricate(:member, email: 'winner@example.com')
+    winner_service = Fabricate(:auth_service, member: winner,
+                                              provider: 'github',
+                                              uid: 'race-uid-123')
+
+    mock_auth_hash(provider: 'github', uid: 'race-uid-123',
+                   email: 'loser@example.com')
+
+    # Simulate the losing callback: it read the DB *before* the winner committed,
+    # so its initial find_by saw nothing; the insert then collides and the rescue
+    # re-finds the winner via find_by!.
+    allow(AuthService).to receive_messages(find_by: nil, find_by!: winner_service)
+
+    expect { post '/auth/github/callback' }.not_to raise_error
+
+    expect(response).to redirect_to(edit_member_details_path)
+    expect(session[:member_id]).to eq(winner.id)
+    expect(session[:service_id]).to eq(winner_service.id)
+    # the losing callback must not flip the winner's can_log_in flag back
+    expect(winner.reload.can_log_in).to be(false)
+  end
+end


### PR DESCRIPTION
## Problem

A double-fired OAuth callback can pass the initial `AuthService.find_by(provider:, uid:)` lookup concurrently (both see nothing), then both enter the create branch and collide while `member.save!` saves the nested auth service. The unique `(uid, provider)` index (already live in prod) plus the auth_service uniqueness validation make one request error — `RecordNotUnique` on a true TOCTOU race, or `RecordInvalid` via the app validation when the duplicate is already visible. Result: an errored login request.

## What this does

In `auth_services_controller#create`, wrap `member.save!` in a rescue of both `RecordInvalid` and `RecordNotUnique`, and on collision reuse the already-created auth service:
- `AuthService.find_by!(provider:, uid:)` acts as the **guard** — if no winner exists this isn't a race, so it raises the real error instead of swallowing it.
- `can_log_in` is only enabled on **actual creation** (`created`) — `update_column(:can_log_in, true) if created` — so the losing callback doesn't touch the winner's flag (set, not toggle; see #2783).

## Verification
- New request spec (`spec/requests/auth_services_callback_spec.rb`) deterministically exercises the rescue and asserts the loser reuses the winner's member/service and does not touch `can_log_in`.
- Rebases cleanly onto current master (resolves the overlap with #2778's `can_log_in` change).
- Rubocop clean; request spec + signup feature specs (login / ToC / newsletter / joining): 20 examples, 0 failures.

## Why a separate PR from #2779
The `auth_services (uid, provider)` index already shipped to prod in the first partial run of the unique-index migration, so this fix is independently urgent and not gated on #2779 — it gets focused auth review on its own clock.
