### PR TITLE
fix(member): persist newsletter checkbox state on form re-render

### DIFF
--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -21,7 +21,7 @@ class Member::DetailsController < ApplicationController
 
     return render :edit unless @member.update(attrs)
 
-    attrs[:newsletter] ? subscribe_to_newsletter(@member) : unsubscribe_from_newsletter(@member)
+    @member.newsletter ? subscribe_to_newsletter(@member) : unsubscribe_from_newsletter(@member)
     redirect_to step2_member_path
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -63,7 +63,9 @@ class Member < ApplicationRecord
 
   acts_as_taggable_on :skills
 
-  attr_accessor :attendance, :newsletter
+  attr_accessor :attendance
+
+  attribute :newsletter, :boolean
 
   def organiser?
     organised_chapters.present?

--- a/spec/controllers/member/details_controller_spec.rb
+++ b/spec/controllers/member/details_controller_spec.rb
@@ -73,6 +73,54 @@ RSpec.describe Member::DetailsController do
         expect(member.how_you_found_us_other_reason).to eq('From a colleague')
         expect(response).to redirect_to(step2_member_path)
       end
+
+      it 'subscribes to the newsletter when checked' do
+        patch :update, params: {
+          id: member.id,
+          member: {
+            how_you_found_us: 'social_media',
+            newsletter: 'true'
+          }
+        }
+
+        expect(mailing_list).to have_received(:subscribe)
+        expect(mailing_list).not_to have_received(:unsubscribe)
+      end
+
+      it 'unsubscribes from the newsletter when unchecked' do
+        patch :update, params: {
+          id: member.id,
+          member: {
+            how_you_found_us: 'social_media',
+            newsletter: 'false'
+          }
+        }
+
+        expect(mailing_list).to have_received(:unsubscribe)
+        expect(mailing_list).not_to have_received(:subscribe)
+      end
+    end
+
+    context 'with a validation failure' do
+      it 'keeps the newsletter checkbox checked when it was checked' do
+        patch :update, params: {
+          id: member.id,
+          member: { newsletter: 'true' }
+        }
+
+        expect(response.body).to include('You must select one option')
+        expect(response.body).to have_css('input#member_newsletter[checked]')
+      end
+
+      it 'keeps the newsletter checkbox unchecked when it was unchecked' do
+        patch :update, params: {
+          id: member.id,
+          member: { newsletter: 'false' }
+        }
+
+        expect(response.body).to include('You must select one option')
+        expect(response.body).to have_no_css('input#member_newsletter[checked]')
+      end
     end
 
     context 'when update fails (invalid data)' do


### PR DESCRIPTION
## Summary

On the member details form reached after GitHub sign-in, the "Sign up for our newsletter" checkbox lost its default checked state whenever a required field was missing and the form reloaded. The checkbox now keeps the value the user actually chose across a failed-submit reload.

Root cause: `newsletter` was a plain `attr_accessor`, so the model kept the raw form string `"true"`/`"false"`. That string was compared against a boolean checked value and always rendered unchecked on re-render. Declaring it as a boolean-typed attribute (`attribute :newsletter, :boolean`) lets Rails' own type system coerce the submitted value, which also fixes a second latent bug - the string `"false"` is truthy, so unchecking the box still subscribed to the newsletter.

Fixes #2754

## Manual verification

1. Run the app locally (`bundle exec rails server`) and go to `http://localhost:3000`.
2. Click **Log in with GitHub** and authenticate (or use the existing signup flow that lands on the member details form).
3. On the details form, leave **a required field empty** (e.g. name) and click **Save**.
4. Confirm the form reloads with the error and that the **"Sign up for our newsletter" checkbox is still checked** (it was unchecked before this fix).
5. Uncheck the checkbox, leave a required field empty again, and click **Save**.
6. Confirm the checkbox is **still unchecked** after the reload - i.e. it preserves your choice in both directions.
7. Fill all fields, keep the checkbox **checked**, and submit. Confirm you reach the next step.
8. (Optional) Repeat step 7 with the checkbox **unchecked** and confirm the member is not subscribed.

## Tests

Added controller specs asserting the checkbox keeps its state on a failed validation, plus specs asserting `subscribe`/`unsubscribe` are called correctly for checked/unchecked submissions. Run:

```
bundle exec rspec spec/controllers/member/details_controller_spec.rb
```
