### PR TITLE
Fix N+1 query on dashboard (workshop host)

### DIFF
--- a/app/queries/dashboard_query.rb
+++ b/app/queries/dashboard_query.rb
@@ -3,7 +3,7 @@ class DashboardQuery
   MAX_WORKSHOP_QUERY = 10
 
   def self.upcoming_events
-    workshops = Workshop.eager_load(:chapter, :sponsors, :organisers, :permissions)
+    workshops = Workshop.eager_load(:chapter, :sponsors, :organisers, :permissions, :workshop_host)
                         .today_and_upcoming
                         .limit(MAX_WORKSHOP_QUERY)
                         .to_a


### PR DESCRIPTION
## What

Adds `:workshop_host` to the `eager_load` in `DashboardQuery.upcoming_events`, resolving the eager-loading detection bullet logged for `GET /`.

## Why

`DashboardQuery.upcoming_events` (`app/queries/dashboard_query.rb`) loaded `workshop_host` lazily on each workshop when rendering the front page, triggering an N+1 detected by Rails' eager-loading checker.

```
USE eager loading detected
  Workshop => [:workshop_host]
  Add to your query: .includes([:workshop_host])
```

The query already uses `eager_load` for `:chapter, :sponsors, :organisers, :permissions`, so `:workshop_host` joins the same preload.

## Verification

`bundle exec rspec spec/queries/dashboard_query_spec.rb` — 9 examples, 0 failures.
