### PR TITLE
feat(member): replace can_log_in with derived active? and drop the column

### DIFF
--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -44,10 +44,8 @@ class AuthServicesController < ApplicationController
           uid: omnihash[:uid]
         )
 
-        created = false
         begin
           member.save!
-          created = true
         rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
           # Concurrent OAuth callback for the same account: another request just
           # created this member/auth_service (both email and (uid, provider) are
@@ -59,18 +57,16 @@ class AuthServicesController < ApplicationController
           member = member_service.member
         end
 
-        # Set, not Toggle: toggling would flip can_log_in off for a member who
-        # links a second auth service. Skip the conditional profile validations
-        # here on purpose — a brand-new member completes name/about_you on the
-        # next (details) page, and running them now aborts the signup callback.
-        member.update_column(:can_log_in, true) if created # rubocop:disable Rails/SkipsModelValidations
-
         session[:member_id]          = member.id
         session[:service_id]         = member_service.id
         session[:oauth_token]        = omnihash[:credentials][:token]
         session[:oauth_token_secret] = omnihash[:credentials][:secret]
 
-        redirect_to edit_member_details_path(member_type: member_type)
+        if member.requires_additional_details?
+          redirect_to edit_member_details_path(member_type: member_type)
+        else
+          redirect_to referer_or_dashboard_path
+        end
     end
   end
 

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -63,7 +63,7 @@ class AuthServicesController < ApplicationController
         session[:oauth_token_secret] = omnihash[:credentials][:secret]
 
         if member.requires_additional_details?
-          redirect_to edit_member_details_path(member_type: member_type)
+          redirect_to edit_member_details_path(member_type:)
         else
           redirect_to referer_or_dashboard_path
         end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,4 +1,6 @@
 class Member < ApplicationRecord
+  self.ignored_columns += ['can_log_in']
+
   include DigestHelper
 
   rolify role_cname: 'Permission', role_table_name: :permission, role_join_table_name: :members_permissions
@@ -27,9 +29,9 @@ class Member < ApplicationRecord
   has_many :member_email_deliveries
 
   validates :auth_services, presence: true
-  validates :name, :surname, :email, :about_you, presence: true, if: :can_log_in?
+  validates :name, :surname, :email, :about_you, presence: true, if: :active?
   validates :email, uniqueness: true
-  validates :email, email: { mode: :strict }, if: :can_log_in?
+  validates :email, email: { mode: :strict }, if: :active?
   validates :about_you, length: { maximum: 255 }
 
   DIETARY_RESTRICTIONS = %w[vegan vegetarian pescetarian halal gluten_free dairy_free other].freeze
@@ -125,7 +127,11 @@ class Member < ApplicationRecord
   end
 
   def requires_additional_details?
-    can_log_in? && !valid?
+    active? && !valid?
+  end
+
+  def active?
+    auth_services.exists?
   end
 
   def existing_rsvp_on?(date)

--- a/db/migrate/20260806000000_remove_can_log_in_from_members.rb
+++ b/db/migrate/20260806000000_remove_can_log_in_from_members.rb
@@ -1,0 +1,5 @@
+class RemoveCanLogInFromMembers < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured { remove_column :members, :can_log_in, :boolean }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_104506) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -441,7 +441,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_104506) do
   create_table "members", id: :serial, force: :cascade do |t|
     t.string "about_you"
     t.datetime "accepted_toc_at", precision: nil
-    t.boolean "can_log_in", default: false, null: false
     t.datetime "created_at", precision: nil
     t.enum "dietary_restrictions", default: [], array: true, enum_type: "dietary_restriction_enum"
     t.string "email"

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -16,7 +16,6 @@ RSpec.feature 'A new student signs up', type: :feature do
 
   scenario 'A visitor must fill in all mandatory fields in order to sign up' do
     member = Fabricate(:member, name: nil, surname: nil, email: nil, about_you: nil, how_you_found_us: nil, how_you_found_us_other_reason: nil)
-    member.update_attribute(:can_log_in, true)
     login member
 
     visit edit_member_details_path
@@ -68,7 +67,6 @@ RSpec.feature 'A new student signs up', type: :feature do
     group = Fabricate(:group)
 
     login member
-    member.update(can_log_in: true)
 
     visit step2_member_path
     expect(page).to have_current_path(step2_member_path)

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe Member do
       it { is_expected.to validate_length_of(:about_you).is_at_most(255) }
       it { is_expected.to validate_uniqueness_of(:email) }
 
-      describe 'can_log_in' do
-        let(:member) { Fabricate.build(:member, can_log_in: true) }
+      describe 'active' do
+        # Fabricated members have a persisted auth service, so #active? is true
+        # and the profile presence/email validations run.
+        let(:member) { Fabricate(:member) }
 
         it { expect(member).to validate_presence_of(:name) }
         it { expect(member).to validate_presence_of(:surname) }
@@ -44,6 +46,32 @@ RSpec.describe Member do
         it 'accepts email with plus addressing' do
           member.email = 'user+tag@example.com'
           expect(member).to be_valid
+        end
+
+        context 'when the member has no auth service' do
+          let(:member) do
+            member = Fabricate(:member)
+            member.auth_services.delete_all
+            member.name = nil
+            member.surname = nil
+            member.about_you = nil
+            member
+          end
+
+          it 'is not active' do
+            expect(member.active?).to be(false)
+          end
+
+          it 'skips the gated profile presence validations' do
+            member.valid?
+            expect(member.errors[:name]).to be_empty
+            expect(member.errors[:surname]).to be_empty
+            expect(member.errors[:about_you]).to be_empty
+          end
+
+          it 'does not require additional details' do
+            expect(member.requires_additional_details?).to be(false)
+          end
         end
       end
     end

--- a/spec/requests/auth_services_callback_spec.rb
+++ b/spec/requests/auth_services_callback_spec.rb
@@ -17,10 +17,45 @@ RSpec.describe 'AuthServices callback' do
 
     expect { post '/auth/github/callback' }.not_to raise_error
 
-    expect(response).to redirect_to(edit_member_details_path)
+    # The winner is a complete member, so the losing callback must not bounce
+    # them back to the details page — they go to the dashboard instead.
+    expect(response).to redirect_to(dashboard_path)
     expect(session[:member_id]).to eq(winner.id)
     expect(session[:service_id]).to eq(winner_service.id)
-    # the losing callback must not flip the winner's can_log_in flag back
-    expect(winner.reload.can_log_in).to be(false)
+    expect(winner.reload.active?).to be(true)
+  end
+
+  it 'sends a complete member who links a second provider to the dashboard, not details' do
+    complete = Fabricate(:member, email: 'existing@example.com')
+    mock_auth_hash(provider: 'github', uid: 'second-uid',
+                   email: 'existing@example.com')
+
+    post '/auth/github/callback'
+
+    expect(response).to redirect_to(dashboard_path)
+    expect(session[:member_id]).to eq(complete.id)
+  end
+
+  it 'sends a complete member who links a second provider to a stored referer' do
+    complete = Fabricate(:member, email: 'referer@example.com')
+    mock_auth_hash(provider: 'github', uid: 'second-uid-referer',
+                   email: 'referer@example.com')
+
+    # AuthServicesController#new (GET /login) stores a workshop/event/meeting
+    # referer in the session; a complete member then follows it instead of
+    # being bounced to the details page.
+    get '/login', headers: { 'HTTP_REFERER' => '/workshops/1' }
+    post '/auth/github/callback'
+
+    expect(response).to redirect_to('/workshops/1')
+    expect(session[:member_id]).to eq(complete.id)
+  end
+
+  it 'sends a brand-new member to complete their profile details' do
+    mock_auth_hash(provider: 'github', uid: 'new-uid', email: 'new@example.com')
+
+    post '/auth/github/callback'
+
+    expect(response).to redirect_to(edit_member_details_path)
   end
 end


### PR DESCRIPTION
## Summary

Issue #2784. Replace the stored `members.can_log_in` boolean with a derived `Member#active?` and drop the column; stop writing `can_log_in` in the OAuth callback and gate the details redirect on `requires_additional_details?`.

`can_log_in` was never a login gate. Its only consumer, `requires_additional_details?` (`app/models/member.rb`), gates profile completion after login, and issue #2783 showed the value had degraded into a parity artifact across 116 members. A member is active by having an auth service, so the flag duplicates easily-derived truth — this removes the column and derives it.

Key behaviours:
- New members keep skipping the profile presence/email validations at signup: during `member.save!` in the callback the just-built `auth_service` is not yet persisted, so `active?` (`auth_services.exists?`) is false; the member becomes `active?` after save.
- A complete member who links a second provider is no longer bounced to `/member/details/edit` — they go to `referer_or_dashboard_path` instead. This closes the unconditional-redirect part of #2783.
- Migration follows the strong_migrations ignore-then-drop contract (`self.ignored_columns += ['can_log_in']` precedes the `safety_assured` drop). No data repair is needed: the 116 affected members self-correct to active because they have auth services.

Fixes #2784 · Resolves #2783

## Base

Rebased onto `master`. #2780 (OAuth race fix) is merged, so this PR contains only the #2784 work; no longer stacked on the race-fix branch.


## Verification

- `51 + 12` RSpec examples pass (member, callback, controller, joining, ToC specs); rubocop clean.
- ce-code-review (correctness, testing, data-migration): no blocking findings. Advisory P3 items applied (#3 active? false-branch model coverage, #4 referer redirect) and recorded; residual risks noted for the destructive-DDL rollback and the `session[:referer_path]` staleness (pre-existing).

## Post-Deploy Monitoring & Validation

- Deployment note: the migration drops `members.can_log_in`. Per the strong_migrations contract, ship the code containing `ignored_columns` in the same release as the migration.
- Rollback: `remove_column` is reversible (re-adds the column) but cannot restore dropped values; treat the column as obsolete (impact nil).
- After deploy, validation window ~1 week. Watch for `NoMethodError` / undefined-column errors on `can_log_in` in Rollbar (would indicate old code running against the dropped column — i.e. a missed two-phase deploy).
- Healthy signal: no errors; `Member#requires_additional_details?` behaves as before for new-signup and second-provider flows.
- No additional runtime monitoring required beyond the above; the change is entirely derive/drop with no new background or scheduled work.


