### PR TITLE
fix: make sponsor coach spots nil-safe

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -53,7 +53,9 @@ class Sponsor < ApplicationRecord
   mount_uploader(:avatar, AvatarUploader)
 
   def coach_spots
-    number_of_coaches || (seats / 2.0).round
+    return number_of_coaches if number_of_coaches.present?
+
+    seats.present? ? (seats / 2.0).round : nil
   end
 
   def self.latest

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -64,4 +64,24 @@ RSpec.describe Sponsor do
         .with_values(%i[hidden standard bronze silver gold community])
     end
   end
+
+  describe '#coach_spots' do
+    it 'returns number_of_coaches when present' do
+      sponsor = Fabricate.build(:sponsor, number_of_coaches: 4, seats: 10)
+
+      expect(sponsor.coach_spots).to eq(4)
+    end
+
+    it 'falls back to half the seats rounded' do
+      sponsor = Fabricate.build(:sponsor, number_of_coaches: nil, seats: 15)
+
+      expect(sponsor.coach_spots).to eq(8)
+    end
+
+    it 'does not raise when both seats and number_of_coaches are missing' do
+      sponsor = Fabricate.build(:sponsor, number_of_coaches: nil, seats: nil)
+
+      expect(sponsor.coach_spots).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Linked to #2500. The admin sponsor show page returned an HTTP 500 for some sponsor records.

`Sponsor#coach_spots` did `number_of_coaches || (seats / 2.0).round`, which raises `NoMethodError: undefined method '/' for nil` when both `number_of_coaches` and `seats` are nil. The show view calls this unconditionally, so any incomplete record crashes.

The #1794 fix (adding presence validations + HTML5 `required`) prevents new bad rows, but pre-existing records can still hold nil values, so `coach_spots` remains crash-prone.

## Change

Make `coach_spots` nil-safe: return `number_of_coaches` when present, else half the seats rounded, else `nil` instead of raising.

## Tests

Added three `#coach_spots` cases to `spec/models/sponsor_spec.rb`. The nil-both case fails on the old implementation and passes with this fix.

## Database analysis

Checked the `codebar_dump` Postgres database for records that would trigger this crash. Querying for `sponsors` rows where `seats IS NULL OR number_of_coaches IS NULL` returned **0 rows** across all 751 sponsors. The broken records referenced in #2500 (IDs 1539 and 1540) are absent from the dump — only the valid `1541` (`BDO UK`, seats 0 / coaches 0) survives — so the bad rows appear to have already been removed in production. No data cleanup is required. The `0` values on remaining rows are valid (validation allows `>= 0`), so this fix is defensive hardening against recurrence through any non-controller data path.

Note: the "duplicate sponsor on update" aspect of #2500 was not reproducible — no code path in the update/create actions creates a new Sponsor row.