### PR TITLE
fix: only show signup flash to newly created members

### DIFF
--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -35,6 +35,7 @@ class AuthServicesController < ApplicationController
 
         member = Member.find_by(email:)
         member ||= Member.new(email:)
+        new_member = member.new_record?
 
         member.name    ||= omnihash[:info][:name]&.split(' ')&.first || ''
         member.surname ||= omnihash[:info][:name]&.split(' ')&.drop(1)&.join(' ') || ''
@@ -55,6 +56,7 @@ class AuthServicesController < ApplicationController
           member_service = AuthService.find_by!(provider: omnihash[:provider],
                                                 uid: omnihash[:uid])
           member = member_service.member
+          new_member = false
         end
 
         session[:member_id]          = member.id
@@ -63,6 +65,7 @@ class AuthServicesController < ApplicationController
         session[:oauth_token_secret] = omnihash[:credentials][:secret]
 
         if member.requires_additional_details?
+          session[:new_member] = new_member
           redirect_to edit_member_details_path(member_type:)
         else
           redirect_to referer_or_dashboard_path

--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -8,7 +8,9 @@ class Member::DetailsController < ApplicationController
 
   def edit
     accept_terms
-    flash[notice] = I18n.t('notifications.signing_up')
+    if session.delete(:new_member)
+      flash[notice] = I18n.t('notifications.signing_up')
+    end
     @member.newsletter ||= true
   end
 

--- a/spec/controllers/member/details_controller_spec.rb
+++ b/spec/controllers/member/details_controller_spec.rb
@@ -9,6 +9,28 @@ RSpec.describe Member::DetailsController do
     allow(mailing_list).to receive_messages(subscribe: true, unsubscribe: true)
   end
 
+  describe 'GET #edit' do
+    context 'when a brand-new member' do
+      it 'shows the signing up message' do
+        session[:new_member] = true
+
+        get :edit
+
+        expect(response.body).to include(I18n.t('notifications.signing_up'))
+      end
+    end
+
+    context 'when an existing member' do
+      it 'does not show the signing up message' do
+        session[:new_member] = false
+
+        get :edit
+
+        expect(response.body).not_to include(I18n.t('notifications.signing_up'))
+      end
+    end
+  end
+
   describe 'PATCH #update' do
     context 'with valid params' do
       it 'updates how_you_found_us with radio option' do

--- a/spec/requests/auth_services_callback_spec.rb
+++ b/spec/requests/auth_services_callback_spec.rb
@@ -57,5 +57,21 @@ RSpec.describe 'AuthServices callback' do
     post '/auth/github/callback'
 
     expect(response).to redirect_to(edit_member_details_path)
+    expect(session[:new_member]).to be(true)
+  end
+
+  it 'does not mark an existing incomplete member as a new signup when they return to complete their profile' do
+    returning = Fabricate(:member, name: nil, surname: nil, about_you: nil,
+                                   email: 'returning@example.com')
+    returning.auth_services.delete_all
+    svc = Fabricate(:auth_service, member: returning,
+                                   provider: 'github', uid: 'returning-github-uid')
+    mock_auth_hash(provider: 'github', uid: svc.uid,
+                   email: 'returning@example.com', name: nil)
+
+    post '/auth/github/callback'
+
+    expect(response).to redirect_to(edit_member_details_path)
+    expect(session[:new_member]).to be_nil
   end
 end


### PR DESCRIPTION
## Summary

Returning members routed to the "Almost there..." details page (because their profile is incomplete) were still told "Thanks for signing up", even though no new account was created. The signup flash now shows only for members actually created during the OAuth callback; existing members land on the details page with no misleading message.

## Test plan

Extended `auth_services_callback_spec.rb` and the details controller spec to cover both cases. The browser feature test for a genuine new signup still shows the flash. 21 examples, 0 failures; RuboCop clean.

Fixes #2788
