### PR TITLE
Fix WorkshopsController#rsvp 500 when member already has a nil-attending invitation

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -44,9 +44,10 @@ class WorkshopsController < ApplicationController
   end
 
   def find_or_create_invitation(workshop, user, role)
-    WorkshopInvitation.create_or_find_by(workshop: workshop,
-                                         member: user,
-                                         role: role)
+    invitation = WorkshopInvitation.create_or_find_by(workshop: workshop,
+                                                      member: user,
+                                                      role: role)
+    invitation.persisted? ? invitation : WorkshopInvitation.find_by(workshop: workshop, member: user, role: role)
   end
 
   def user_attending_or_waitlisted?(workshop, user)

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -44,10 +44,10 @@ class WorkshopsController < ApplicationController
   end
 
   def find_or_create_invitation(workshop, user, role)
-    invitation = WorkshopInvitation.create_or_find_by(workshop: workshop,
+    invitation = WorkshopInvitation.create_or_find_by(workshop:,
                                                       member: user,
-                                                      role: role)
-    invitation.persisted? ? invitation : WorkshopInvitation.find_by(workshop: workshop, member: user, role: role)
+                                                      role:)
+    invitation.persisted? ? invitation : WorkshopInvitation.find_by(workshop:, member: user, role:)
   end
 
   def user_attending_or_waitlisted?(workshop, user)

--- a/spec/controllers/workshops_controller_spec.rb
+++ b/spec/controllers/workshops_controller_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe WorkshopsController, type: :controller do
+  let(:member) { Fabricate(:member) }
+  let(:workshop) { Fabricate(:workshop) }
+
+  before { login(member) }
+
+  describe 'POST #rsvp' do
+    context 'when the member already has an invitation for the workshop and role with attending nil' do
+      let!(:invitation) do
+        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: nil)
+      end
+
+      it 'redirects to the existing invitation page' do
+        post :rsvp, params: { id: workshop.id, role: 'Coach' }
+
+        expect(response).to redirect_to(invitation_path(invitation))
+      end
+
+      it 'does not create a new invitation' do
+        expect do
+          post :rsvp, params: { id: workshop.id, role: 'Coach' }
+        end.not_to change(WorkshopInvitation, :count)
+      end
+    end
+
+    context 'when the member does not have an invitation for the workshop and role' do
+      it 'creates a new invitation and redirects' do
+        expect do
+          post :rsvp, params: { id: workshop.id, role: 'Coach' }
+        end.to change(WorkshopInvitation, :count).by(1)
+
+        invitation = WorkshopInvitation.last
+        expect(response).to redirect_to(invitation_path(invitation))
+      end
+    end
+
+    context 'when the member is already attending' do
+      before do
+        Fabricate(:attending_workshop_invitation, workshop: workshop, member: member, role: 'Coach')
+      end
+
+      it 'redirects back with already wish to attend message' do
+        post :rsvp, params: { id: workshop.id, role: 'Coach' }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq(I18n.t('workshops.already_wish_to_attend'))
+      end
+    end
+  end
+end

--- a/spec/controllers/workshops_controller_spec.rb
+++ b/spec/controllers/workshops_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe WorkshopsController, type: :controller do
+RSpec.describe WorkshopsController do
   let(:member) { Fabricate(:member) }
   let(:workshop) { Fabricate(:workshop) }
 


### PR DESCRIPTION
Closes #2790

## Summary

Fixes a 500 error when a member clicks **Attend as a coach/student** on a workshop where they already have a `WorkshopInvitation` row for that workshop + role with `attending` NULL.

## Root cause

`find_or_create_invitation` used `WorkshopInvitation.create_or_find_by`. In Rails 8.1, `create_or_find_by` calls the non-bang `create`. When the uniqueness validation fails (row already exists), it returns an unpersisted record with `id: nil`. The subsequent `redirect_to invitation_path(@invitation)` then raises `ActionController::UrlGenerationError`.

## Fix

After `create_or_find_by`, check `persisted?`. If the record is not persisted, fall back to `WorkshopInvitation.find_by(workshop:, member:, role:)` to return the existing row.

## Verification

- Added `spec/controllers/workshops_controller_spec.rb` covering:
  - Existing nil-attending invitation for the workshop + role redirects to the existing invitation page.
  - No new invitation is created in that case.
  - Member without an invitation still creates one.
  - Already-attending member is redirected back with the existing message.
- Ran the new spec and all controller/request specs:
  - `bundle exec rspec spec/controllers/workshops_controller_spec.rb` — 4 examples, 0 failures
  - `bundle exec rspec spec/controllers/ spec/requests/` — 136 examples, 0 failures
- `bundle exec rubocop app/controllers/workshops_controller.rb spec/controllers/workshops_controller_spec.rb` — no offenses

## Post-Deploy Monitoring & Validation

- Monitor error tracking for `ActionController::UrlGenerationError` with `controller: "workshop_invitation", id: nil` in `WorkshopsController#rsvp`.
- Expected signal: zero occurrences after deploy.
- If occurrences persist, verify the member/workshop/role combination and check for invitations that cannot be found by `find_by` (e.g. unique index vs validation mismatch).