### PR TITLE
Add make dump_production to restore production db locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,62 @@ backup_production:
 	heroku pgbackups:capture --app=codebar-production
 	curl -o pg-production-latest.dump `heroku pgbackups:url --app=codebar-production`
 	bzip2 pg-production-latest.dump
+# ---------------------------------------------------------------------------
+# dump_production - restore a fresh copy of the production database locally
+#
+# Usage:
+#   make dump_production
+#
+# Fetches the codebar-production Heroku database directly and restores it into a
+# local PostgreSQL database named $(DUMP_DB), overwriting whatever is there.
+# Use this as the starting point for working against production data locally.
+#
+# Requirements:
+#   - Heroku CLI installed and logged in (works when `heroku auth:whoami` succeeds)
+#   - Local PostgreSQL running (matches config/database.yml): DB_HOST / DB_PORT
+#     env vars are respected, defaulting to your OS user on localhost:5432
+#
+# How it works:
+#   1. Pulls the live connection string (host/db/user/password) from Heroku, so
+#      no credentials are hardcoded and they can't go stale.
+#   2. `pg_dump`s the production database to a temporary SQL file first. Any
+#      dump failure aborts here, before the local database is touched.
+#   3. Creates the local database if missing.
+#   4. Drops and recreates the public schema (a clean overwrite every run), then
+#      restores from the temp file and removes it. `--no-owner --no-acl` stops
+#      production roles colliding with local ones.
+#
+# Any failing step aborts loudly; the previous local copy is never destroyed
+# unless a fresh dump has already succeeded.
+# ---------------------------------------------------------------------------
+DUMP_APP := codebar-production
+DUMP_DB  := codebar_production_dump
+
+dump_production:
+	@command -v heroku   >/dev/null || { echo "error: Heroku CLI not installed"; exit 1; }
+	@command -v pg_dump  >/dev/null || { echo "error: pg_dump not found on PATH"; exit 1; }
+	@command -v psql     >/dev/null || { echo "error: psql not found on PATH"; exit 1; }
+	@command -v createdb >/dev/null || { echo "error: createdb not found on PATH"; exit 1; }
+	@command -v pg_isready >/dev/null || { echo "error: pg_isready not found on PATH"; exit 1; }
+	@heroku auth:whoami >/dev/null 2>&1 || { echo "error: not logged in to Heroku (run: heroku login)"; exit 1; }
+	@echo "Checking access to $(DUMP_APP)..."
+	@heroku pg:info --app=$(DUMP_APP) >/dev/null 2>&1 || { echo "error: cannot read $(DUMP_APP) database (check Heroku access)"; exit 1; }
+	@echo "Checking local PostgreSQL..."
+	@pg_isready -h "$${DB_HOST:-localhost}" -p "$${DB_PORT:-5432}" >/dev/null 2>&1 || { echo "error: local PostgreSQL not running"; exit 1; }
+	@echo "Dumping $(DUMP_APP) to a temporary file..."
+	@DUMP_FILE="$$(mktemp -t codebar_dump.XXXXXX).sql"; \
+	  DUMP_URL="$$(heroku pg:credentials:url DATABASE_URL --app=$(DUMP_APP) 2>/dev/null | grep -o 'postgres://[^ ]*' | head -1)"; \
+	  [ -n "$$DUMP_URL" ] || { echo "error: could not read connection URL for $(DUMP_APP)"; exit 1; }; \
+	  pg_dump "$$DUMP_URL" --no-owner --no-acl -f "$$DUMP_FILE" \
+	    || { echo "error: production dump failed"; rm -f "$$DUMP_FILE"; exit 1; }; \
+	  createdb "$(DUMP_DB)" 2>/dev/null || true; \
+	  psql -d "$(DUMP_DB)" -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;' >/dev/null \
+	    || { echo "error: could not reset local schema in $(DUMP_DB)"; rm -f "$$DUMP_FILE"; exit 1; }; \
+	  psql -d "$(DUMP_DB)" -f "$$DUMP_FILE" \
+	    || { echo "error: restore into $(DUMP_DB) failed"; rm -f "$$DUMP_FILE"; exit 1; }; \
+	  rm -f "$$DUMP_FILE"; \
+	  echo "Done: production copy restored into '$(DUMP_DB)'."
+
 deploy_production:
 	heroku maintenance:on --app=codebar-production
 	git tag production_release_`date +"%Y%m%d-%H%M%S"`


### PR DESCRIPTION
I often make a local snapshot of the production database to run analysis on when investigating bugs. It would be convenient, if this was a single command with solid pre-conditions check ... hence this PR.

## Problem

Working against production data locally requires dumping the codebar-production Heroku database into a local postgres copy. That is currently a manual, multi-step process that hardcodes connection details and leaves `.sql` dump files lying around.

## Change

Add a single `make dump_production` target to the `Makefile` that pulls the live `codebar-production` database directly into the local `codebar_production_dump` postgres database, overwriting it on every run.

- Connection details are fetched live via `heroku pg:credentials:url`, so nothing is hardcoded and it cannot go stale.
- Pre-checks prerequisites (Heroku CLI and login, app reachability, local postgres) and fails loudly before touching the database.
- Dumps to a temporary file first; the destructive schema reset only runs after a successful dump, so a failed run never destroys the previous local copy.
- Uses `--no-owner --no-acl` so production roles don't collide with local ones; the temp file is cleaned up on success and on every failure path.

## Verification

End-to-end run restored 29,373 members in ~76s; tables owned by local user (no prod-role collisions); confirmed a failing dump aborts without printing "Done" and leaves the prior copy intact.

## How to use

`make dump_production`
