### PR TITLE
Fix events coach/student 500 when member already has an event invitation

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -63,8 +63,9 @@ class EventsController < ApplicationController
 
   def find_invitation_and_redirect_to_event(role)
     set_event
-    @invitation = Invitation.create_or_find_by(event: @event, member: current_user, role: role)
-    redirect_to event_invitation_path(@event, @invitation)
+    invitation = Invitation.create_or_find_by(event: @event, member: current_user, role: role)
+    invitation = Invitation.find_by(event: @event, member: current_user, role: role) unless invitation.persisted?
+    redirect_to event_invitation_path(@event, invitation)
   end
 
   def set_event

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -15,6 +15,78 @@ RSpec.describe EventsController do
     end
   end
 
+  describe 'GET #student' do
+    let(:member) { Fabricate(:member) }
+    let(:event) { Fabricate(:event) }
+
+    before { login(member) }
+
+    context 'when the member already has an invitation for the event and role with attending nil' do
+      let!(:invitation) do
+        Fabricate(:invitation, event: event, member: member, role: 'Student', attending: nil)
+      end
+
+      it 'redirects to the existing invitation page' do
+        get :student, params: { event_id: event.slug }
+
+        expect(response).to redirect_to(event_invitation_path(event, invitation))
+      end
+
+      it 'does not create a new invitation' do
+        expect do
+          get :student, params: { event_id: event.slug }
+        end.not_to change(Invitation, :count)
+      end
+    end
+
+    context 'when the member does not have an invitation for the event and role' do
+      it 'creates a new invitation and redirects' do
+        expect do
+          get :student, params: { event_id: event.slug }
+        end.to change(Invitation, :count).by(1)
+
+        invitation = Invitation.last
+        expect(response).to redirect_to(event_invitation_path(event, invitation))
+      end
+    end
+  end
+
+  describe 'GET #coach' do
+    let(:member) { Fabricate(:member) }
+    let(:event) { Fabricate(:event) }
+
+    before { login(member) }
+
+    context 'when the member already has a coach invitation for the event with attending nil' do
+      let!(:invitation) do
+        Fabricate(:coach_invitation, event: event, member: member, attending: nil)
+      end
+
+      it 'redirects to the existing invitation page' do
+        get :coach, params: { event_id: event.slug }
+
+        expect(response).to redirect_to(event_invitation_path(event, invitation))
+      end
+
+      it 'does not create a new invitation' do
+        expect do
+          get :coach, params: { event_id: event.slug }
+        end.not_to change(Invitation, :count)
+      end
+    end
+
+    context 'when the member does not have a coach invitation for the event' do
+      it 'creates a new coach invitation and redirects' do
+        expect do
+          get :coach, params: { event_id: event.slug }
+        end.to change(Invitation, :count).by(1)
+
+        invitation = Invitation.last
+        expect(response).to redirect_to(event_invitation_path(event, invitation))
+      end
+    end
+  end
+
   describe '#past' do
     before { Fabricate(:event, date_and_time: 2.weeks.ago) }
 


### PR DESCRIPTION
Closes #2794

## Summary

Fixes a 500 when a logged-in member clicks **Coach**/**Student** on an event where they already have an `Invitation` row for that event + role with `attending` NULL.

## Related Rollbar items

- [Rollbar 712](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/712) — `EventsController#student`, event 448 (`virtual-open-day-8`)
- [Rollbar 713](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/713) — `EventsController#coach`, event 448 (`virtual-open-day-8`)

Both are the same defect triggered through the `student` and `coach` actions respectively.

## Root cause

`find_invitation_and_redirect_to_event` used `Invitation.create_or_find_by`. In Rails 8.1, `create_or_find_by` calls the non-bang `create`. When the uniqueness validation fails (row already exists), it returns an unpersisted record with `token: nil`. Because `Invitation#to_param` returns `token`, the subsequent `redirect_to event_invitation_path` raises `ActionController::UrlGenerationError`. Same bug as #2790, on the events/Invitation path — #2791 only covered workshops.

## Fix

After `create_or_find_by`, check `persisted?`. If not persisted, fall back to `Invitation.find_by(event:, member:, role:)` to return the existing row.

## Verification

- Added controller specs for `GET #student` and `GET #coach` covering:
  - Existing nil-attending invitation for the event + role redirects to the existing invitation page.
  - No new invitation is created in that case.
  - Member without an invitation still creates one and redirects.
- Reproduced the exact production scenario against the `codebar_production_dump` for both Rollbar items:
  - 712: members 3863/29087 for event 448 (`virtual-open-day-8`), Student role
  - 713: members 19217/29875 for event 448 (`virtual-open-day-8`), Coach role
  - All four now route to their existing invitation with a valid `/events/virtual-open-day-8/invitation/:token` URL.
- Ran controller + request specs: 145 examples, 0 failures.
- `bundle exec rubocop app/controllers/events_controller.rb spec/controllers/events_controller_spec.rb` — no offenses.

## Post-Deploy Monitoring & Validation

- Monitor error tracking for `ActionController::UrlGenerationError` with `controller: "invitations"` and `token: nil` in `EventsController#find_invitation_and_redirect_to_event`.
- Expected signal: zero occurrences across both Rollbar items (712 and 713) after deploy.