### PR TITLE
Allow adding organisers during workshop creation

### DIFF
--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -15,7 +15,12 @@ class Admin::WorkshopsController < Admin::ApplicationController
   end
 
   def new
-    @workshop = Workshop.new
+    chapter_id = params[:chapter_id]
+    @workshop = if chapter_id.present? && Chapter.exists?(chapter_id)
+      Workshop.new(chapter_id: chapter_id)
+    else
+      Workshop.new
+    end
     authorize @workshop
   end
 
@@ -24,7 +29,7 @@ class Admin::WorkshopsController < Admin::ApplicationController
     authorize(@workshop)
 
     if workshop_type_valid? && @workshop.save
-      grant_organiser_access(@workshop.chapter.organisers.pluck(:id))
+      assign_organisers_or_default
       assign_host(host_id)
 
       redirect_to admin_workshop_path(@workshop), notice: I18n.t('admin.messages.workshop.created')
@@ -213,6 +218,14 @@ class Admin::WorkshopsController < Admin::ApplicationController
     organiser_ids.reject!(&:empty?)
     grant_organiser_access(organiser_ids)
     revoke_organiser_access(organiser_ids)
+  end
+
+  def assign_organisers_or_default
+    if organiser_ids.present?
+      assign_organisers(organiser_ids)
+    else
+      grant_organiser_access(@workshop.chapter.organisers.pluck(:id))
+    end
   end
 
   def host_id

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -15,9 +15,9 @@ class Admin::WorkshopsController < Admin::ApplicationController
   end
 
   def new
-    chapter_id = params[:chapter_id]
-    @workshop = if chapter_id.present? && Chapter.exists?(chapter_id)
-      Workshop.new(chapter_id: chapter_id)
+    chapter_id = params[:chapter_id].presence
+    @workshop = if chapter_id && Chapter.exists?(chapter_id)
+      Workshop.new(chapter_id:)
     else
       Workshop.new
     end

--- a/app/views/admin/chapters/show.html.haml
+++ b/app/views/admin/chapters/show.html.haml
@@ -61,7 +61,7 @@
       .mb-4.mt-md-4.mt-lg-0
         .d-md-flex.justify-content-between.align-items-center
           %h3 Upcoming Workshops
-          = link_to 'New workshop', new_admin_workshop_path, class: 'btn btn-primary btn-sm'
+          = link_to 'New workshop', new_admin_workshop_path(chapter_id: @chapter.id), class: 'btn btn-primary btn-sm'
         - if @workshops.any?
           %ul.list-unstyled.ms-0.mb-0
             - @workshops.each do |workshop|

--- a/app/views/admin/workshops/_form.html.haml
+++ b/app/views/admin/workshops/_form.html.haml
@@ -4,6 +4,9 @@
       = render partial: 'shared_form', locals: { f: f }
     .col-12.col-md-6
       = render partial: 'virtual_workshop_fields', locals: { f: f }
+    - if @workshop.chapter
+      .col-12.col-md-6
+        = f.input :organisers, collection: @workshop.chapter.organisers, value_method: :id, label_method: :full_name, selected: @workshop.chapter.organisers.pluck(:id), input_html: { multiple: true }
     .col-12
       = f.input :invitable, hint_html: { class: 'd-block ms-1' }
   .row

--- a/app/views/admin/workshops/_shared_form.html.haml
+++ b/app/views/admin/workshops/_shared_form.html.haml
@@ -1,6 +1,9 @@
 .row
-  .col-12
-    = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
+  - if @workshop.chapter
+    = f.hidden_field :chapter_id
+  - else
+    .col-12
+      = f.association :chapter, as: :select, collection: Chapter.available_to_user(current_user)
   .col-12
     = f.input :local_date, label: 'Date', as: :string, required: true, input_html: { data: { value: @workshop.date_and_time.try(:strftime, '%d/%m/%Y') } }
   .col-12.col-md-6

--- a/app/views/admin/workshops/new.html.haml
+++ b/app/views/admin/workshops/new.html.haml
@@ -1,6 +1,8 @@
+- content_for :title, @workshop.chapter ? "New Workshop for #{@workshop.chapter.name}" : 'New Workshop'
+
 .container.py-4.py-lg-5
   .row.mb-4
     .col
-      %h1 New Workshop
+      %h1= @workshop.chapter ? "New Workshop for #{@workshop.chapter.name}" : 'New Workshop'
 
   = render partial: 'form'

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -162,6 +162,59 @@ RSpec.feature 'An admin managing workshops', type: :feature do
         expect(page).to have_text 'Invite'
       end
     end
+
+    context 'when creating a workshop from a chapter page' do
+      around do |example|
+        travel_to Time.zone.local(2020, 12, 0o1, 0, 0, 0)
+        example.run
+        travel_back
+      end
+
+      scenario 'pre-selects the chapter and allows organisers to be assigned' do
+        kept_organiser = Fabricate(:member)
+        removed_organiser = Fabricate(:member)
+        kept_organiser.add_role(:organiser, chapter)
+        removed_organiser.add_role(:organiser, chapter)
+
+        visit admin_chapter_path(chapter)
+
+        within('.col-12.col-lg-8') do
+          click_on 'New workshop'
+        end
+
+        expect(page).to have_css('h1', text: "New Workshop for #{chapter.name}")
+        expect(page).to have_title("New Workshop for #{chapter.name}")
+        expect(page).to have_no_select('workshop_chapter_id')
+        expect(page).to have_select('workshop_organisers', with_options: [kept_organiser.full_name, removed_organiser.full_name])
+
+        unselect removed_organiser.full_name, from: 'workshop_organisers'
+
+        fill_in 'Date', with: Date.current
+        fill_in 'Begins at', with: '11:30'
+        fill_in 'Ends at', with: '12:45'
+
+        within '#host' do
+          select sponsor.name
+        end
+
+        click_on 'Save'
+
+        expect(page).to have_text('Workshop successfully created')
+        workshop = Workshop.last
+        expect(workshop.chapter).to eq(chapter)
+        expect(workshop.organisers.map(&:id)).to include(kept_organiser.id)
+        expect(workshop.organisers.map(&:id)).not_to include(removed_organiser.id)
+      end
+
+      scenario 'falls back to the standard form when chapter_id is invalid' do
+        visit new_admin_workshop_path(chapter_id: 0)
+
+        expect(page).to have_css('h1', text: 'New Workshop')
+        expect(page).to have_title('New Workshop')
+        expect(page).to have_select('workshop_chapter_id')
+        expect(page).to have_no_select('workshop_organisers')
+      end
+    end
   end
 
   context 'with dietary restrictions' do


### PR DESCRIPTION
Closes #2398.

When creating a workshop from a chapter admin page, the chapter is now pre-selected, the chapter dropdown is hidden, and the chapter's organisers are shown as pre-selected but editable. The page heading and browser title also reflect the selected chapter.

<img width="1064" height="1007" alt="image" src="https://github.com/user-attachments/assets/cbabe4ec-70d1-4d1a-8fc5-01696306780c" />

## Changes

- Pass `chapter_id` from the chapter show page's "New workshop" link.
- Pre-select the chapter in `Admin::WorkshopsController#new` when a valid `chapter_id` is provided.
- Hide the chapter select and show the organisers input on the new-workshop form when a chapter is pre-selected.
- Add a hidden `chapter_id` field so a failed create re-renders with the chapter still selected.
- Assign the selected organisers on create when the organisers param is present; otherwise keep the existing behaviour of auto-granting all chapter organisers.
- Update the new-workshop page heading and title to "New Workshop for <chapter name>" when a chapter is pre-selected.
- Add feature specs for the chapter-prefixed create flow and invalid `chapter_id` fallback.

## How to verify

1. Start the app locally (`bundle exec rails server`) and sign in as an admin or chapter organiser.
2. Go to a chapter's admin page (e.g., `/admin/chapters/<chapter-id>`).
3. Click the **New workshop** button.
4. Confirm the page heading reads **New Workshop for <chapter name>**, the browser tab title matches, the **Chapter** dropdown is hidden, and the **Organisers** multi-select is visible with the chapter's organisers pre-selected.
5. Remove one or more organisers, fill in the required fields (date, time, host), and click **Save**.
6. On the workshop page, confirm that only the organisers you kept are listed.
7. Visit `/admin/workshops/new` directly (without a `chapter_id`) and confirm the heading is **New Workshop**, the **Chapter** dropdown is visible, and there is no **Organisers** input.
8. Run the test suite: `make test`.

## Verification

- `bundle exec rspec spec/features/admin/workshops_spec.rb` passes.
- `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb` passes.
- `bundle exec rubocop` passes for the changed Ruby files.
- `bundle exec haml-lint` passes for the changed HAML files.
- `make test` passes (1226 examples, 0 failures).