### PR TITLE
fix(auth): link codebar logins to existing members by GitHub id

### DIFF
--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -33,7 +33,7 @@ class AuthServicesController < ApplicationController
           return redirect_to root_url
         end
 
-        member = Member.find_by(email:)
+        member = member_from_github_id || Member.find_by(email:)
         member ||= Member.new(email:)
         new_member = member.new_record?
 
@@ -88,6 +88,15 @@ class AuthServicesController < ApplicationController
   end
 
   private
+
+  def member_from_github_id
+    return unless omnihash[:provider] == 'codebar'
+
+    github_id = omnihash.dig(:extra, :raw_info, 'github_id')
+    return if github_id.blank?
+
+    AuthService.find_by(provider: 'github', uid: github_id.to_s)&.member
+  end
 
   def referer_or_dashboard_path
     session[:referer_path] || dashboard_path

--- a/spec/requests/auth_services_callback_spec.rb
+++ b/spec/requests/auth_services_callback_spec.rb
@@ -74,4 +74,60 @@ RSpec.describe 'AuthServices callback' do
     expect(response).to redirect_to(edit_member_details_path)
     expect(session[:new_member]).to be_nil
   end
+
+  it 'links a codebar callback to an existing member via legacy github id when emails differ' do
+    original = Fabricate(:member, email: 'original@example.com')
+    Fabricate(:auth_service, member: original, provider: 'github', uid: '12345')
+
+    mock_auth_hash(provider: 'codebar', uid: 'different@example.com',
+                   email: 'different@example.com', github_id: '12345')
+
+    expect { post '/auth/codebar/callback' }
+      .to change { original.reload.auth_services.where(provider: 'codebar').count }.by(1)
+
+    expect(response).to redirect_to(dashboard_path)
+    expect(session[:member_id]).to eq(original.id)
+    expect(Member.where(email: 'different@example.com').count).to eq(0)
+  end
+
+  it 'creates a new member when the codebar callback has no matching github id or email' do
+    Fabricate(:member, email: 'existing@example.com')
+    Fabricate(:auth_service, provider: 'github', uid: '99999')
+
+    mock_auth_hash(provider: 'codebar', uid: 'brandnew@example.com',
+                   email: 'brandnew@example.com', github_id: '11111')
+
+    expect { post '/auth/codebar/callback' }.to change(Member, :count).by(1)
+
+    expect(response).to redirect_to(edit_member_details_path)
+  end
+
+  it 'prefers github_id over email when they resolve to different members' do
+    member_a = Fabricate(:member, email: 'a@example.com')
+    Fabricate(:auth_service, member: member_a, provider: 'github', uid: '12345')
+    member_b = Fabricate(:member, email: 'b@example.com')
+    member_b_codebar_count = member_b.auth_services.where(provider: 'codebar').count
+
+    mock_auth_hash(provider: 'codebar', uid: 'b@example.com',
+                   email: 'b@example.com', github_id: '12345')
+
+    expect { post '/auth/codebar/callback' }
+      .to change { member_a.reload.auth_services.where(provider: 'codebar').count }.by(1)
+
+    expect(session[:member_id]).to eq(member_a.id)
+    expect(member_b.reload.auth_services.where(provider: 'codebar').count).to eq(member_b_codebar_count)
+    expect(Member.count).to eq(2)
+  end
+
+  it 'falls back to email matching when the codebar callback has no github_id' do
+    existing = Fabricate(:member, email: 'fallback@example.com')
+
+    mock_auth_hash(provider: 'codebar', uid: 'fallback@example.com',
+                   email: 'fallback@example.com')
+
+    post '/auth/codebar/callback'
+
+    expect(session[:member_id]).to eq(existing.id)
+    expect(response).to redirect_to(dashboard_path)
+  end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,7 +1,8 @@
 require 'omniauth'
 
 module OmniauthMacros
-  def mock_auth_hash(name: Faker::Name.name, email: Faker::Internet.email, provider: 'codebar', uid: 'uid')
+  def mock_auth_hash(name: Faker::Name.name, email: Faker::Internet.email, provider: 'codebar', uid: 'uid',
+    github_id: nil)
     OmniAuth.config.mock_auth[provider.to_sym] = {
       provider: provider,
       uid: uid,
@@ -12,6 +13,11 @@ module OmniauthMacros
       credentials: {
         token: 'mock_token',
         secret: 'mock_secret'
+      },
+      extra: {
+        raw_info: {
+          'github_id' => github_id
+        }.compact
       }
     }
   end


### PR DESCRIPTION
## Summary

Fixes #2805.

Since the move to codebar auth (#2717), members whose GitHub primary email differs from their stored planner email have been created as a new member on login, losing roles and history. When the codebar auth callback includes a `github_id` claim, the sign-in flow now looks up the existing legacy GitHub `AuthService` before falling back to email matching. The lookup is scoped to the `codebar` provider so other OAuth strategies are unaffected.

## Changes

- `AuthServicesController#create` tries `member_from_github_id` before `Member.find_by(email:)`.
- Added a provider guard so only codebar callbacks read the `github_id` claim.
- Extended the OmniAuth test helper to carry `extra.raw_info.github_id`.
- Added request specs covering:
  - matching by `github_id` when emails differ,
  - `github_id` taking precedence over email,
  - falling back to email when no `github_id` is present,
  - creating a new member when nothing matches.

## Deployment note

This change requires the codebar auth app to include `github_id` in the id_token payload (auth app change described in option 1 of #2805). Without it, behaviour falls back to the existing email-based matching.

## Post-Deploy Monitoring & Validation

- Monitor Rollbar for `AuthServicesController` and OmniAuth callback errors after deploy.
- Check that members with a legacy GitHub auth service can still log in via codebar auth.
- Watch for any new duplicate member records created via codebar auth in the days after deploy.
- Verify the auth app id_token includes a `github_id` claim.

Related: #2717
