### PR TITLE
chore(deps): remove unused importmap-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,8 +73,6 @@ gem 'rails-html-sanitizer', '~> 1.7.1'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 8.0'
-# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-gem 'importmap-rails'
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem 'turbo-rails'
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,10 +240,6 @@ GEM
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
-    importmap-rails (2.2.3)
-      actionpack (>= 6.0.0)
-      activesupport (>= 6.0.0)
-      railties (>= 6.0.0)
     iniparse (1.5.0)
     io-console (0.9.2)
     irb (1.18.0)
@@ -660,7 +656,6 @@ DEPENDENCIES
   high_voltage
   icalendar
   image_processing
-  importmap-rails
   irb
   jquery-rails
   jwt
@@ -810,7 +805,6 @@ CHECKSUMS
   icalendar (2.12.4) sha256=acf9b8b166dad4679b8be2cc3202260896c199ab7302f748c760c97e9d32e3a2
   ice_cube (0.17.0) sha256=32deb45dda4b4acc53505c2f581f6d32b5afc04d29b9004769944a0df5a5fcbe
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
-  importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -5,7 +5,6 @@ CI.run do
 
   step "Style: Ruby", "bin/rubocop"
 
-  step "Security: Importmap vulnerability audit", "bin/importmap audit"
   step "Tests: Rails", "bin/rails test"
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 


### PR DESCRIPTION
## What

Removes the unused `importmap-rails` gem and its dangling CI step.

## Why

`importmap-rails` was added to the Gemfile but the project never wired it up:

- no `config/importmap.rb`
- no `app/javascript` directory
- no `javascript_importmap_tags` in layouts
- the CI step `bin/importmap audit` pointed to a missing `bin/importmap` binstub

It is therefore dead weight.

## Changes

- Remove `gem 'importmap-rails'` from `Gemfile`
- Remove `importmap-rails` from `Gemfile.lock`
- Remove the `Security: Importmap vulnerability audit` step from `config/ci.rb`

## Verification

- `bundle exec rubocop Gemfile config/ci.rb` — clean
- `bundle exec rails runner 'puts "boot OK"'` — boots
- `bundle exec rspec spec/models/chapter_spec.rb` — 15 examples, 0 failures