### PR TITLE
chore(deps): remove unused coffee-script gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ ruby file: '.ruby-version'
 gem 'rails', '~> 8.1.3' # LOCKED: It is Rails.
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
-# LOCKED: Added because Sprockets autoloads it when seeing .coffee files in the
-# asset pipeline. Can be removed when that does not happen.
-gem 'coffee-script'
-
 gem 'amazing_print' # colourful output (suggested by rails_semantic_logger)
 gem 'rails_semantic_logger' # condense log lines: https://github.com/codebar/planner/issues/2339
 gem 'strong_migrations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,10 +151,6 @@ GEM
       logger (~> 1.5)
     cocoon (1.2.15)
     coderay (1.1.3)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     commonmarker (2.9.0-aarch64-linux)
     commonmarker (2.9.0-arm64-darwin)
     commonmarker (2.9.0-x86_64-darwin)
@@ -641,7 +637,6 @@ DEPENDENCIES
   carrierwave
   carrierwave-aws (~> 1.6)
   cocoon
-  coffee-script
   commonmarker
   csv
   database_cleaner
@@ -763,8 +758,6 @@ CHECKSUMS
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   cocoon (1.2.15) sha256=d08f14e69653287d7a060ee43389b8c824e55191dffbca0c5c586f38ef491f0d
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
-  coffee-script (2.4.1) sha256=82fe281e11b93c8117b98c5ea8063e71741870f1c4fbb27177d7d6333dd38765
-  coffee-script-source (1.12.2) sha256=e12b16fd8927fbbf8b87cb2e9a85a6cf457c6881cc7ff8b1af15b31f70da07a4
   commonmarker (2.9.0-aarch64-linux) sha256=e2b4aadb9a2cfa4e206582641ce3a49465549ac1ed4c289fdd63b78d8f24579c
   commonmarker (2.9.0-arm64-darwin) sha256=1748dbfa4f5813b0d2a14bb4bbfa65a4ec293aa1c825016d60029ee0e132b046
   commonmarker (2.9.0-x86_64-darwin) sha256=0a9914ccfd2f5d2a59c7bd0dda4fe90eb084cf513b477e499008e09ec9d6edd6


### PR DESCRIPTION
## What

Removes the `coffee-script` gem and its lockfile entries.

## Why

- No `.coffee` files exist in the repo.
- No bundled gem contains `.coffee` files.
- The Gemfile comment above the gem said it was only kept because Sprockets autoloads it when `.coffee` files are present, and that it could be removed when that no longer happens.

## Changes

- Remove `gem 'coffee-script'` and its explanatory comment from `Gemfile`
- Remove `coffee-script` and `coffee-script-source` from `Gemfile.lock`

## Verification

- `bundle exec rubocop Gemfile` — clean
- `bundle exec rails runner 'puts "boot OK"'` — boots
- `bundle exec rspec spec/models/chapter_spec.rb` — 15 examples, 0 failures
- `RAILS_ENV=test bundle exec rails assets:precompile` — succeeds without the CoffeeScript processor