### PR TITLE
fix(assets): restore missing feedback-rating require after pickadate merge

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require rails-ujs
 //= require activestorage
 //= require chosen.jquery
+//= require feedback-rating
 //= require subscriptions-toggle
 //= require add-all-chapters
 //= require invitations


### PR DESCRIPTION
## Problem

PR #2814 (remove pickadate) merge dropped the `feedback-rating` require that PR #2812 had added. The `app/assets/javascripts/feedback-rating.js` file still exists in the repo but is no longer included in the Sprockets manifest, so the star rating UI on feedback forms is broken.

## Fix

Restore the `//= require feedback-rating` line in `application.js`.