### PR TITLE
refactor(admin): replace Chosen with datalist for sponsor chapter filter

### DIFF
--- a/app/queries/sponsors_search.rb
+++ b/app/queries/sponsors_search.rb
@@ -26,8 +26,15 @@ class SponsorsSearch
   end
 
   def by_chapter
-    if chapter.present?
-      @sponsors = sponsors.joins(:workshops).where('workshops.chapter_id' => chapter).group('sponsors.id')
-    end
+    return if chapter.blank?
+
+    chapter_id = chapter.to_s.match?(/\A\d+\z/) ? chapter : lookup_chapter_id
+    return unless chapter_id
+
+    @sponsors = sponsors.joins(:workshops).where('workshops.chapter_id' => chapter_id).group('sponsors.id')
+  end
+
+  def lookup_chapter_id
+    Chapter.find_by('LOWER(name) = LOWER(?)', chapter.strip)&.id
   end
 end

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -1,20 +1,32 @@
+- title 'Sponsors'
+%style= ".form-control::placeholder { opacity: 0.7; }"
+
 .container.py-4.py-lg-5
   .row.mb-4
     .col-12
       %nav{'aria-label': 'breadcrumb'}
         %ol.breadcrumb.ms-0
-          %li.breadcrumb-item.active= t('admin.shared.sponsors')
+          %li.breadcrumb-item= link_to 'Admin', admin_root_path
+          %li.breadcrumb-item.active Sponsors
+
+    .col-12
+      %h1.mb-3 Sponsors
 
     .col-12
       .row.row-cols-md-auto.align-items-center
-        = simple_form_for @sponsors_search, url: admin_sponsors_path, method: :get, wrapper: :inline_form, html: { class: 'row row-cols-1 row-cols-md-auto align-items-center' } do |f|
-          = f.input :chapter, as: :string, required: false, label: false, placeholder: 'Filter by chapter', input_html: { list: 'chapter-options', class: 'my-2 my-md-0' }
+        = form_with model: @sponsors_search, url: admin_sponsors_path, method: :get, class: 'row row-cols-1 row-cols-md-auto align-items-end gap-1' do |f|
+          .col
+            = f.label :chapter, 'Chapter', class: 'form-label'
+            = f.text_field :chapter, list: 'chapter-options', placeholder: 'ex: London', class: 'form-control w-auto'
           %datalist#chapter-options
             - @chapters.each do |chapter|
               %option{ value: chapter.name }
-          = f.input :name, required: false, label: false, placeholder: 'Filter by sponsor name', input_html: { class: 'my-2 my-md-0' }
-          = f.button :button, 'Filter', class: 'btn btn-primary'
-        = link_to 'Reset form', admin_sponsors_path
+          .col
+            = f.label :name, 'Sponsor name', class: 'form-label'
+            = f.text_field :name, placeholder: 'ex: Google', class: 'form-control w-auto'
+          .col
+            = f.button 'Filter', class: 'btn btn-primary'
+            = link_to 'Reset form', admin_sponsors_path
 
   = render partial: 'shared/pagination', locals: { pagy: @pagy, model: 'sponsor' }
 
@@ -43,5 +55,3 @@
                   = link_to chapter.name, admin_chapter_path(chapter)
               %td
                 = sponsor.sponsorships_count
-
-  = render partial: 'shared/pagination', locals: { pagy: @pagy, model: 'sponsor' }

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -8,7 +8,10 @@
     .col-12
       .row.row-cols-md-auto.align-items-center
         = simple_form_for @sponsors_search, url: admin_sponsors_path, method: :get, wrapper: :inline_form, html: { class: 'row row-cols-1 row-cols-md-auto align-items-center' } do |f|
-          = f.collection_select :chapter, @chapters, :id, :name, { include_blank: true, prompt: 'Select a chapter' }, { class: 'chosen-select'}
+          = f.input :chapter, as: :string, required: false, label: false, placeholder: 'Filter by chapter', input_html: { list: 'chapter-options', class: 'my-2 my-md-0' }
+          %datalist#chapter-options
+            - @chapters.each do |chapter|
+              %option{ value: chapter.name }
           = f.input :name, required: false, label: false, placeholder: 'Filter by sponsor name', input_html: { class: 'my-2 my-md-0' }
           = f.button :button, 'Filter', class: 'btn btn-primary'
         = link_to 'Reset form', admin_sponsors_path

--- a/spec/features/admin/filtering_sponsors_list_spec.rb
+++ b/spec/features/admin/filtering_sponsors_list_spec.rb
@@ -25,5 +25,23 @@ RSpec.feature 'Admin filtering sponsors list', type: :feature do
         expect(page).to have_text(sponsors.first.name)
       end
     end
+
+    describe 'when filtering by chapter' do
+      let!(:chapter) { Fabricate(:chapter, name: 'London') }
+      let!(:workshop) { Fabricate(:workshop_no_sponsor, chapter: chapter) }
+      let!(:matching_sponsor) { Fabricate(:sponsor) }
+
+      before do
+        Fabricate(:workshop_sponsor, workshop: workshop, sponsor: matching_sponsor)
+      end
+
+      scenario 'only sponsors for that chapter are displayed' do
+        fill_in 'sponsors_search[chapter]', with: 'London'
+        click_on 'Filter'
+
+        expect(page).to have_css('.sponsor', count: 1)
+        expect(page).to have_text(matching_sponsor.name)
+      end
+    end
   end
 end

--- a/spec/queries/sponsors_search_spec.rb
+++ b/spec/queries/sponsors_search_spec.rb
@@ -44,6 +44,29 @@ RSpec.describe SponsorsSearch do
       expect(results).to contain_exactly(matching)
     end
 
+    it 'filters by chapter name' do
+      chapter = Fabricate(:chapter, name: 'London')
+      matching = Fabricate(:sponsor)
+      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter), sponsor: matching)
+      Fabricate(:sponsor)
+
+      results = described_class.new(name: nil, chapter: 'London').call
+
+      expect(results).to contain_exactly(matching)
+    end
+
+    it 'is case insensitive when filtering by chapter name' do
+      chapter = Fabricate(:chapter, name: 'London')
+      matching = Fabricate(:sponsor)
+      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter), sponsor: matching)
+
+      results = described_class.new(name: nil, chapter: 'london').call
+      expect(results).to contain_exactly(matching)
+
+      results = described_class.new(name: nil, chapter: 'LONDON').call
+      expect(results).to contain_exactly(matching)
+    end
+
     it 'filters by chapter' do
       chapter = Fabricate(:chapter)
       matching = Fabricate(:sponsor)


### PR DESCRIPTION
## What

Replaces the Chosen-enhanced `collection_select` on `/admin/sponsors` with a native text input backed by a `<datalist>` of chapter names.

## Why

Chosen 1.8.7 is abandoned (last release 2018). This is the first step in migrating admin selects away from it. The sponsors index chapter filter is the smallest and simplest case — 54 chapters, well within Chromium's 512-option datalist limit.

## Changes

- `app/views/admin/sponsors/index.html.haml` — `collection_select` → `f.input :chapter, as: :string` with `list: 'chapter-options'` and a `<datalist>`
- `app/queries/sponsors_search.rb` — `by_chapter` now accepts chapter names (case-insensitive lookup) as well as IDs for backward compatibility
- Tests added for chapter name filtering and case insensitivity

## No JavaScript

Zero JS required. Works with native browser autocomplete.

## Testing

- `bundle exec rspec spec/queries/sponsors_search_spec.rb` — 10 examples, 0 failures
- `bundle exec rspec spec/features/admin/filtering_sponsors_list_spec.rb` — 3 scenarios, 0 failures
