### PR TITLE
Improve sponsor filter UX and page layout

### DIFF
--- a/app/queries/sponsors_search.rb
+++ b/app/queries/sponsors_search.rb
@@ -29,9 +29,12 @@ class SponsorsSearch
     return if chapter.blank?
 
     chapter_id = chapter.to_s.match?(/\A\d+\z/) ? chapter : lookup_chapter_id
-    return unless chapter_id
-
-    @sponsors = sponsors.joins(:workshops).where('workshops.chapter_id' => chapter_id).group('sponsors.id')
+    if chapter_id
+      @sponsors = sponsors.joins(:workshops).where('workshops.chapter_id' => chapter_id).group('sponsors.id')
+    else
+      errors.add(:chapter, :not_found, message: 'no chapter with that name')
+      @sponsors = Sponsor.none
+    end
   end
 
   def lookup_chapter_id

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -43,7 +43,7 @@
             %th
               Level
             %th
-              Chapter(s)
+              Chapters
             %th
               Sponsorships
         %tbody

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -1,9 +1,15 @@
+- title 'Sponsors'
+
 .container.py-4.py-lg-5
   .row.mb-4
     .col-12
       %nav{'aria-label': 'breadcrumb'}
         %ol.breadcrumb.ms-0
-          %li.breadcrumb-item.active= t('admin.shared.sponsors')
+          %li.breadcrumb-item= link_to 'Admin', admin_root_path
+          %li.breadcrumb-item.active Sponsors
+
+    .col-12
+      %h1.mb-3 Sponsors
 
     .col-12
       .row.row-cols-md-auto.align-items-center

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -1,4 +1,5 @@
 - title 'Sponsors'
+%style= ".form-control::placeholder { opacity: 0.7; }"
 
 .container.py-4.py-lg-5
   .row.mb-4
@@ -12,12 +13,23 @@
       %h1.mb-3 Sponsors
 
     .col-12
-      .row.row-cols-md-auto.align-items-center
-        = form_with model: @sponsors_search, url: admin_sponsors_path, method: :get, class: 'row row-cols-1 row-cols-md-auto align-items-center' do |f|
-          = render(ChapterPickerComponent.new(name: 'sponsors_search[chapter]', chapters: @chapters, selected: @sponsors_search.chapter, placeholder: 'Filter by chapter'))
-          = f.text_field :name, placeholder: 'Filter by sponsor name', class: 'form-control w-auto my-2 my-md-0'
-          = f.button 'Filter', class: 'btn btn-primary'
-        = link_to 'Reset form', admin_sponsors_path
+      = form_with model: @sponsors_search, url: admin_sponsors_path, method: :get do |f|
+        %fieldset.border.rounded.bg-light.p-3
+          %legend Filter sponsors
+          .row.row-cols-1.row-cols-md-auto.align-items-start.gap-1
+            - chapter_error = @sponsors_search.errors[:chapter].any?
+            .col
+              = f.label :chapter, 'Chapter', class: 'form-label'
+              = render(ChapterPickerComponent.new(name: 'sponsors_search[chapter]', chapters: @chapters, selected: @sponsors_search.chapter, placeholder: 'ex: London'))
+              - if chapter_error
+                .invalid-feedback.d-block= @sponsors_search.errors[:chapter].join(', ')
+            .col
+              = f.label :name, 'Sponsor name', class: 'form-label'
+              = f.text_field :name, placeholder: 'ex: Google', class: 'form-control w-auto'
+            .col
+              .form-label.invisible &nbsp;
+              = f.button 'Filter', class: 'btn btn-primary'
+              = link_to 'Reset form', admin_sponsors_path
 
   = render partial: 'shared/pagination', locals: { pagy: @pagy, model: 'sponsor' }
 
@@ -46,5 +58,3 @@
                   = link_to chapter.name, admin_chapter_path(chapter)
               %td
                 = sponsor.sponsorships_count
-
-  = render partial: 'shared/pagination', locals: { pagy: @pagy, model: 'sponsor' }

--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -1,6 +1,6 @@
 .row.align-items-center.justify-content-between
   .col-auto
     %p.mb-3
-      != pagy.info_tag(item_name: model)
+      != pagy.info_tag(item_name: model.pluralize(pagy.count))
   .col-auto
     != pagy.series_nav(:bootstrap) if pagy.pages > 1

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
       click_on 'Filter'
 
       expect(page).to have_css('tbody tr', count: 0)
-      expect(page).to have_text('No sponsor found')
+      expect(page).to have_text('No sponsors found')
     end
 
     scenario 'can clear filtering form' do

--- a/spec/queries/sponsors_search_spec.rb
+++ b/spec/queries/sponsors_search_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe SponsorsSearch do
       expect(results).to contain_exactly(matching)
     end
 
+    it 'returns an empty relation when chapter does not exist' do
+      Fabricate(:sponsor)
+      search = described_class.new(name: nil, chapter: 'Nonexistent')
+
+      results = search.call
+
+      expect(results).to be_empty
+      expect(search.errors[:chapter]).to include('no chapter with that name')
+    end
+
     it 'returns an empty relation when nothing matches' do
       Fabricate(:sponsor, name: 'Apple Inc')
 


### PR DESCRIPTION
> **Stacked on #2820** — review and merge that PR first.

## What

Improves the admin sponsors filter form and page layout.

## Changes

- Add page title (`<title>`) and `<h1>` heading
- Add breadcrumb with link back to Admin
- Replace raw inputs with labelled form fields in a styled fieldset
- Add validation error when chapter name is not found
- Style fieldset with Bootstrap border, background and rounded corners
- Fix pagination info tag to pluralize item names correctly
- Rename table heading from "Chapter(s)" to "Chapters"
- Remove duplicate pagination render

#### Screenshot

<img width="967" height="696" alt="image" src="https://github.com/user-attachments/assets/5a09f677-8d5b-466a-95d3-82a16e2ab672" />

## Testing

- `bundle exec rspec spec/queries/sponsors_search_spec.rb`
- `bundle exec rspec spec/features/admin/filtering_sponsors_list_spec.rb`