### PR TITLE
refactor(js): remove dead Chosen code from invitations.js

### DIFF
--- a/app/assets/javascripts/invitations.js
+++ b/app/assets/javascripts/invitations.js
@@ -8,27 +8,6 @@ $(document).ready(function() {
       var rowId = $row.attr('id');
       $row.replaceWith(xhr.responseText);
       $(".row.attendee[id='" + rowId + "']").find('[data-bs-toggle="tooltip"]').tooltip();
-    } else {
-      var $invitations = $("#invitations");
-      $invitations.html(xhr.responseText);
-
-      $invitations.find('select').chosen({
-        allow_single_deselect: true,
-        no_results_text: 'No results matched'
-      });
     }
   });
-  
-  $(document).on('change','#workshop_invitations ',function() {
-    // Rails 5.1 has dropped jquery as a dependency and therefore has replaced jquery-ujs with a complete rewritten rails-ujs.
-    // See:
-    // + http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/
-    // + https://stackoverflow.com/questions/12683524/with-rails-ujs-how-to-submit-a-remote-form-from-a-function
-    // As such, you'll have to trigger the proper CustomEvent object in rails-ujs.
-    //
-    // NOTE: Without this, if we simply call this.form.submit() then we get a 500 HTTP status code and the following logs:
-    // Can't verify CSRF token authenticity.
-    // ActionController::InvalidAuthenticityToken
-    Rails.fire(this.form, 'submit');
-  })
 });


### PR DESCRIPTION
## What

Prunes dead Chosen-related code from `app/assets/javascripts/invitations.js`.

## Why

The `ajax:success` handler had two branches:

1. `verify_attendance` — still used for targeted row replacement after attendance verify/unverify clicks
2. `else` — replaced entire `#invitations` container and re-initialised Chosen on any `<select>` inside it

The `else` branch is dead code: no `<select>` elements exist in any `#invitations` container anymore:
- `admin/workshops/_invitation_management` — no selects
- `admin/meetings/_invitation_management` — uses TomSelect (`class: 'tom-select'`)
- `admin/events/_invitation_management` — select is commented out

Also removed the dead `change` handler for `#workshop_invitations`, which has no matching element in the DOM.

## What stays

The `verify_attendance` row replacement and tooltip re-initialisation is still needed and untouched.

## Testing

- `bundle exec rspec spec/features/admin/manage_workshop_attendances_spec.rb` — 7 scenarios, 0 failures
- `bundle exec rspec spec/features/managing_workshop_attendance_spec.rb` — 28 scenarios, 0 failures
