### PR TITLE
Manage subscriptions page shouldn't show ALL chapters!

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,7 +3,7 @@ class SubscriptionsController < ApplicationController
 
   def index
     @mailing_list = MailingListForm.new
-    @groups = Group.includes(:chapter).references(:chapter).order('chapters.city')
+    @groups = Group.where(chapter: { active: true }).order('chapter.city')
     @member = MemberPresenter.new(current_user)
   end
 

--- a/spec/features/subscribing_to_emails_spec.rb
+++ b/spec/features/subscribing_to_emails_spec.rb
@@ -21,6 +21,16 @@ RSpec.feature 'Managing subscriptions', type: :feature do
       click_on 'Subscribed'
       expect(page).to have_text("You have unsubscribed from #{group.chapter.city}'s #{group.name} group")
     end
+
+    scenario 'groups belonging to inactive chapters are not shown' do
+      inactive_chapter = Fabricate(:chapter, active: false)
+      Fabricate(:group, chapter: inactive_chapter)
+
+      visit subscriptions_path
+
+      expect(page).to have_text(group.chapter.name)
+      expect(page).to have_no_text(inactive_chapter.name)
+    end
   end
 
   context 'when a member receives a welcome email' do


### PR DESCRIPTION
Fixes #2816.

The subscriptions page (`/subscriptions`) listed every chapter's groups, including deactivated ones. `SubscriptionsController#index` now filters to active chapters:

```ruby
@groups = Group.where(chapter: { active: true }).order('chapter.city')
```

`Group` already carries a `default_scope` that joins and includes `chapter`, so the extra `includes`/`references` in the old query were redundant and are dropped. The `order` now references the join alias `chapter` (Postgres rejects `chapters.city` against that alias).

A feature spec confirms a group belonging to an `active: false` chapter is not rendered, while an active one is.

Note: a member already subscribed to a group in a now-deactivated chapter will no longer see (or be able to unsubscribe from) that subscription on this page, which matches the issue's intent of hiding deactivated chapters entirely.