### PR TITLE
fix: persist delivered email body in MemberEmailDelivery

### DIFF
--- a/app/mailers/concerns/email_delivery.rb
+++ b/app/mailers/concerns/email_delivery.rb
@@ -11,7 +11,9 @@ module EmailDelivery
     MemberEmailDelivery.create!(
       member: member,
       subject: mail.subject,
-      body: mail.body.to_s,
+      # premailer-rails' interceptor empties the body container and moves the
+      # content into text/html parts during delivery, so read the html part
+      body: mail.html_part ? mail.html_part.body.to_s : mail.body.to_s,
       to: Array(mail.to),
       cc: Array(mail.cc),
       bcc: Array(mail.bcc)

--- a/app/mailers/concerns/email_delivery.rb
+++ b/app/mailers/concerns/email_delivery.rb
@@ -11,8 +11,6 @@ module EmailDelivery
     MemberEmailDelivery.create!(
       member: member,
       subject: mail.subject,
-      # premailer-rails' interceptor empties the body container and moves the
-      # content into text/html parts during delivery, so read the html part
       body: mail.html_part ? mail.html_part.body.to_s : mail.body.to_s,
       to: Array(mail.to),
       cc: Array(mail.cc),

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -182,6 +182,10 @@ RSpec.describe MemberMailer do
       expect(log.member).to eq(member)
       expect(log.subject).to eq('It’s been a while, how are you doing? ♥️')
       expect(log.to).to eq([member.email])
+      # premailer-rails converts the message to multipart/alternative during
+      # delivery, so the logged body must come from the html part
+      expect(log.body).to be_present
+      expect(log.body).to include('codebar workshop')
     end
   end
 end


### PR DESCRIPTION
## Problem

`member_email_deliveries.body` has never captured any content — all 439 rows in production are empty, so the email audit log cannot show what was actually sent.

## Root cause

`premailer-rails` registers a Mail interceptor that runs during delivery: it converts the message to `multipart/alternative` (adding a plain-text part and inlining CSS), which empties the body container. `EmailDelivery#log_sent_email` then runs in an `after_deliver` callback and reads `mail.body.to_s` — the now-empty container — storing `""`.

The emails themselves are unaffected: recipients receive complete `multipart/alternative` messages with both plain-text and HTML parts. Only the audit log is broken. Chaser dedup checks row existence, not body, so it works as before.

## Fix

Read the html part instead of the body container:

```ruby
body: mail.html_part ? mail.html_part.body.to_s : mail.body.to_s,
```

Pure plain-text mailers (no html part) fall back to `mail.body` as before.

## Testing

Extended the `MemberMailer#chaser` logging spec to assert the persisted row has a body containing the template copy. Confirmed red→green: the assertion fails with `""` on master and passes with the fix. Full mailer specs and the three-month chaser service spec pass (85 examples), RuboCop clean.

## Context

Found while diagnosing chaser reliability for #2384 (chaser introduced in #2449 for #2383).