### PR TITLE
test: wire ViewComponent RSpec helpers via type metadata

### DIFF
--- a/spec/components/chapter_picker_component_spec.rb
+++ b/spec/components/chapter_picker_component_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
-require 'view_component/test_helpers'
 
 RSpec.describe ChapterPickerComponent do
-  include ViewComponent::TestHelpers
-
   let(:chapters) { Fabricate.times(3, :chapter) }
 
   it 'renders a text input with datalist attributes' do

--- a/spec/components/chapters_sidebar_component_spec.rb
+++ b/spec/components/chapters_sidebar_component_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
-require 'view_component/test_helpers'
 
 RSpec.describe ChaptersSidebarComponent do
-  include ViewComponent::TestHelpers
   include Rails.application.routes.url_helpers
 
   let(:chapters) { Fabricate.times(3, :chapter) }

--- a/spec/components/event_card_component_spec.rb
+++ b/spec/components/event_card_component_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
-require 'view_component/test_helpers'
 
 RSpec.describe EventCardComponent, type: :component do
-  include ViewComponent::TestHelpers
   let(:chapter) { Fabricate(:chapter, active: true) }
 
   context 'with a workshop' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,13 +29,16 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours based on the
-  # file location of the spec. This line needs to be present for ViewComponent
-  # to work with controller specs
+  # file location of the spec.
+  # Register the spec/components directory mapping BEFORE inference runs —
+  # `infer_spec_type_from_file_location!` snapshots DIRECTORY_MAPPINGS at call time.
+  RSpec::Rails::DIRECTORY_MAPPINGS[:component] = %w[spec components]
   config.infer_spec_type_from_file_location!
 
-  # Connect ViewComponent to RSpec, adding RSpec metadata type: :component.
-  # This extends Rails' own built-in (e.g. "type: :controller") metadata system.
-  RSpec::Rails::DIRECTORY_MAPPINGS[:component] = %w[spec/components]
+  # ViewComponent does not wire its RSpec helpers into RSpec itself (no
+  # lib/view_component/rspec.rb in v4), so include them for type: :component specs.
+  require 'view_component/test_helpers'
+  config.include ViewComponent::TestHelpers, type: :component
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
Follow-up to #2820, addressing [Olle's comment](https://github.com/codebar/planner/pull/2820#discussion_r3890376455): component specs should get `ViewComponent::TestHelpers` via RSpec type metadata instead of requiring and including it by hand.

While checking, we found that path-based inference for `type: :component` **never actually worked** in this repo. `infer_spec_type_from_file_location!` iterates `DIRECTORY_MAPPINGS` at call time, but `spec/rails_helper.rb` registered the `:component` mapping only on the following line. `event_card_component_spec` masked the problem by declaring `type: :component` explicitly (the view_component generator adds it); the other two component specs patched over the missing helpers with a manual `require` + `include`.

## Changes

- `spec/rails_helper.rb`: register `DIRECTORY_MAPPINGS[:component]` **before** calling `infer_spec_type_from_file_location!`, and include `ViewComponent::TestHelpers` once for `type: :component` specs. ViewComponent 4.x no longer ships its own RSpec auto-wiring (no `lib/view_component/rspec.rb`), so this belongs here.
- `spec/components/*`: drop the per-spec `require 'view_component/test_helpers'` and `include ViewComponent::TestHelpers` boilerplate.

Net −4 lines. All 16 component spec examples pass; rubocop clean.