### PR TITLE
chore: remove unused member_type from member_email_deliveries

### DIFF
--- a/app/models/member_email_delivery.rb
+++ b/app/models/member_email_delivery.rb
@@ -1,3 +1,5 @@
 class MemberEmailDelivery < ApplicationRecord
+  self.ignored_columns += ['member_type']
+
   belongs_to :member
 end

--- a/db/migrate/20260831090000_remove_member_type_from_member_email_deliveries.rb
+++ b/db/migrate/20260831090000_remove_member_type_from_member_email_deliveries.rb
@@ -1,0 +1,9 @@
+class RemoveMemberTypeFromMemberEmailDeliveries < ActiveRecord::Migration[8.1]
+  def change
+    # Safe to drop in a single phase: no code reads or writes member_type
+    # (introduced in PR #2449 for polymorphism that was never built, and
+    # NULL in every production row). Recipients are always Members, so
+    # re-add with a polymorphic association if non-member recipients arrive.
+    safety_assured { remove_column :member_email_deliveries, :member_type, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -243,10 +243,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
     t.string "token"
     t.datetime "updated_at", precision: nil
     t.integer "workshop_id"
-    t.index ["member_id"], name: "index_feedback_requests_on_member_id"
-    t.index ["workshop_id"], name: "index_feedback_requests_on_workshop_id"
     t.index ["member_id", "workshop_id"], name: "index_feedback_requests_on_member_id_and_workshop_id", unique: true
+    t.index ["member_id"], name: "index_feedback_requests_on_member_id"
     t.index ["token"], name: "index_feedback_requests_on_token", unique: true
+    t.index ["workshop_id"], name: "index_feedback_requests_on_workshop_id"
   end
 
   create_table "feedbacks", id: :serial, force: :cascade do |t|
@@ -351,9 +351,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
     t.index ["event_id", "attending"], name: "index_invitations_event_attending"
     t.index ["event_id"], name: "index_invitations_on_event_id"
     t.index ["member_id", "attending"], name: "index_invitations_member_attending"
+    t.index ["member_id", "event_id", "role"], name: "index_invitations_on_member_id_and_event_id_and_role", unique: true
     t.index ["member_id"], name: "index_invitations_on_member_id"
     t.index ["verified_by_id"], name: "index_invitations_on_verified_by_id"
-    t.index ["member_id", "event_id", "role"], name: "index_invitations_on_member_id_and_event_id_and_role", unique: true
   end
 
   create_table "jobs", id: :serial, force: :cascade do |t|
@@ -394,8 +394,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
     t.index ["meeting_id", "attending"], name: "index_meeting_invitations_meeting_attending"
     t.index ["meeting_id"], name: "index_meeting_invitations_on_meeting_id"
     t.index ["member_id", "attending"], name: "index_meeting_invitations_member_attending"
-    t.index ["member_id"], name: "index_meeting_invitations_on_member_id"
     t.index ["member_id", "meeting_id"], name: "index_meeting_invitations_on_member_id_and_meeting_id", unique: true
+    t.index ["member_id"], name: "index_meeting_invitations_on_member_id"
   end
 
   create_table "meetings", id: :serial, force: :cascade do |t|
@@ -421,7 +421,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
     t.text "cc", default: [], array: true
     t.datetime "created_at", null: false
     t.bigint "member_id"
-    t.string "member_type"
     t.text "subject"
     t.text "to", default: [], array: true
     t.datetime "updated_at", null: false
@@ -605,9 +604,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
     t.datetime "updated_at", precision: nil
     t.integer "workshop_id"
     t.index ["member_id", "attending"], name: "index_workshop_invitations_member_attending"
+    t.index ["member_id", "workshop_id", "role"], name: "idx_on_member_id_workshop_id_role_e3cea6bbfd", unique: true
     t.index ["member_id"], name: "index_workshop_invitations_on_member_id"
     t.index ["token"], name: "index_workshop_invitations_on_token", unique: true
-    t.index ["member_id", "workshop_id", "role"], name: "idx_on_member_id_workshop_id_role_e3cea6bbfd", unique: true
     t.index ["workshop_id", "attending"], name: "index_workshop_invitations_workshop_attending"
     t.index ["workshop_id"], name: "index_workshop_invitations_on_workshop_id"
   end
@@ -618,10 +617,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_091618) do
     t.integer "sponsor_id"
     t.datetime "updated_at", precision: nil
     t.integer "workshop_id"
+    t.index ["sponsor_id", "workshop_id"], name: "index_workshop_sponsors_on_sponsor_id_and_workshop_id", unique: true
     t.index ["sponsor_id"], name: "index_workshop_sponsors_on_sponsor_id"
     t.index ["workshop_id", "host"], name: "index_workshop_sponsors_on_workshop_id_and_host"
     t.index ["workshop_id"], name: "index_workshop_sponsors_on_workshop_id"
-    t.index ["sponsor_id", "workshop_id"], name: "index_workshop_sponsors_on_sponsor_id_and_workshop_id", unique: true
   end
 
   create_table "workshops", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Problem

`member_email_deliveries.member_type` is dead weight. It was added in #2449 (same day as the table) for polymorphism that was never built: the model is a plain `belongs_to :member`, the `EmailDelivery` concern never writes it, nothing reads it, and it is `NULL` in all 439 production rows.

## Change

- Drop the column (`safety_assured` — same single-phase pattern as the `can_log_in` removal in `20260806000000`; safe because no code references the column, so old dynos during a rolling deploy cannot break)
- Keep `ignored_columns` on the model to guard stale schema caches, matching the `can_log_in` precedent

If non-`Member` recipients ever need email logging, re-add the column together with a real polymorphic association.

## Testing

Migration applied to dev and test databases; `member_mailer` and `three_month_email_service` specs pass (32 examples, including the chaser logging spec that writes rows through the concern). RuboCop clean.

## Context

Found during the #2384 brainstorm while investigating the table's history.