### PR TITLE
chore: drop member_type from MemberEmailDelivery ignored_columns

### DIFF
--- a/app/models/member_email_delivery.rb
+++ b/app/models/member_email_delivery.rb
@@ -1,5 +1,3 @@
 class MemberEmailDelivery < ApplicationRecord
-  self.ignored_columns += ['member_type']
-
   belongs_to :member
 end


### PR DESCRIPTION
## Problem

Follow-up to #2829: the `ignored_columns += ['member_type']` guard added there is unnecessary and would linger as a "why is this here?" artifact.

## Reasoning

`ignored_columns` matters for two-phase column removals: deploy code that ignores the column first, drop it later, so old dynos with a stale schema cache can't generate SQL referencing it. That is why the `can_log_in` precedent kept its line — its rollout was two-phase.

Here the column removal ships in the same release as the migration, and no code ever referenced `member_type` (the concern's `INSERT`s list explicit attributes; all reads are `SELECT .*`). Old dynos during the rolling deploy cannot generate SQL mentioning the column, so there is nothing for the guard to protect.

## Context

Stacked on #2829 — base branch is `chore/remove-unused-member-type`; retarget to `master` when that merges.