### PR TITLE
Enable RuboCop EnforcedShorthandSyntax: always and autocorrect the codebase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -208,6 +208,7 @@ Style/GuardClause:
 
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: always
 
 Style/IfUnlessModifier:
   Enabled: false

--- a/app/controllers/admin/meeting_invitations_controller.rb
+++ b/app/controllers/admin/meeting_invitations_controller.rb
@@ -5,7 +5,7 @@ class Admin::MeetingInvitationsController < Admin::ApplicationController
     status = params.permit(:attendance_status)[:attendance_status]
     attended = params.permit(:attended)[:attended]
 
-    @invitation.update(attending: status, attended: attended)
+    @invitation.update(attending: status, attended:)
 
     redirect_to [:admin, @invitation.meeting],
                 notice: t('admin.messages.invitation.update_rsvp', name: @invitation.member.full_name)
@@ -15,12 +15,12 @@ class Admin::MeetingInvitationsController < Admin::ApplicationController
     member = Member.find(params[:meeting_invitations][:member])
     meeting = Meeting.find_by(slug: params[:meeting_invitations][:meeting_id])
 
-    if MeetingInvitation.accepted.where(meeting: meeting, member: member).exists?
+    if MeetingInvitation.accepted.where(meeting:, member:).exists?
       return redirect_to [:admin, meeting],
                          notice: t('admin.messages.invitation.already_on_list', name: member.full_name)
     end
 
-    invitation = meeting.invitations.find_or_create_by(member: member)
+    invitation = meeting.invitations.find_or_create_by(member:)
     invitation.assign_attributes(attending: true, role: 'Participant')
 
     if invitation.save

--- a/app/controllers/admin/meetings_controller.rb
+++ b/app/controllers/admin/meetings_controller.rb
@@ -54,7 +54,7 @@ class Admin::MeetingsController < Admin::ApplicationController
   private
 
   def set_meeting
-    @meeting = Meeting.find_by!(slug: slug)
+    @meeting = Meeting.find_by!(slug:)
   end
 
   def slug

--- a/app/controllers/admin/member_search_controller.rb
+++ b/app/controllers/admin/member_search_controller.rb
@@ -17,12 +17,12 @@ class Admin::MemberSearchController < Admin::ApplicationController
       redirect_to callback_url and return
     end
 
-    render 'index', locals: { members: members, callback_url: callback_url }
+    render 'index', locals: { members:, callback_url: }
   end
 
   def results
     pick_params = params.expect(member_pick: { members: [] })
     members = Member.find(pick_params[:members])
-    render 'show', locals: { members: members }
+    render 'show', locals: { members: }
   end
 end

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -282,6 +282,6 @@ class Admin::WorkshopsController < Admin::ApplicationController
   end
 
   def workshop_sponsor(host = false)
-    @workshop_sponsor ||= WorkshopSponsor.new(workshop: @workshop, sponsor: @sponsor, host: host)
+    @workshop_sponsor ||= WorkshopSponsor.new(workshop: @workshop, sponsor: @sponsor, host:)
   end
 end

--- a/app/controllers/chapter_controller.rb
+++ b/app/controllers/chapter_controller.rb
@@ -1,6 +1,6 @@
 class ChapterController < ApplicationController
   def show
-    @chapter = ChapterPresenter.new(Chapter.active.find_by!(slug: slug))
+    @chapter = ChapterPresenter.new(Chapter.active.find_by!(slug:))
 
     upcoming_workshops = upcoming_events_by_chapter(@chapter)
     @upcoming_workshops = event_presenters_by_date(upcoming_workshops)

--- a/app/controllers/concerns/workshop_invitation_concerns.rb
+++ b/app/controllers/concerns/workshop_invitation_concerns.rb
@@ -23,7 +23,7 @@ module WorkshopInvitationConcerns
     end
 
     def set_invitation
-      @invitation = WorkshopInvitation.includes(:workshop, :member).find_by!(token: token)
+      @invitation = WorkshopInvitation.includes(:workshop, :member).find_by!(token:)
     end
   end
 end

--- a/app/controllers/contact_preferences_controller.rb
+++ b/app/controllers/contact_preferences_controller.rb
@@ -1,6 +1,6 @@
 class ContactPreferencesController < ApplicationController
   def show
-    @contact = Contact.find_by(token: token)
+    @contact = Contact.find_by(token:)
 
     return if @contact
 
@@ -9,7 +9,7 @@ class ContactPreferencesController < ApplicationController
 
   def update
     contact = Contact.find_by!(token: contact_preferences[:token])
-    contact.update(mailing_list_consent: mailing_list_consent)
+    contact.update(mailing_list_consent:)
     ContactMailingListService.sync(contact)
     audit_contact_subscription(contact)
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -27,7 +27,7 @@ class EventsController < ApplicationController
 
     return unless logged_in?
 
-    invitation = Invitation.find_by(member: current_user, event: event, attending: true)
+    invitation = Invitation.find_by(member: current_user, event:, attending: true)
     redirect_to event_invitation_path(@event, invitation) if invitation
   end
 
@@ -44,7 +44,7 @@ class EventsController < ApplicationController
     ticket = Services::Ticket.new(request, params)
     member = Member.find_by(email: ticket.email)
     invitation = member.invitations.where(event: @event, role: 'Student').first
-    invitation ||= Invitation.create_or_find_by(event: @event, member: member, role: 'Student')
+    invitation ||= Invitation.create_or_find_by(event: @event, member:, role: 'Student')
 
     invitation.update(attending: true)
     head :ok
@@ -63,8 +63,8 @@ class EventsController < ApplicationController
 
   def find_invitation_and_redirect_to_event(role)
     set_event
-    invitation = Invitation.create_or_find_by(event: @event, member: current_user, role: role)
-    invitation = Invitation.find_by(event: @event, member: current_user, role: role) unless invitation.persisted?
+    invitation = Invitation.create_or_find_by(event: @event, member: current_user, role:)
+    invitation = Invitation.find_by(event: @event, member: current_user, role:) unless invitation.persisted?
     redirect_to event_invitation_path(@event, invitation)
   end
 
@@ -135,7 +135,7 @@ class EventsController < ApplicationController
     total = ActiveRecord::Base.connection.select_value(count_query.to_sql).to_i
     return nil if total.zero?
 
-    pagy_opts = { count: total, page: page, limit: 20, request: request }
+    pagy_opts = { count: total, page:, limit: 20, request: }
     pagy_opts[:request] = Pagy::Request.new(pagy_opts)
     pagy = Pagy::Offset.new(**pagy_opts)
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -36,12 +36,12 @@ class InvitationsController < ApplicationController
         EventInvitationMailer.attending(@invitation.event, @invitation.member, @invitation).deliver_now
       end
       notice = t('messages.invitations.spot_not_confirmed') if event.surveys_required
-      redirect_back fallback_location: root_path, notice: notice
+      redirect_back fallback_location: root_path, notice:
     else
       email = event.chapters.present? ? event.chapters.first.email : 'hello@codebar.io'
       redirect_back(
         fallback_location: root_path,
-        notice: t('messages.invitations.event.no_available_seats', email: email)
+        notice: t('messages.invitations.event.no_available_seats', email:)
       )
     end
   end
@@ -95,7 +95,7 @@ class InvitationsController < ApplicationController
       MeetingInvitation.find_by(token: params[:token], member: current_user)
     else
       meeting = Meeting.find_by(slug: params[:meeting_id])
-      MeetingInvitation.new(meeting: meeting, member: current_user, role: 'Participant')
+      MeetingInvitation.new(meeting:, member: current_user, role: 'Participant')
     end
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -25,7 +25,7 @@ class MembersController < ApplicationController
   def update
     if @member.update(member_params)
       notice = 'Your details have been updated.'
-      redirect_to profile_path, notice: notice
+      redirect_to profile_path, notice:
     else
       render 'edit'
     end
@@ -33,7 +33,7 @@ class MembersController < ApplicationController
 
   def unsubscribe
     require 'verifier'
-    member = Verifier.new(token: token).verify(Member)
+    member = Verifier.new(token:).verify(Member)
 
     session[:member_id] = member.id
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -8,7 +8,7 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
-    subscription = Subscription.new(group_id: group_id, member: current_user)
+    subscription = Subscription.new(group_id:, member: current_user)
 
     if subscription.save
       SubscriptionMailingListService.subscribe(subscription)
@@ -23,7 +23,7 @@ class SubscriptionsController < ApplicationController
 
   def destroy
     # Don't error if subscription is not found
-    subscription = current_user.subscriptions.find_by(group_id: group_id)
+    subscription = current_user.subscriptions.find_by(group_id:)
     SubscriptionMailingListService.unsubscribe(subscription) if subscription
     subscription&.destroy
 

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -40,7 +40,7 @@ class WorkshopsController < ApplicationController
   end
 
   def find_attending_invitation(workshop, user)
-    WorkshopInvitation.find_by(workshop: workshop, member: user, attending: true)
+    WorkshopInvitation.find_by(workshop:, member: user, attending: true)
   end
 
   def find_or_create_invitation(workshop, user, role)

--- a/app/helpers/email_header_helper.rb
+++ b/app/helpers/email_header_helper.rb
@@ -19,9 +19,9 @@ module EmailHeaderHelper
 
     mail(from: "codebar.io <#{from_email}>",
          to: member.email,
-         cc: cc,
-         bcc: bcc,
-         subject: subject,
+         cc:,
+         bcc:,
+         subject:,
          &block)
   end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -61,7 +61,7 @@ class Chapter < ApplicationRecord
   private
 
   def members_for_group(name)
-    members.where(groups: { name: name }).distinct
+    members.where(groups: { name: }).distinct
   end
 
   def expire_chapters_sidebar_cache

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -8,7 +8,7 @@ class Feedback < ApplicationRecord
   validates :tutorial, presence: true
 
   def self.submit_feedback(params, token)
-    feedback_request = FeedbackRequest.find_by(token: token)
+    feedback_request = FeedbackRequest.find_by(token:)
     return false unless feedback_request
 
     feedback = Feedback.new(params)

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -31,7 +31,7 @@ class Meeting < ApplicationRecord
   end
 
   def attending?(member)
-    invitations.accepted.where(member: member).present?
+    invitations.accepted.where(member:).present?
   end
 
   def not_full

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -9,7 +9,7 @@ class WaitingList < ApplicationRecord
   scope :with_notes_and_their_authors, -> { includes(member: [{ member_notes: :author }, :attendance_warnings]) }
 
   def self.add(invitation, auto_rsvp = true)
-    find_or_create_by(invitation: invitation) do |waiting_list|
+    find_or_create_by(invitation:) do |waiting_list|
       waiting_list.auto_rsvp = auto_rsvp
     end
   end

--- a/app/serializers/workshop_calendar.rb
+++ b/app/serializers/workshop_calendar.rb
@@ -50,7 +50,7 @@ class WorkshopCalendar
 
     event.url = invitation_url
     event.organizer = workshop.chapter.email.to_s
-    event.summary = I18n.t('workshop.calendar.summary', host_name: host_name)
+    event.summary = I18n.t('workshop.calendar.summary', host_name:)
     event.ip_class = 'PRIVATE'
   end
 

--- a/app/services/auditor.rb
+++ b/app/services/auditor.rb
@@ -16,16 +16,16 @@ module Auditor
     end
 
     def log_with_note(note)
-      create(note: note)
+      create(note:)
     end
 
     private
 
     def create(changes)
       PublicActivity::Activity.create(trackable: model,
-                                      key: key,
+                                      key:,
                                       owner: user,
-                                      recipient: recipient,
+                                      recipient:,
                                       parameters: changes)
     end
   end

--- a/app/services/chapter_creation_service.rb
+++ b/app/services/chapter_creation_service.rb
@@ -10,8 +10,8 @@ class ChapterCreationService
       chapter.groups.create!(name: 'Coaches')
     end
 
-    Result.new(chapter: chapter, success: true, errors: nil)
+    Result.new(chapter:, success: true, errors: nil)
   rescue ActiveRecord::RecordInvalid => e
-    Result.new(chapter: chapter, success: false, errors: e.message)
+    Result.new(chapter:, success: false, errors: e.message)
   end
 end

--- a/app/services/invitation_logger.rb
+++ b/app/services/invitation_logger.rb
@@ -60,7 +60,7 @@ class InvitationLogger
     return unless @log
 
     @log.update!(
-      total_invitees: total_invitees,
+      total_invitees:,
       completed_at: Time.current,
       status: :completed
     )
@@ -83,7 +83,7 @@ class InvitationLogger
   end
 
   def find_or_build_entry(member, invitation, status)
-    @log.entries.find_or_create_by(member: member, invitation: invitation) do |entry|
+    @log.entries.find_or_create_by(member:, invitation:) do |entry|
       entry.status = status
     end
   end

--- a/app/services/invitation_manager.rb
+++ b/app/services/invitation_manager.rb
@@ -31,7 +31,7 @@ class InvitationManager
 
   def send_meeting_emails(meeting)
     meeting.invitees.not_banned.each do |invitee|
-      invitation = MeetingInvitation.new(meeting: meeting, member: invitee, role: 'Participant')
+      invitation = MeetingInvitation.new(meeting:, member: invitee, role: 'Participant')
       next unless invitation.save
 
       MeetingInvitationMailer.invite(meeting, invitee, invitation).deliver_now
@@ -164,14 +164,14 @@ class InvitationManager
   end
 
   def create_invitation(workshop, member, role)
-    WorkshopInvitation.find_or_create_by!(workshop: workshop, member: member, role: role)
+    WorkshopInvitation.find_or_create_by!(workshop:, member:, role:)
   rescue StandardError => e
     log_invitation_failure(workshop, member, role, e)
     nil
   end
 
   def create_event_invitation(event, member, role)
-    Invitation.find_or_create_by!(event: event, member: member, role: role)
+    Invitation.find_or_create_by!(event:, member:, role:)
   rescue StandardError => e
     log_event_meeting_invitation_failure("event_id=#{event.id}", member, e)
     nil
@@ -260,7 +260,7 @@ class InvitationManager
     initiator = Member.find_by(id: initiator_id)
     return nil unless initiator
 
-    InvitationLogger.new(loggable, initiator, audience, :invite, chapter_id: chapter_id)
+    InvitationLogger.new(loggable, initiator, audience, :invite, chapter_id:)
   end
 
   def start_invitation_batch(logger)

--- a/app/services/three_month_email_service.rb
+++ b/app/services/three_month_email_service.rb
@@ -27,7 +27,7 @@ class ThreeMonthEmailService
                     .distinct
 
     members.find_each do |member|
-      MemberMailer.with(member: member).chaser.deliver_later
+      MemberMailer.with(member:).chaser.deliver_later
     end
   end
 end

--- a/lib/omniauth/strategies/codebar.rb
+++ b/lib/omniauth/strategies/codebar.rb
@@ -30,11 +30,11 @@ module OmniAuth
         session['omniauth.codebar.redirect_uri'] = redirect_uri
         params = {
           client_id: 'planner',
-          redirect_uri: redirect_uri,
+          redirect_uri:,
           response_type: 'code',
-          state: state,
+          state:,
           scope: 'openid profile email',
-          code_challenge: code_challenge,
+          code_challenge:,
           code_challenge_method: 'S256'
         }
 
@@ -90,7 +90,7 @@ module OmniAuth
                                                provider: name,
                                                uid: email,
                                                info: {
-                                                 email: email,
+                                                 email:,
                                                  name: payload['name'] || email
                                                },
                                                credentials: {
@@ -141,11 +141,11 @@ module OmniAuth
         request['User-Agent'] = 'Codebar Planner/1.0'
         request.body = URI.encode_www_form({
                                              grant_type: 'authorization_code',
-                                             code: code,
+                                             code:,
                                              client_id: 'planner',
                                              redirect_uri: session.delete('omniauth.codebar.redirect_uri') ||
                                                callback_url,
-                                             code_verifier: code_verifier
+                                             code_verifier:
                                            })
 
         response = http_for(uri).request(request)
@@ -169,7 +169,7 @@ module OmniAuth
         decode = lambda { |jwks|
           JWT.decode(token, nil, true, {
                        algorithms: %w[RS256],
-                       jwks: jwks,
+                       jwks:,
                        iss: options.auth_url,
                        aud: options.audience,
                        verify_iss: true,

--- a/lib/tasks/delete_member.rake
+++ b/lib/tasks/delete_member.rake
@@ -9,7 +9,7 @@ namespace :member do
 
     abort("You have to provide an email address. #{usage_example}") if email.blank?
 
-    member = Member.find_by!(email: email)
+    member = Member.find_by!(email:)
 
     $stdout.puts "Deleting #{member.name} #{member.surname}'s account..."
     $stdout.puts 'This action is irreversible.'

--- a/lib/tasks/feedback.rake
+++ b/lib/tasks/feedback.rake
@@ -4,12 +4,12 @@ namespace :feedback do
     workshops = Workshop.completed_since_yesterday
     Rails.logger.info 'Sending Feedback request emails' if workshops.any?
     workshops.each do |workshop|
-      WorkshopInvitation.accepted.where(workshop: workshop, role: 'Student').find_each do |invitation|
-        feedback_request = FeedbackRequest.create(member: invitation.member, workshop: workshop, submited: false)
+      WorkshopInvitation.accepted.where(workshop:, role: 'Student').find_each do |invitation|
+        feedback_request = FeedbackRequest.create(member: invitation.member, workshop:, submited: false)
         FeedbackRequestMailer.request_feedback(workshop, invitation.member, feedback_request).deliver_now
       end
       Rails.logger.info "Feedback requests sent for #{workshop.chapter.name}'s #{workshop}: \
-                         #{FeedbackRequest.where(workshop: workshop).count}"
+                         #{FeedbackRequest.where(workshop:).count}"
     end
   end
 end

--- a/lib/verifier.rb
+++ b/lib/verifier.rb
@@ -14,7 +14,7 @@ class Verifier
 
   def verify(model)
     id = verifier.verify(token)
-    model.find_by(id: id)
+    model.find_by(id:)
   end
 
   private

--- a/spec/components/chapter_picker_component_spec.rb
+++ b/spec/components/chapter_picker_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ChapterPickerComponent do
   let(:chapters) { Fabricate.times(3, :chapter) }
 
   it 'renders a text input with datalist attributes' do
-    render_inline described_class.new(name: 'sponsors_search[chapter]', chapters: chapters, placeholder: 'Filter by chapter')
+    render_inline described_class.new(name: 'sponsors_search[chapter]', chapters:, placeholder: 'Filter by chapter')
 
     expect(page).to have_field('sponsors_search[chapter]')
     input = page.find('input')
@@ -14,7 +14,7 @@ RSpec.describe ChapterPickerComponent do
   end
 
   it 'renders a datalist with chapter names' do
-    render_inline described_class.new(name: 'sponsors_search[chapter]', chapters: chapters)
+    render_inline described_class.new(name: 'sponsors_search[chapter]', chapters:)
 
     expect(page).to have_css('datalist#sponsors_search-chapter-options')
     chapters.each do |chapter|
@@ -23,13 +23,13 @@ RSpec.describe ChapterPickerComponent do
   end
 
   it 'sanitises bracket characters in the datalist id' do
-    render_inline described_class.new(name: 'workshop[chapter_id]', chapters: chapters)
+    render_inline described_class.new(name: 'workshop[chapter_id]', chapters:)
 
     expect(page).to have_css('datalist#workshop-chapter_id-options')
   end
 
   it 'pre-fills the input when selected value is provided' do
-    render_inline described_class.new(name: 'sponsors_search[chapter]', chapters: chapters, selected: 'London')
+    render_inline described_class.new(name: 'sponsors_search[chapter]', chapters:, selected: 'London')
 
     input = page.find('input')
     expect(input['value']).to eq('London')

--- a/spec/components/chapters_sidebar_component_spec.rb
+++ b/spec/components/chapters_sidebar_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ChaptersSidebarComponent do
   let(:chapters) { Fabricate.times(3, :chapter) }
 
   it 'renders chapter names as links' do
-    render_inline described_class.new(chapters: chapters)
+    render_inline described_class.new(chapters:)
 
     chapters.each do |chapter|
       expect(page).to have_link(chapter.name, href: chapter_path(chapter.slug))

--- a/spec/components/event_card_component_spec.rb
+++ b/spec/components/event_card_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EventCardComponent, type: :component do
   let(:chapter) { Fabricate(:chapter, active: true) }
 
   context 'with a workshop' do
-    let(:workshop) { Fabricate(:workshop, chapter: chapter) }
+    let(:workshop) { Fabricate(:workshop, chapter:) }
     let(:presenter) { WorkshopPresenter.new(workshop) }
 
     it 'renders the workshop card' do
@@ -67,19 +67,19 @@ RSpec.describe EventCardComponent, type: :component do
   end
 
   context 'with a user' do
-    let(:workshop) { Fabricate(:workshop, chapter: chapter) }
+    let(:workshop) { Fabricate(:workshop, chapter:) }
     let(:presenter) { WorkshopPresenter.new(workshop) }
     let(:member) { Fabricate(:member) }
 
     it 'renders attending badge when user is attending (as presenter)' do
-      Fabricate(:workshop_invitation, workshop: workshop, member: member, attending: true)
+      Fabricate(:workshop_invitation, workshop:, member:, attending: true)
       user_presenter = MemberPresenter.new(member)
       render_inline(described_class.new(event_card: presenter, user: user_presenter))
       expect(page).to have_text('Attending')
     end
 
     it 'renders attending badge when raw Member is passed' do
-      Fabricate(:workshop_invitation, workshop: workshop, member: member, attending: true)
+      Fabricate(:workshop_invitation, workshop:, member:, attending: true)
       render_inline(described_class.new(event_card: presenter, user: member))
       expect(page).to have_text('Attending')
     end

--- a/spec/controllers/admin/chapters_controller_spec.rb
+++ b/spec/controllers/admin/chapters_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Admin::ChaptersController, type: :controller do
 
     it 'marks a chapter with a past workshop as active' do
       chapter = Fabricate(:chapter_with_groups)
-      Fabricate(:workshop, chapter: chapter, date_and_time: 2.months.ago)
+      Fabricate(:workshop, chapter:, date_and_time: 2.months.ago)
 
       get :status
 
@@ -64,7 +64,7 @@ RSpec.describe Admin::ChaptersController, type: :controller do
 
     it 'marks a chapter with only a future workshop as active' do
       chapter = Fabricate(:chapter_with_groups)
-      Fabricate(:workshop, chapter: chapter, date_and_time: 2.months.from_now)
+      Fabricate(:workshop, chapter:, date_and_time: 2.months.from_now)
 
       get :status
 
@@ -83,7 +83,7 @@ RSpec.describe Admin::ChaptersController, type: :controller do
 
     it 'flags at-risk chapters with no recent workshops' do
       chapter = Fabricate(:chapter_with_groups)
-      Fabricate(:workshop, chapter: chapter, date_and_time: 6.months.ago + 1.week)
+      Fabricate(:workshop, chapter:, date_and_time: 6.months.ago + 1.week)
 
       get :status, params: { months: '6' }
 
@@ -92,7 +92,7 @@ RSpec.describe Admin::ChaptersController, type: :controller do
 
     it 'does not flag active chapters with recent workshops as at-risk' do
       chapter = Fabricate(:chapter_with_groups)
-      Fabricate(:workshop, chapter: chapter, date_and_time: 1.month.ago)
+      Fabricate(:workshop, chapter:, date_and_time: 1.month.ago)
 
       get :status, params: { months: '6' }
 

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Admin::InvitationsController, type: :controller do
 
   describe 'PUT #update with attended param' do
     let(:workshop) { Fabricate(:workshop, date_and_time: Time.zone.now - 1.day) }
-    let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
+    let(:invitation) { Fabricate(:workshop_invitation, workshop:, attending: true) }
     let(:admin) { Fabricate(:chapter_organiser) }
 
     before do

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
         post :create, params: {
           sponsor: {
             name: 'name', website: 'https://example.com', seats: 40,
-            address: address, avatar: avatar, members: [1, 2]
+            address:, avatar:, members: [1, 2]
           }
         }
       end.not_to change(Sponsor, :count)
@@ -25,7 +25,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
         post :create, params: {
           sponsor: {
             name: 'name', website: 'https://example.com', seats: 40,
-            address: address, avatar: avatar
+            address:, avatar:
           }
         }
       end.not_to change(Sponsor, :count)
@@ -40,7 +40,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
           post :create, params: {
             sponsor: {
               name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
-              address: address, avatar: avatar
+              address:, avatar:
             }
           }
         end.to change(Sponsor, :count).by(1)
@@ -54,7 +54,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
           post :create, params: {
             sponsor: {
               name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
-              address: address, avatar: avatar, contact_ids: [member.id, member1.id]
+              address:, avatar:, contact_ids: [member.id, member1.id]
             }
           }
         end.to change(Sponsor, :count).by(1)
@@ -69,7 +69,7 @@ RSpec.describe Admin::SponsorsController, type: :controller do
             sponsor: {
               name: 'name', website: 'https://example.com', seats: 40, number_of_coaches: 10,
               address: Fabricate(:address, latitude: '54.47474', longitude: '-0.12345'),
-              avatar: avatar, members: []
+              avatar:, members: []
             }
           }
         end.to change(Sponsor, :count).by(1)

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
 
   describe 'GET #show' do
     it 'loads the workshop attendance page with attendees' do
-      Fabricate(:workshop_invitation, workshop: workshop, attending: true)
+      Fabricate(:workshop_invitation, workshop:, attending: true)
       get :show, params: { id: workshop.id }
 
       expect(response).to have_http_status(:success)
@@ -30,11 +30,11 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
       4.times { Fabricate(:past_attending_workshop_invitation, member: attendee) }
       2.times { Fabricate(:attendance_warning, member: attendee) }
       Fabricate(:member_note, member: attendee, created_at: 1.day.ago)
-      Fabricate(:workshop_invitation, workshop: workshop, member: attendee, attending: true, role: 'Student')
-      Fabricate(:workshop_invitation, workshop: workshop, attending: true, role: 'Coach')
+      Fabricate(:workshop_invitation, workshop:, member: attendee, attending: true, role: 'Student')
+      Fabricate(:workshop_invitation, workshop:, attending: true, role: 'Coach')
 
       # adds a second attendee to catch per-row scaling
-      Fabricate(:workshop_invitation, workshop: workshop, attending: true, role: 'Student')
+      Fabricate(:workshop_invitation, workshop:, attending: true, role: 'Student')
 
       count = count_queries { get :show, params: { id: workshop.id } }
 
@@ -46,7 +46,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
       render_views
 
       it 'links to the RSVP members page instead of rendering an invitations select' do
-        Fabricate(:workshop_invitation, workshop: workshop, attending: nil)
+        Fabricate(:workshop_invitation, workshop:, attending: nil)
         get :show, params: { id: workshop.id }
 
         expect(response.body).to include(admin_workshop_rsvp_path(workshop))
@@ -60,12 +60,12 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
     render_views
 
     let(:member) { Fabricate(:member, name: 'Zoe', surname: 'Searchable') }
-    let!(:matching) { Fabricate(:workshop_invitation, workshop: workshop, member: member, attending: nil) }
+    let!(:matching) { Fabricate(:workshop_invitation, workshop:, member:, attending: nil) }
 
     before do
       Fabricate(:ban, member: Fabricate(:member, name: 'Bob', surname: 'Banned'))
-      Fabricate(:workshop_invitation, workshop: workshop, attending: true) # an already-attending member (counts toward eligible)
-      Fabricate(:workshop_invitation, member: member) # an invite for a DIFFERENT workshop
+      Fabricate(:workshop_invitation, workshop:, attending: true) # an already-attending member (counts toward eligible)
+      Fabricate(:workshop_invitation, member:) # an invite for a DIFFERENT workshop
     end
 
     it 'is not accessible without organiser rights' do
@@ -103,7 +103,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
     end
 
     it 'eager loads member so rendering does not query per row' do
-      3.times { Fabricate(:workshop_invitation, workshop: workshop, member: Fabricate(:member, name: 'Eager', surname: 'Load'), attending: nil) }
+      3.times { Fabricate(:workshop_invitation, workshop:, member: Fabricate(:member, name: 'Eager', surname: 'Load'), attending: nil) }
 
       get :rsvp, params: { workshop_id: workshop.id, q: 'Eager' }
 
@@ -112,7 +112,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
 
     it 'paginates results at 20 per page and preserves the search term across pages' do
       21.times do |i|
-        Fabricate(:workshop_invitation, workshop: workshop, member: Fabricate(:member, name: "Page#{i}", surname: 'User'), attending: nil)
+        Fabricate(:workshop_invitation, workshop:, member: Fabricate(:member, name: "Page#{i}", surname: 'User'), attending: nil)
       end
 
       get :rsvp, params: { workshop_id: workshop.id, q: 'Page' }
@@ -129,7 +129,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
 
     it 'renders the not-attending badge and RSVP toggle for a declined member' do
       declined = Fabricate(:member, name: 'Declined', surname: 'Member')
-      Fabricate(:workshop_invitation, workshop: workshop, member: declined, attending: false)
+      Fabricate(:workshop_invitation, workshop:, member: declined, attending: false)
 
       get :rsvp, params: { workshop_id: workshop.id, q: 'Declined' }
 
@@ -151,7 +151,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
 
     it 'renders the not-attending toggle for an already-attending result' do
       attending_member = Fabricate(:member, name: 'Aaron', surname: 'Other')
-      Fabricate(:workshop_invitation, workshop: workshop, member: attending_member, attending: true)
+      Fabricate(:workshop_invitation, workshop:, member: attending_member, attending: true)
 
       get :rsvp, params: { workshop_id: workshop.id, q: 'Aaron' }
 
@@ -170,7 +170,7 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
   describe 'DELETE #destroy' do
     context 'when workshop invitations have been sent' do
       before do
-        Fabricate(:attending_workshop_invitation, workshop: workshop)
+        Fabricate(:attending_workshop_invitation, workshop:)
       end
 
       context "when workshop deletion tried within specific time frame since it's creation" do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe EventsController do
 
     context 'when the member already has an invitation for the event and role with attending nil' do
       let!(:invitation) do
-        Fabricate(:invitation, event: event, member: member, role: 'Student', attending: nil)
+        Fabricate(:invitation, event:, member:, role: 'Student', attending: nil)
       end
 
       it 'redirects to the existing invitation page' do
@@ -59,7 +59,7 @@ RSpec.describe EventsController do
 
     context 'when the member already has a coach invitation for the event with attending nil' do
       let!(:invitation) do
-        Fabricate(:coach_invitation, event: event, member: member, attending: nil)
+        Fabricate(:coach_invitation, event:, member:, attending: nil)
       end
 
       it 'redirects to the existing invitation page' do

--- a/spec/controllers/waiting_lists_controller_spec.rb
+++ b/spec/controllers/waiting_lists_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe WaitingListsController do
   let(:workshop) { Fabricate(:workshop) }
-  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop) }
+  let(:invitation) { Fabricate(:workshop_invitation, workshop:) }
 
   describe 'POST #create' do
     it 'creates a waiting list entry on first submission' do
@@ -28,7 +28,7 @@ RSpec.describe WaitingListsController do
       post :create, params: { invitation_id: invitation.token }
       post :create, params: { invitation_id: invitation.token }
 
-      expect(WaitingList.where(invitation: invitation).count).to eq(1)
+      expect(WaitingList.where(invitation:).count).to eq(1)
     end
   end
 end

--- a/spec/controllers/workshop_invitation_controller_spec.rb
+++ b/spec/controllers/workshop_invitation_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe WorkshopInvitationController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:tutorial) { Fabricate(:tutorial) }
   let(:workshop) { Fabricate(:workshop) }
-  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member, tutorial: tutorial.title) }
+  let(:invitation) { Fabricate(:workshop_invitation, workshop:, member:, tutorial: tutorial.title) }
 
   before { login(member) }
 
@@ -65,7 +65,7 @@ RSpec.describe WorkshopInvitationController, type: :controller do
         capacity = workshop.host.seats
         capacity.times do
           m = Fabricate(:member)
-          Fabricate(:workshop_invitation, workshop: workshop, member: m, role: 'Student', attending: true)
+          Fabricate(:workshop_invitation, workshop:, member: m, role: 'Student', attending: true)
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.describe WorkshopInvitationController, type: :controller do
     end
 
     context 'when tutorial is missing for student' do
-      let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member, tutorial: nil) }
+      let(:invitation) { Fabricate(:workshop_invitation, workshop:, member:, tutorial: nil) }
 
       it 'does not change attendance' do
         post :accept, params: { id: invitation.token }
@@ -143,7 +143,7 @@ RSpec.describe WorkshopInvitationController, type: :controller do
 
     context 'when someone is on waiting list' do
       let(:waitlisted_member) { Fabricate(:member) }
-      let(:waitlisted_invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: waitlisted_member, role: 'Student') }
+      let(:waitlisted_invitation) { Fabricate(:workshop_invitation, workshop:, member: waitlisted_member, role: 'Student') }
 
       before do
         invitation.update!(attending: true)

--- a/spec/controllers/workshops_controller_spec.rb
+++ b/spec/controllers/workshops_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WorkshopsController do
   describe 'POST #rsvp' do
     context 'when the member already has an invitation for the workshop and role with attending nil' do
       let!(:invitation) do
-        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: nil)
+        Fabricate(:workshop_invitation, workshop:, member:, role: 'Coach', attending: nil)
       end
 
       it 'redirects to the existing invitation page' do
@@ -36,7 +36,7 @@ RSpec.describe WorkshopsController do
 
     context 'when the member is already attending' do
       before do
-        Fabricate(:attending_workshop_invitation, workshop: workshop, member: member, role: 'Coach')
+        Fabricate(:attending_workshop_invitation, workshop:, member:, role: 'Coach')
       end
 
       it 'redirects back with already wish to attend message' do

--- a/spec/fabricators/chapter_fabricator.rb
+++ b/spec/fabricators/chapter_fabricator.rb
@@ -16,8 +16,8 @@ end
 
 Fabricator(:chapter_with_groups, from: :chapter) do
   after_create do |chapter|
-    Fabricate(:students, chapter: chapter)
-    Fabricate(:coaches, chapter: chapter)
+    Fabricate(:students, chapter:)
+    Fabricate(:coaches, chapter:)
   end
 end
 

--- a/spec/fabricators/event_fabricator.rb
+++ b/spec/fabricators/event_fabricator.rb
@@ -20,6 +20,6 @@ end
 
 Fabricator(:event_with_sponsorship, from: :event) do
   after_build do |event|
-    Fabricate(:sponsorship, event: event, sponsor: Fabricate(:sponsor))
+    Fabricate(:sponsorship, event:, sponsor: Fabricate(:sponsor))
   end
 end

--- a/spec/fabricators/sponsor_fabricator.rb
+++ b/spec/fabricators/sponsor_fabricator.rb
@@ -23,14 +23,14 @@ end
 Fabricator(:sponsor_with_member_contacts, from: :sponsor) do
   after_build do |sponsor, _transients|
     Fabricate.times(3, :member_contact,
-                    sponsor: sponsor)
+                    sponsor:)
   end
 end
 
 Fabricator(:sponsor_with_contacts, from: :sponsor_full) do
   after_build do |sponsor, _transients|
     Fabricate(:contact,
-              sponsor: sponsor)
+              sponsor:)
   end
 end
 

--- a/spec/fabricators/workshop_fabricator.rb
+++ b/spec/fabricators/workshop_fabricator.rb
@@ -6,7 +6,7 @@ Fabricator(:workshop) do
   coach_spaces { |transients| transients[:coach_count] || 10 }
   after_build do |workshop, transients|
     Fabricate(:workshop_sponsor,
-              workshop: workshop,
+              workshop:,
               sponsor: Fabricate(:sponsor,
                                  seats: transients[:student_count] || 10,
                                  number_of_coaches: transients[:coach_count] || 10),
@@ -59,6 +59,6 @@ end
 
 Fabricator(:virtual_workshop_sponsored, from: :virtual_workshop) do
   after_build do |workshop|
-    Fabricate(:workshop_sponsor, workshop: workshop, sponsor: Fabricate(:sponsor), host: false)
+    Fabricate(:workshop_sponsor, workshop:, sponsor: Fabricate(:sponsor), host: false)
   end
 end

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature 'Accepting a workshop invitation', type: :feature do
   describe '#workshop' do
     let(:member) { Fabricate(:member) }
-    let(:invitation) { Fabricate(:workshop_invitation, member: member, tutorial: tutorial.title) }
+    let(:invitation) { Fabricate(:workshop_invitation, member:, tutorial: tutorial.title) }
     let(:invitation_route) { invitation_path(invitation) }
     let(:accept_invitation_route) { accept_invitation_path(invitation) }
     let(:reject_invitation_route) { reject_invitation_path(invitation) }
@@ -15,7 +15,7 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
 
       spots_to_fill.times do
         member = Fabricate(:member)
-        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student', attending: true)
+        Fabricate(:workshop_invitation, workshop:, member:, role: 'Student', attending: true)
       end
     end
     let!(:tutorial) { Fabricate(:tutorial) }
@@ -69,7 +69,7 @@ RSpec.feature 'Accepting a workshop invitation', type: :feature do
       end
 
       context 'when a coach' do
-        let(:invitation) { Fabricate(:coach_workshop_invitation, member: member) }
+        let(:invitation) { Fabricate(:coach_workshop_invitation, member:) }
         let(:note) { 'I am most comfortable with being paired in JavaScript' }
 
         scenario 'can accept their invitation without a note' do

--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -2,10 +2,10 @@ RSpec.feature 'Chapter workshop feedback', type: :feature do
   it 'is only available to chapter organisers' do
     member = Fabricate(:member)
     chapter = Fabricate(:chapter)
-    workshop = Fabricate(:workshop, chapter: chapter)
+    workshop = Fabricate(:workshop, chapter:)
     other_workshop = Fabricate(:workshop)
 
-    feedbacks = Fabricate.times(1, :feedback, workshop: workshop)
+    feedbacks = Fabricate.times(1, :feedback, workshop:)
     other_feedbacks = Fabricate.times(1, :feedback, workshop: other_workshop)
 
     login_as_organiser(member, chapter)

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Chapters', type: :feature do
 
   context 'when viewing the how you found us card' do
     let(:chapter) { Fabricate(:chapter) }
-    let(:group) { Fabricate(:group, chapter: chapter) }
+    let(:group) { Fabricate(:group, chapter:) }
 
     before do
       login_as_admin(member)
@@ -147,7 +147,7 @@ RSpec.feature 'Chapters', type: :feature do
 
     scenario 'shows the card when there are responses' do
       member_with_response = Fabricate(:member, how_you_found_us: :from_a_friend)
-      Fabricate(:subscription, member: member_with_response, group: group)
+      Fabricate(:subscription, member: member_with_response, group:)
 
       visit admin_chapter_path(chapter)
 

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Event creation', type: :feature do
         visit new_admin_event_path
 
         fill_in_mandatory_event_fields(name: 'A test event', slug: 'a-test-event',
-                                       description: 'A test event description', date: date, sponsor: sponsor)
+                                       description: 'A test event description', date:, sponsor:)
 
         aggregate_failures do
           expect(page).to have_text('Event successfully created')

--- a/spec/features/admin/filtering_sponsors_list_spec.rb
+++ b/spec/features/admin/filtering_sponsors_list_spec.rb
@@ -28,11 +28,11 @@ RSpec.feature 'Admin filtering sponsors list', type: :feature do
 
     describe 'when filtering by chapter' do
       let!(:chapter) { Fabricate(:chapter, name: 'London') }
-      let!(:workshop) { Fabricate(:workshop_no_sponsor, chapter: chapter) }
+      let!(:workshop) { Fabricate(:workshop_no_sponsor, chapter:) }
       let!(:matching_sponsor) { Fabricate(:sponsor) }
 
       before do
-        Fabricate(:workshop_sponsor, workshop: workshop, sponsor: matching_sponsor)
+        Fabricate(:workshop_sponsor, workshop:, sponsor: matching_sponsor)
         Fabricate(:sponsor)
         visit admin_sponsors_path
       end

--- a/spec/features/admin/groups_spec.rb
+++ b/spec/features/admin/groups_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature 'admin groups', type: :feature do
   describe '#show page' do
     let(:member) { Fabricate(:member) }
     let(:chapter) { Fabricate(:chapter, name: 'Brighton') }
-    let(:group) { Fabricate(:group, chapter: chapter, name: 'Students') }
+    let(:group) { Fabricate(:group, chapter:, name: 'Students') }
 
     before do
       login_as_admin(member)

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Managing events', type: :feature do
   end
 
   scenario 'verifying an attendance' do
-    invitation = Fabricate(:invitation, event: event, attending: true)
+    invitation = Fabricate(:invitation, event:, attending: true)
     visit admin_event_path(event)
 
     click_on 'Verify'
@@ -42,7 +42,7 @@ RSpec.feature 'Managing events', type: :feature do
   end
 
   scenario 'cancelling an attendance' do
-    invitation = Fabricate(:invitation, event: event, attending: true)
+    invitation = Fabricate(:invitation, event:, attending: true)
     visit admin_event_path(event)
 
     click_on 'Cancel'
@@ -52,8 +52,8 @@ RSpec.feature 'Managing events', type: :feature do
   end
 
   scenario 'accessing a list of attendee emails' do
-    student_invitation = Fabricate(:invitation, event: event, attending: true)
-    coach_invitation = Fabricate(:coach_invitation, event: event, attending: true)
+    student_invitation = Fabricate(:invitation, event:, attending: true)
+    coach_invitation = Fabricate(:coach_invitation, event:, attending: true)
     visit admin_event_path(event)
 
     click_on 'Emails'

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -2,8 +2,8 @@ RSpec.feature 'managing workshop attendances', type: :feature do
   context 'when an admin' do
     let(:member) { Fabricate(:member) }
     let(:chapter) { Fabricate(:chapter) }
-    let(:workshop) { Fabricate(:workshop, chapter: chapter) }
-    let!(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
+    let(:workshop) { Fabricate(:workshop, chapter:) }
+    let!(:invitation) { Fabricate(:workshop_invitation, workshop:, attending: true) }
 
     before do
       login_as_admin(member)
@@ -11,7 +11,7 @@ RSpec.feature 'managing workshop attendances', type: :feature do
     end
 
     describe '#verify_attendance' do
-      let(:workshop) { Fabricate(:workshop, chapter: chapter, date_and_time: Time.zone.now - 1.day) }
+      let(:workshop) { Fabricate(:workshop, chapter:, date_and_time: Time.zone.now - 1.day) }
 
       scenario 'can verify that a member has attended the workshop' do
         visit admin_workshop_path(workshop)
@@ -21,7 +21,7 @@ RSpec.feature 'managing workshop attendances', type: :feature do
       end
 
       scenario 'verifies and unverifies attendance with targeted row replacement', :js do
-        second_invitation = Fabricate(:workshop_invitation, workshop: workshop, attending: true)
+        second_invitation = Fabricate(:workshop_invitation, workshop:, attending: true)
 
         visit admin_workshop_path(workshop)
 
@@ -51,7 +51,7 @@ RSpec.feature 'managing workshop attendances', type: :feature do
     end
 
     scenario 'can move a member from the waiting list to the attendee list' do
-      other_invitation = Fabricate(:workshop_invitation, workshop: workshop, attending: nil)
+      other_invitation = Fabricate(:workshop_invitation, workshop:, attending: nil)
       WaitingList.add(other_invitation)
 
       visit admin_workshop_path(workshop)
@@ -65,7 +65,7 @@ RSpec.feature 'managing workshop attendances', type: :feature do
     scenario 'can rsvp an invited student to the workshop', :js do
       login_as_admin(member)
 
-      other_invitation = Fabricate(:workshop_invitation, workshop: workshop, attending: nil)
+      other_invitation = Fabricate(:workshop_invitation, workshop:, attending: nil)
       student = other_invitation.member
 
       visit admin_workshop_path(workshop)
@@ -87,7 +87,7 @@ RSpec.feature 'managing workshop attendances', type: :feature do
     end
 
     scenario 'can view the tutorial and note set by an attendee' do
-      invitation = Fabricate(:attending_workshop_invitation, workshop: workshop)
+      invitation = Fabricate(:attending_workshop_invitation, workshop:)
       login_as_admin(member)
 
       visit admin_workshop_path(workshop)
@@ -98,17 +98,17 @@ RSpec.feature 'managing workshop attendances', type: :feature do
     describe '#changes' do
       before do
         # Workshop invitations without `attending` status
-        Fabricate(:workshop_invitation, workshop: workshop, role: 'Coach')
-        Fabricate(:workshop_invitation, workshop: workshop, role: 'Student')
+        Fabricate(:workshop_invitation, workshop:, role: 'Coach')
+        Fabricate(:workshop_invitation, workshop:, role: 'Student')
 
         # Not attending
-        Fabricate(:workshop_invitation, workshop: workshop, role: 'Coach', attending: false)
-        Fabricate(:workshop_invitation, workshop: workshop, role: 'Student', attending: false)
+        Fabricate(:workshop_invitation, workshop:, role: 'Coach', attending: false)
+        Fabricate(:workshop_invitation, workshop:, role: 'Student', attending: false)
 
         # Attending, with a student having been manually added/confirmed by an organiser
-        Fabricate(:attending_workshop_invitation, workshop: workshop, role: 'Coach')
-        Fabricate(:attending_workshop_invitation, workshop: workshop, role: 'Student')
-        overridden = Fabricate(:attending_workshop_invitation, workshop: workshop, role: 'Student')
+        Fabricate(:attending_workshop_invitation, workshop:, role: 'Coach')
+        Fabricate(:attending_workshop_invitation, workshop:, role: 'Student')
+        overridden = Fabricate(:attending_workshop_invitation, workshop:, role: 'Student')
         overridden.update(last_overridden_by_id: member.id)
       end
 

--- a/spec/features/admin/managing_meeting_invitations_spec.rb
+++ b/spec/features/admin/managing_meeting_invitations_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Managing meeting invitations', type: :feature do
 
   describe 'creating a new meeting invitation' do
     scenario 'for a member that is not already attending', :js do
-      Fabricate(:attending_meeting_invitation, meeting: meeting)
+      Fabricate(:attending_meeting_invitation, meeting:)
       member = Fabricate(:member)
 
       visit admin_meeting_path(meeting)
@@ -23,8 +23,8 @@ RSpec.feature 'Managing meeting invitations', type: :feature do
     scenario 'for a member that is already attending', :js do
       meeting = Fabricate(:meeting)
       attending_member = Fabricate(:member)
-      Fabricate(:attending_meeting_invitation, meeting: meeting)
-      Fabricate(:attending_meeting_invitation, meeting: meeting, member: attending_member)
+      Fabricate(:attending_meeting_invitation, meeting:)
+      Fabricate(:attending_meeting_invitation, meeting:, member: attending_member)
 
       visit admin_meeting_path(meeting)
 
@@ -37,7 +37,7 @@ RSpec.feature 'Managing meeting invitations', type: :feature do
 
   scenario 'Updating the attendance of an invitation' do
     meeting = Fabricate(:meeting, date_and_time: 1.day.ago)
-    Fabricate(:attending_meeting_invitation, meeting: meeting)
+    Fabricate(:attending_meeting_invitation, meeting:)
 
     visit admin_meeting_path(meeting)
     find('.verify-attendance').click

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Managing meetings', type: :feature do
     let(:meeting) { Fabricate(:meeting) }
 
     scenario 'when format: :text' do
-      invitations = Fabricate.times(2, :attending_meeting_invitation, meeting: meeting)
+      invitations = Fabricate.times(2, :attending_meeting_invitation, meeting:)
       visit attendees_emails_admin_meeting_path(meeting, format: :text)
 
       invitations.each do |invitation|
@@ -109,7 +109,7 @@ RSpec.feature 'Managing meetings', type: :feature do
       chapter = Fabricate(:chapter_with_groups)
       meeting = Fabricate(:meeting, chapters: [chapter])
       chapter.members[0..1].each do |member|
-        Fabricate(:ban, member: member)
+        Fabricate(:ban, member:)
       end
       expired_ban = Fabricate.build(:ban, member: chapter.members[2], expires_at: Time.zone.today - 1.month)
       expired_ban.save(validate: false)

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Admin managing members', type: :feature do
                         other_dietary_restrictions: 'peanut allergy')
   end
   let(:admin) { Fabricate(:chapter_organiser) }
-  let(:invitation) { Fabricate(:attended_workshop_invitation, member: member) }
+  let(:invitation) { Fabricate(:attended_workshop_invitation, member:) }
 
   before do
     invitation

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
     let(:sponsor2) { Fabricate(:sponsor) }
 
     scenario 'can filter by chapter' do
-      sponsored_workshop = Fabricate(:workshop_sponsor, sponsor: sponsor).workshop
+      sponsored_workshop = Fabricate(:workshop_sponsor, sponsor:).workshop
       hosted_workshop = Fabricate(:workshop_sponsor, sponsor: sponsor2, host: true).workshop
 
       visit admin_sponsors_path
@@ -31,11 +31,11 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
 
     scenario 'can filter by sponsor' do
       # Single workshop
-      Fabricate(:workshop_sponsor, sponsor: sponsor)
+      Fabricate(:workshop_sponsor, sponsor:)
       # Multiple works with the same sponsor and chapter
       chapter = Fabricate(:chapter)
       2.times do
-        Fabricate(:workshop_sponsor, sponsor: sponsor2, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter))
+        Fabricate(:workshop_sponsor, sponsor: sponsor2, workshop: Fabricate(:workshop_no_sponsor, chapter:))
       end
 
       visit admin_sponsors_path
@@ -62,7 +62,7 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
     end
 
     scenario 'can clear filtering form' do
-      sponsored_workshop = Fabricate(:workshop_sponsor, sponsor: sponsor).workshop
+      sponsored_workshop = Fabricate(:workshop_sponsor, sponsor:).workshop
       hosted_workshop = Fabricate(:workshop_sponsor, sponsor: sponsor2, host: true).workshop
 
       visit admin_sponsors_path
@@ -118,8 +118,8 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
       end
 
       scenario 'when there are workshop sponsorships' do
-        sponsored_workshop = Fabricate(:workshop_sponsor, sponsor: sponsor).workshop
-        hosted_workshop = Fabricate(:workshop_sponsor, sponsor: sponsor, host: true).workshop
+        sponsored_workshop = Fabricate(:workshop_sponsor, sponsor:).workshop
+        hosted_workshop = Fabricate(:workshop_sponsor, sponsor:, host: true).workshop
         visit admin_sponsor_path(sponsor)
 
         within '#sponsorships' do
@@ -130,9 +130,9 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
       end
 
       scenario 'when there are event sponsorships' do
-        gold_event = Fabricate(:sponsorship, sponsor: sponsor, level: 'gold').event
-        silver_event = Fabricate(:sponsorship, sponsor: sponsor, level: 'silver').event
-        standard_event = Fabricate(:sponsorship, sponsor: sponsor, level: nil).event
+        gold_event = Fabricate(:sponsorship, sponsor:, level: 'gold').event
+        silver_event = Fabricate(:sponsorship, sponsor:, level: 'silver').event
+        standard_event = Fabricate(:sponsorship, sponsor:, level: nil).event
 
         visit admin_sponsor_path(sponsor)
 
@@ -214,7 +214,7 @@ RSpec.feature 'Admin::Sponsors', type: :feature do
     end
 
     it 'can unsubscribe a contact to the sponsor newsletter', :wip do
-      contact = Fabricate(:contact, sponsor: sponsor, mailing_list_consent: true)
+      contact = Fabricate(:contact, sponsor:, mailing_list_consent: true)
       visit edit_admin_sponsor_path(sponsor)
 
       uncheck 'sponsor_contacts_attributes_0_mailing_list_consent'

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
 
   describe '#views' do
     scenario 'list of all chapter workshops' do
-      workshops = Fabricate.times(2, :workshop, chapter: chapter)
+      workshops = Fabricate.times(2, :workshop, chapter:)
       visit admin_chapter_workshops_path(chapter)
 
       workshops.each do |workshop|
@@ -220,7 +220,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
   context 'with dietary restrictions' do
     scenario 'displays dietary restriction badges for attendees' do
       workshop = Fabricate(:workshop)
-      attendee = Fabricate(:attending_workshop_invitation, workshop: workshop)
+      attendee = Fabricate(:attending_workshop_invitation, workshop:)
       attendee.member.update(dietary_restrictions: %w[vegan gluten_free])
 
       visit admin_workshop_path(workshop)
@@ -259,7 +259,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
 
     scenario 'viewing a text file with all attendee emails' do
       workshop = Fabricate(:workshop)
-      attendees = Fabricate.times(2, :attending_workshop_invitation, workshop: workshop)
+      attendees = Fabricate.times(2, :attending_workshop_invitation, workshop:)
       attendees_emails = attendees.map(&:member).map(&:email)
       visit admin_workshop_attendees_emails_path(workshop, format: :text)
 
@@ -271,7 +271,7 @@ RSpec.feature 'An admin managing workshops', type: :feature do
     context 'when viewing the attendee names list' do
       scenario 'viewing a text file with all names' do
         workshop = Fabricate(:workshop)
-        attendees = Fabricate.times(2, :attending_workshop_invitation, workshop: workshop)
+        attendees = Fabricate.times(2, :attending_workshop_invitation, workshop:)
         visit admin_workshop_attendees_checklist_path(workshop, format: :text)
         attendees.map(&:member).map(&:full_name).each do |name|
           expect(page).to have_text(name)

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'viewing a Chapter', type: :feature do
       travel_to(Time.current) do
         chapter = Fabricate(:chapter)
         workshops = Array.new(2) do |n|
-          Fabricate(:workshop, chapter: chapter, date_and_time: 9.days.from_now - n.weeks)
+          Fabricate(:workshop, chapter:, date_and_time: 9.days.from_now - n.weeks)
         end
 
         visit chapter_path(chapter.slug)
@@ -68,8 +68,8 @@ RSpec.feature 'viewing a Chapter', type: :feature do
     it 'renders the most recent past workshop for the chapter' do
       travel_to(Time.current) do
         chapter = Fabricate(:chapter)
-        past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: 2.weeks.ago)
-        recent_past_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: 1.week.ago)
+        past_workshop = Fabricate(:workshop, chapter:, date_and_time: 2.weeks.ago)
+        recent_past_workshop = Fabricate(:workshop, chapter:, date_and_time: 1.week.ago)
 
         visit chapter_path(chapter.slug)
         expect(page).to have_text "Workshop at #{recent_past_workshop.host.name}"
@@ -81,7 +81,7 @@ RSpec.feature 'viewing a Chapter', type: :feature do
       travel_to(Time.current) do
         chapter = Fabricate(:chapter)
         workshops = Array.new(2) do |n|
-          Fabricate(:workshop, chapter: chapter, date_and_time: n.weeks.ago)
+          Fabricate(:workshop, chapter:, date_and_time: n.weeks.ago)
         end
 
         visit chapter_path(chapter.slug)

--- a/spec/features/coach_accepting_invitation_spec.rb
+++ b/spec/features/coach_accepting_invitation_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature 'a Coach can', type: :feature do
   describe '#workshop' do
     let(:member) { Fabricate(:member) }
-    let(:invitation) { Fabricate(:coach_workshop_invitation, member: member) }
+    let(:invitation) { Fabricate(:coach_workshop_invitation, member:) }
     let(:invitation_route) { invitation_path(invitation) }
     let(:reject_invitation_route) { reject_invitation_path(invitation) }
     let(:accept_invitation_route) { accept_invitation_path(invitation) }
@@ -16,7 +16,7 @@ RSpec.feature 'a Coach can', type: :feature do
 
       spots_to_fill.times do
         member = Fabricate(:member)
-        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: true)
+        Fabricate(:workshop_invitation, workshop:, member:, role: 'Coach', attending: true)
       end
     end
 

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature 'when visiting the coaches page', type: :feature do
   scenario 'I can see the most active coaches' do
     # Use a past workshop date in the current year to ensure the coach is counted
     workshop = Fabricate(:workshop, date_and_time: Time.zone.today.beginning_of_year + 1.month)
-    coach = Fabricate(:attended_coach, workshop: workshop).member
+    coach = Fabricate(:attended_coach, workshop:).member
     visit coaches_path
     expect(page).to have_text(coach.name, wait: 5)
   end

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'event listing', type: :feature do
     let!(:event) { Fabricate(:event) }
 
     before do
-      Fabricate(:workshop, chapter: chapter)
+      Fabricate(:workshop, chapter:)
     end
 
     scenario 'displays upcoming events page' do
@@ -21,7 +21,7 @@ RSpec.feature 'event listing', type: :feature do
     let!(:past_event) { Fabricate(:event, date_and_time: 2.weeks.ago) }
 
     before do
-      Fabricate(:workshop, date_and_time: 1.week.ago, chapter: chapter)
+      Fabricate(:workshop, date_and_time: 1.week.ago, chapter:)
     end
 
     scenario 'displays past events page' do
@@ -46,7 +46,7 @@ RSpec.feature 'event listing', type: :feature do
       travel_to(Time.current) do
         chapter = Fabricate(:chapter, active: true)
         Fabricate.times(22, :event, date_and_time: 2.weeks.ago)
-        Fabricate(:workshop, date_and_time: 3.weeks.ago, chapter: chapter)
+        Fabricate(:workshop, date_and_time: 3.weeks.ago, chapter:)
 
         visit past_events_path
         expect(page).to have_css('.card', count: 20)

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'member feedback', type: :feature do
   let!(:tutorial) { Fabricate(:tutorial, title: 'tutorial title') }
 
   before do
-    Fabricate(:feedback, coach: coach)
+    Fabricate(:feedback, coach:)
 
     Fabricate(:attended_workshop_invitation, workshop: feedback_request.workshop, member: coach, role: 'Coach')
   end
@@ -118,7 +118,7 @@ RSpec.feature 'member feedback', type: :feature do
 
       expect(page).to have_text(feedback_submited_message)
 
-      feedback = Feedback.find_by(workshop: feedback_request.workshop, coach: coach, tutorial: tutorial)
+      feedback = Feedback.find_by(workshop: feedback_request.workshop, coach:, tutorial:)
       expect(feedback).to be_present
       expect(feedback.rating).to eq(4)
     end

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature 'Member portal', type: :feature do
 
       it 'can view attending workshops' do
         workshop = Fabricate(:workshop, chapter: Fabricate(:chapter_with_groups))
-        Fabricate(:subscription, member: member, group: workshop.chapter.groups.first)
-        Fabricate(:attending_workshop_invitation, member: member,
-                                                  workshop: workshop)
+        Fabricate(:subscription, member:, group: workshop.chapter.groups.first)
+        Fabricate(:attending_workshop_invitation, member:,
+                                                  workshop:)
         presenter = WorkshopPresenter.new(workshop)
         visit dashboard_path
 
@@ -29,10 +29,10 @@ RSpec.feature 'Member portal', type: :feature do
 
       it 'can view upcoming workshops for their chapters' do
         c1_workshop = Fabricate(:workshop, chapter: Fabricate(:chapter_with_groups))
-        Fabricate(:subscription, member: member, group: c1_workshop.chapter.groups.first)
+        Fabricate(:subscription, member:, group: c1_workshop.chapter.groups.first)
 
         c2_workshop = Fabricate(:workshop, chapter: Fabricate(:chapter_with_groups))
-        Fabricate(:subscription, member: member, group: c2_workshop.chapter.groups.first)
+        Fabricate(:subscription, member:, group: c2_workshop.chapter.groups.first)
         c1_workshop_presenter = WorkshopPresenter.new(c1_workshop)
         c2_workshop_presenter = WorkshopPresenter.new(c2_workshop)
 
@@ -71,7 +71,7 @@ RSpec.feature 'Member portal', type: :feature do
     end
 
     it 'can view the invitations they RSVPed to' do
-      invitations = Array.new(2) { Fabricate(:attending_workshop_invitation, member: member) }
+      invitations = Array.new(2) { Fabricate(:attending_workshop_invitation, member:) }
       visit invitations_path
 
       expect(page).to have_text('Invitations')

--- a/spec/features/subscribing_to_emails_spec.rb
+++ b/spec/features/subscribing_to_emails_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Managing subscriptions', type: :feature do
     end
 
     scenario '#unsubscribe' do
-      Fabricate.create(:subscription, member: member, group: group)
+      Fabricate.create(:subscription, member:, group:)
       visit subscriptions_path
 
       click_on 'Subscribed'

--- a/spec/features/view_event_spec.rb
+++ b/spec/features/view_event_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature 'viewing an event', type: :feature do
       end
 
       scenario 'is redirected to the event invitation page if they have RSVPed' do
-        invitation = Fabricate(:attending_event_invitation, event: open_event, member: member)
+        invitation = Fabricate(:attending_event_invitation, event: open_event, member:)
         visit event_path(open_event)
 
         expect(page).to have_current_path(event_invitation_path(open_event, invitation.token), ignore_query: true)

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature 'Viewing a workshop invitation', :wip, type: :feature do
-  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop) }
+  let(:invitation) { Fabricate(:workshop_invitation, workshop:) }
 
   before do
     visit invitation_path(invitation)
@@ -77,7 +77,7 @@ RSpec.feature 'Viewing a workshop invitation', :wip, type: :feature do
 
     describe '#description' do
       context 'when RSVPed' do
-        let(:invitation) { Fabricate(:attending_workshop_invitation, workshop: workshop) }
+        let(:invitation) { Fabricate(:attending_workshop_invitation, workshop:) }
 
         it 'contains details about the workshop' do
           within '#info' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ApplicationHelper do
   describe '#contact_email' do
     it "returns the workshop chapter's email" do
       workshop = Fabricate(:workshop)
-      expect(helper.contact_email(workshop: workshop)).to eq(workshop.chapter.email)
+      expect(helper.contact_email(workshop:)).to eq(workshop.chapter.email)
     end
 
     it 'returns hello@codebar.io when no workshop is set' do

--- a/spec/lib/omniauth/strategies/codebar_spec.rb
+++ b/spec/lib/omniauth/strategies/codebar_spec.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 require 'jwt'
 
 RSpec.describe OmniAuth::Strategies::Codebar do
-  subject(:strategy) { described_class.new(app, auth_url: auth_url, audience: 'planner') }
+  subject(:strategy) { described_class.new(app, auth_url:, audience: 'planner') }
 
   let(:app) { ->(_env) { [200, {}, ['OK']] } }
   let(:auth_url) { 'http://localhost:3001' }
@@ -193,7 +193,7 @@ RSpec.describe OmniAuth::Strategies::Codebar do
         .with(headers: { 'User-Agent' => 'Codebar Planner/1.0' })
         .to_return(status: 200, body: {
           access_token: 'test-access-token',
-          id_token: id_token,
+          id_token:,
           token_type: 'Bearer',
           expires_in: 900
         }.to_json, headers: { 'Content-Type' => 'application/json' })

--- a/spec/lib/tasks/delete_member_rake_spec.rb
+++ b/spec/lib/tasks/delete_member_rake_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe 'rake member:delete', type: :task do
   end
 
   it 'anonymises member information' do
-    invitations = Fabricate.times(2, :workshop_invitation, member: member)
+    invitations = Fabricate.times(2, :workshop_invitation, member:)
     tokens = invitations.map(&:token)
 
-    Fabricate.times(1, :subscription, member: member)
+    Fabricate.times(1, :subscription, member:)
 
     allow($stdin).to receive(:getch)
 

--- a/spec/lib/tasks/feedback_rake_spec.rb
+++ b/spec/lib/tasks/feedback_rake_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'rake feedback:request', type: :task do
       travel_to(Time.current) do
         workshop = Fabricate(:workshop, date_and_time: 23.hours.ago)
         student = Fabricate(:member)
-        Fabricate(:attending_workshop_invitation, role: 'Student', member: student, workshop: workshop)
+        Fabricate(:attending_workshop_invitation, role: 'Student', member: student, workshop:)
 
         mailer = double(deliver_now: true)
         allow(Workshop).to receive(:completed_since_yesterday).and_return([workshop])
@@ -49,11 +49,11 @@ RSpec.describe 'rake feedback:request', type: :task do
         task.execute
 
         past_workshops.each do |workshop|
-          expect(FeedbackRequest.where(member: student, workshop: workshop, submited: false).exists?).to be(false)
+          expect(FeedbackRequest.where(member: student, workshop:, submited: false).exists?).to be(false)
         end
 
         yesterdays_workshops.each do |workshop|
-          expect(FeedbackRequest.where(member: student, workshop: workshop, submited: false).exists?).to be(true)
+          expect(FeedbackRequest.where(member: student, workshop:, submited: false).exists?).to be(true)
         end
       end
     end

--- a/spec/lib/tasks/mailing_list_rake_spec.rb
+++ b/spec/lib/tasks/mailing_list_rake_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'rake mailing_list:subscribe_active_members', type: :task do
     ENV['NEWSLETTER_ID'] = 'newsletterid'
     non_subscribed = Fabricate.times(2, :member)
     subscribed = Fabricate.times(2, :member)
-    subscribed.each { |member| Fabricate(:subscription, member: member) }
-    subscribed[0...3].each { |member| Fabricate(:subscription, member: member) }
+    subscribed.each { |member| Fabricate(:subscription, member:) }
+    subscribed[0...3].each { |member| Fabricate(:subscription, member:) }
 
     newslettter = Services::MailingList.new(:id)
     allow(Services::MailingList).to receive(:new).and_return(newslettter)

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -3,11 +3,11 @@ RSpec.describe EventInvitationMailer do
   let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }
   let(:coach_event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event', audience: 'Coaches') }
   let(:member) { Fabricate(:member) }
-  let(:invitation) { Fabricate(:invitation, event: event, member: member) }
+  let(:invitation) { Fabricate(:invitation, event:, member:) }
 
   context 'when the member has an invalid email' do
     let(:bad_member) { Fabricate(:member) }
-    let(:bad_invitation) { Fabricate(:invitation, event: event, member: bad_member) }
+    let(:bad_invitation) { Fabricate(:invitation, event:, member: bad_member) }
 
     before { allow(bad_member).to receive(:email).and_return('invalid-email') }
 
@@ -74,7 +74,7 @@ RSpec.describe EventInvitationMailer do
                 name: 'Test event',
                 description: '<script>alert("xss")</script><p>Safe content</p>')
     end
-    let(:invitation_with_html) { Fabricate(:invitation, event: event_with_html, member: member) }
+    let(:invitation_with_html) { Fabricate(:invitation, event: event_with_html, member:) }
 
     it 'sanitizes description in invite_student email' do
       described_class.invite_student(event_with_html, member, invitation_with_html).deliver_now

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe FeedbackRequestMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:member) { Fabricate(:member) }
-  let(:feedback_request) { Fabricate(:feedback_request, workshop: workshop, member: member) }
+  let(:feedback_request) { Fabricate(:feedback_request, workshop:, member:) }
 
   context 'when the member has an invalid email' do
     let(:workshop) { Fabricate(:workshop) }
     let(:bad_member) { Fabricate(:member) }
-    let(:bad_feedback_request) { Fabricate(:feedback_request, workshop: workshop, member: bad_member) }
+    let(:bad_feedback_request) { Fabricate(:feedback_request, workshop:, member: bad_member) }
 
     before { allow(bad_member).to receive(:email).and_return('invalid-email') }
 

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe MeetingInvitationMailer do
   let(:meeting) { Fabricate(:meeting) }
   let(:member) { Fabricate(:member) }
-  let(:invitation) { Fabricate(:meeting_invitation, meeting: meeting, member: member) }
+  let(:invitation) { Fabricate(:meeting_invitation, meeting:, member:) }
 
   context 'when the member has an invalid email' do
     let(:bad_member) { Fabricate(:member) }
-    let(:bad_invitation) { Fabricate(:meeting_invitation, meeting: meeting, member: bad_member) }
+    let(:bad_invitation) { Fabricate(:meeting_invitation, meeting:, member: bad_member) }
 
     before { allow(bad_member).to receive(:email).and_return('invalid-email') }
 

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe MemberMailer do
     it 'logs the sent email' do
       expect do
         described_class
-          .with(member: member)
+          .with(member:)
           .chaser
           .deliver_now
       end.to change(MemberEmailDelivery, :count).by(1)
@@ -191,7 +191,7 @@ RSpec.describe MemberMailer do
 
     it 'logs one row per member even if the delivery is performed twice' do
       expect do
-        described_class.with(member: member).chaser.deliver_now
+        described_class.with(member:).chaser.deliver_now
         described_class.with(member:).chaser.deliver_now
       end.to change(MemberEmailDelivery, :count).by(1)
     end

--- a/spec/mailers/previews/meeting_invitation_mailer_preview.rb
+++ b/spec/mailers/previews/meeting_invitation_mailer_preview.rb
@@ -5,7 +5,7 @@ class MeetingInvitationMailerPreview < ActionMailer::Preview
 
     # In the real work, MeetingInvitation should have been created already and a
     # token should have been assigned. The next lines are for testing purposes.
-    invitation = MeetingInvitation.new(meeting: meeting, member: member)
+    invitation = MeetingInvitation.new(meeting:, member:)
     invitation.token = 'tokenExample28XIcd6IxQ'
 
     MeetingInvitationMailer.invite(meeting, member, invitation)

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe VirtualWorkshopInvitationMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop) }
   let(:member) { Fabricate(:member) }
-  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
+  let(:invitation) { Fabricate(:workshop_invitation, workshop:, member:) }
 
   context 'when the member has an invalid email' do
     let(:bad_member) { Fabricate(:member) }
-    let(:bad_invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: bad_member) }
+    let(:bad_invitation) { Fabricate(:workshop_invitation, workshop:, member: bad_member) }
 
     before { allow(bad_member).to receive(:email).and_return('invalid-email') }
 
@@ -73,8 +73,8 @@ RSpec.describe VirtualWorkshopInvitationMailer do
 
   it '#attending renders workshop description as HTML, not escaped' do
     description = '<strong>Important notice:</strong> Please bring a laptop.'
-    workshop = Fabricate(:workshop, description: description)
-    invitation = Fabricate(:workshop_invitation, workshop: workshop, member: member)
+    workshop = Fabricate(:workshop, description:)
+    invitation = Fabricate(:workshop_invitation, workshop:, member:)
 
     WorkshopInvitationMailer.attending(workshop, member, invitation).deliver_now
 

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe WorkshopInvitationMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }
   let(:member) { Fabricate(:member) }
-  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
+  let(:invitation) { Fabricate(:workshop_invitation, workshop:, member:) }
   let(:sponsor) { Fabricate(:sponsor) }
 
   context 'when the member has an invalid email' do
     let(:bad_member) { Fabricate(:member) }
-    let(:bad_invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: bad_member) }
+    let(:bad_invitation) { Fabricate(:workshop_invitation, workshop:, member: bad_member) }
 
     before { allow(bad_member).to receive(:email).and_return('invalid-email') }
 
@@ -118,8 +118,8 @@ RSpec.describe WorkshopInvitationMailer do
 
   it '#attending renders workshop description as HTML, not escaped' do
     description = '<strong>Important notice:</strong> Please bring a laptop.'
-    workshop = Fabricate(:workshop, description: description)
-    invitation = Fabricate(:workshop_invitation, workshop: workshop, member: member)
+    workshop = Fabricate(:workshop, description:)
+    invitation = Fabricate(:workshop_invitation, workshop:, member:)
 
     described_class.attending(workshop, member, invitation).deliver_now
 

--- a/spec/models/attendance_warning_spec.rb
+++ b/spec/models/attendance_warning_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AttendanceWarning do
     let(:admin) { Fabricate(:member) }
 
     it 'creates an attendance warning to a member issued by an admin' do
-      attendance_warning = described_class.create(member: member, issued_by: admin)
+      attendance_warning = described_class.create(member:, issued_by: admin)
 
       expect(attendance_warning.issued_by).to eq(admin)
     end
@@ -13,8 +13,8 @@ RSpec.describe AttendanceWarning do
       describe 'last_six_months' do
         it 'returns all attendance warnings issues in the last six months' do
           travel_to(Time.current) do
-            Fabricate(:attendance_warning, member: member, created_at: 7.months.ago)
-            warnings = Fabricate.times(2, :attendance_warning, member: member, created_at: 5.months.ago)
+            Fabricate(:attendance_warning, member:, created_at: 7.months.ago)
+            warnings = Fabricate.times(2, :attendance_warning, member:, created_at: 5.months.ago)
 
             expect(member.attendance_warnings.last_six_months).to match_array(warnings)
           end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Chapter do
 
   describe '#students' do
     let(:chapter) { Fabricate(:chapter) }
-    let(:student_group) { Fabricate(:group, chapter: chapter, name: 'Students') }
+    let(:student_group) { Fabricate(:group, chapter:, name: 'Students') }
 
     it 'returns only students from this chapter' do
       other_chapter = Fabricate(:chapter)
@@ -82,7 +82,7 @@ RSpec.describe Chapter do
 
   describe '#coaches' do
     let(:chapter) { Fabricate(:chapter) }
-    let(:coach_group) { Fabricate(:group, chapter: chapter, name: 'Coaches') }
+    let(:coach_group) { Fabricate(:group, chapter:, name: 'Coaches') }
 
     it 'returns only coaches from this chapter' do
       other_chapter = Fabricate(:chapter)
@@ -96,7 +96,7 @@ RSpec.describe Chapter do
 
   describe '#eligible_students' do
     let(:chapter) { Fabricate(:chapter) }
-    let(:student_group) { Fabricate(:group, chapter: chapter, name: 'Students') }
+    let(:student_group) { Fabricate(:group, chapter:, name: 'Students') }
 
     it 'includes only students with accepted TOC who are not banned' do
       eligible_student = Fabricate(:member, groups: [student_group], accepted_toc_at: Time.zone.now)
@@ -114,7 +114,7 @@ RSpec.describe Chapter do
 
   describe '#eligible_coaches' do
     let(:chapter) { Fabricate(:chapter) }
-    let(:coach_group) { Fabricate(:group, chapter: chapter, name: 'Coaches') }
+    let(:coach_group) { Fabricate(:group, chapter:, name: 'Coaches') }
 
     it 'includes only coaches with accepted TOC who are not banned' do
       eligible_coach = Fabricate(:member, groups: [coach_group], accepted_toc_at: Time.zone.now)

--- a/spec/models/eligibility_inquiry_spec.rb
+++ b/spec/models/eligibility_inquiry_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EligibilityInquiry do
     let(:admin) { Fabricate(:member) }
 
     it 'creates an eligibility inquiry to a member issued by an admin' do
-      eligibility_inquiry = described_class.create(member: member, issued_by: admin)
+      eligibility_inquiry = described_class.create(member:, issued_by: admin)
 
       expect(eligibility_inquiry.issued_by).to eq(admin)
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe Event do
   describe '#verified_students' do
     it 'returns all students who have verified their attendance' do
       event = Fabricate(:event)
-      Array.new(1) { Fabricate(:invitation, event: event, attending: true) }
-      Array.new(2) { Fabricate(:invitation, event: event, attending: true, verified: true) }
+      Array.new(1) { Fabricate(:invitation, event:, attending: true) }
+      Array.new(2) { Fabricate(:invitation, event:, attending: true, verified: true) }
 
       expect(event.verified_students.count).to eq(2)
     end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Group do
     let(:chapter) { group.chapter }
 
     it 'orders members by most recent workshop RSVP' do
-      old_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: 1.month.ago)
-      new_workshop = Fabricate(:workshop, chapter: chapter, date_and_time: 1.week.ago)
+      old_workshop = Fabricate(:workshop, chapter:, date_and_time: 1.month.ago)
+      new_workshop = Fabricate(:workshop, chapter:, date_and_time: 1.week.ago)
 
       member_old = Fabricate(:member, groups: [group])
       member_new = Fabricate(:member, groups: [group])

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe Meeting do
   describe '#not_full' do
     it 'returns true if meeting is not full' do
       meeting = Fabricate(:meeting)
-      Fabricate(:attending_meeting_invitation, meeting: meeting)
+      Fabricate(:attending_meeting_invitation, meeting:)
 
       expect(meeting.not_full).to be(true)
     end
 
     it 'returns false if meeting is full' do
       meeting = Fabricate(:meeting)
-      Fabricate.times(21, :attending_meeting_invitation, meeting: meeting)
+      Fabricate.times(21, :attending_meeting_invitation, meeting:)
 
       expect(meeting.not_full).to be(false)
     end
@@ -68,7 +68,7 @@ RSpec.describe Meeting do
   describe '#attendees_csv' do
     it 'generates a csv of attendees' do
       meeting = Fabricate(:meeting)
-      invitations = Fabricate.times(2, :attending_meeting_invitation, meeting: meeting)
+      invitations = Fabricate.times(2, :attending_meeting_invitation, meeting:)
 
       expect(meeting.attendees_csv).not_to be_blank
       invitations.each do |invitation|

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Member do
 
         it 'returns notes for the most recent five workshops' do
           latest_workshops = (1..6).map do |time_ago|
-            Fabricate.create(:workshop_invitation, member: member) do
+            Fabricate.create(:workshop_invitation, member:) do
               workshop { Fabricate(:workshop, date_and_time: Time.zone.now - (7 * time_ago).days) }
               attended { true }
             end
@@ -112,8 +112,8 @@ RSpec.describe Member do
           outside_deadline = latest_workshops.last.workshop.date_and_time
           within_deadline = latest_workshops.fifth.workshop.date_and_time
 
-          Fabricate.create(:member_note, member: member, created_at: outside_deadline)
-          new_note = Fabricate.create(:member_note, member: member, created_at: within_deadline)
+          Fabricate.create(:member_note, member:, created_at: outside_deadline)
+          new_note = Fabricate.create(:member_note, member:, created_at: within_deadline)
 
           expect(member.recent_notes.to_a).to eq([new_note])
         end
@@ -148,7 +148,7 @@ RSpec.describe Member do
     describe '#in_group' do
       it 'includes members in group' do
         chapter = Fabricate(:chapter)
-        group = Fabricate(:group, chapter: chapter, members: [Fabricate(:member)])
+        group = Fabricate(:group, chapter:, members: [Fabricate(:member)])
 
         expect(described_class.in_group(chapter.groups)).to eq(group.members)
       end
@@ -163,7 +163,7 @@ RSpec.describe Member do
 
       it 'excludes banned members in group' do
         chapter = Fabricate(:chapter)
-        group = Fabricate(:group, chapter: chapter, members: [Fabricate(:banned_member)])
+        group = Fabricate(:group, chapter:, members: [Fabricate(:banned_member)])
 
         expect(described_class.in_group(chapter.groups)).not_to eq(group.members)
       end
@@ -172,13 +172,13 @@ RSpec.describe Member do
 
   describe '.multiple_no_shows?' do
     it 'returns true when a member has missed more than three workshop in the last six months' do
-      Fabricate.times(6, :past_attending_workshop_invitation, member: member)
+      Fabricate.times(6, :past_attending_workshop_invitation, member:)
 
       expect(member.multiple_no_shows?).to be true
     end
 
     it 'returns false when a member has not missed more than three workshop in the last six months' do
-      Fabricate.times(3, :past_attending_workshop_invitation, attended: true, member: member)
+      Fabricate.times(3, :past_attending_workshop_invitation, attended: true, member:)
 
       expect(member.multiple_no_shows?).to be false
     end
@@ -186,21 +186,21 @@ RSpec.describe Member do
 
   describe '.flag_to_organisers' do
     it 'returns false when a member does not have multiple_no_shows?' do
-      Fabricate.times(2, :attendance_warning, member: member)
+      Fabricate.times(2, :attendance_warning, member:)
 
       expect(member.flag_to_organisers?).to be false
     end
 
     it 'returns false when a member does not have at least two two attendance warnings' do
-      Fabricate.times(6, :past_attending_workshop_invitation, member: member)
-      Fabricate(:attendance_warning, member: member)
+      Fabricate.times(6, :past_attending_workshop_invitation, member:)
+      Fabricate(:attendance_warning, member:)
 
       expect(member.flag_to_organisers?).to be false
     end
 
     it 'returns true when a member has multiple_no_shows? and has received at least two attendance warning emails' do
-      Fabricate.times(6, :past_attending_workshop_invitation, member: member)
-      Fabricate.times(2, :attendance_warning, member: member)
+      Fabricate.times(6, :past_attending_workshop_invitation, member:)
+      Fabricate.times(2, :attendance_warning, member:)
 
       expect(member.flag_to_organisers?).to be true
     end
@@ -297,38 +297,38 @@ RSpec.describe Member do
 
     it 'returns event IDs where member has accepted invitation' do
       event = Fabricate(:event)
-      Fabricate(:invitation, member: member, event: event, attending: true)
+      Fabricate(:invitation, member:, event:, attending: true)
       expect(member.attending_event_ids).to include(event.id)
     end
 
     it 'does not include events where invitation is not accepted' do
       event = Fabricate(:event)
-      Fabricate(:invitation, member: member, event: event, attending: false)
+      Fabricate(:invitation, member:, event:, attending: false)
       expect(member.attending_event_ids).not_to include(event.id)
     end
 
     it 'includes workshop IDs' do
       workshop = Fabricate(:workshop)
-      Fabricate(:workshop_invitation, member: member, workshop: workshop, attending: true)
+      Fabricate(:workshop_invitation, member:, workshop:, attending: true)
       expect(member.attending_event_ids).to include(workshop.id)
     end
 
     it 'includes meeting IDs' do
       meeting = Fabricate(:meeting)
-      Fabricate(:meeting_invitation, member: member, meeting: meeting, attending: true)
+      Fabricate(:meeting_invitation, member:, meeting:, attending: true)
       expect(member.attending_event_ids).to include(meeting.id)
     end
 
     it 'caches result in instance variable' do
       event = Fabricate(:event)
-      Fabricate(:invitation, member: member, event: event, attending: true)
+      Fabricate(:invitation, member:, event:, attending: true)
       first_call = member.attending_event_ids
       expect(member.attending_event_ids).to equal(first_call)
     end
 
     it 'can be cleared and re-queries on next call' do
       event = Fabricate(:event)
-      Fabricate(:invitation, member: member, event: event, attending: true)
+      Fabricate(:invitation, member:, event:, attending: true)
       member.attending_event_ids
       member.clear_attending_event_ids_cache!
       expect(member.attending_event_ids).to include(event.id)

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WaitingList do
       end
 
       it 'is returns the waiting list entries when there are any' do
-        invitations = Array.new(2) { Fabricate(:workshop_invitation, workshop: workshop) }
+        invitations = Array.new(2) { Fabricate(:workshop_invitation, workshop:) }
         invitations.each { |invitation| described_class.add(invitation) }
 
         expect(described_class.by_workshop(workshop).map(&:invitation)).to match_array(invitations)
@@ -17,7 +17,7 @@ RSpec.describe WaitingList do
 
     describe '#next_spot' do
       it 'returns the next spot to be allocated' do
-        invitation = Fabricate(:workshop_invitation, workshop: workshop)
+        invitation = Fabricate(:workshop_invitation, workshop:)
         described_class.add(invitation)
 
         expect(described_class.next_spot(workshop, 'Student').invitation).to eq(invitation)
@@ -27,14 +27,14 @@ RSpec.describe WaitingList do
 
   describe '#add' do
     it 'is adds an invitation to the waiting list' do
-      invitation = Fabricate(:workshop_invitation, workshop: workshop)
+      invitation = Fabricate(:workshop_invitation, workshop:)
       described_class.add(invitation)
 
       expect(described_class.by_workshop(workshop).map(&:invitation)).to eq([invitation])
     end
 
     it 'is idempotent - returns existing record when called twice' do
-      invitation = Fabricate(:workshop_invitation, workshop: workshop)
+      invitation = Fabricate(:workshop_invitation, workshop:)
 
       first_call = described_class.add(invitation)
       second_call = described_class.add(invitation)
@@ -44,7 +44,7 @@ RSpec.describe WaitingList do
     end
 
     it 'does not change auto_rsvp on subsequent calls' do
-      invitation = Fabricate(:workshop_invitation, workshop: workshop)
+      invitation = Fabricate(:workshop_invitation, workshop:)
 
       described_class.add(invitation, true)
       second_entry = described_class.add(invitation, false)
@@ -57,7 +57,7 @@ RSpec.describe WaitingList do
     it 'returns waitlisted coaches for a specific workshop' do
       coach = Fabricate(:coach)
 
-      invitation = Fabricate(:coach_workshop_invitation, workshop: workshop, member: coach)
+      invitation = Fabricate(:coach_workshop_invitation, workshop:, member: coach)
       coach_invitation = described_class.add(invitation)
 
       expect(described_class.coaches_for(workshop)).to eq([coach_invitation])
@@ -66,7 +66,7 @@ RSpec.describe WaitingList do
     it 'returns waitlisted students for a specific workshop' do
       student = Fabricate(:student)
 
-      invitation = Fabricate(:student_workshop_invitation, workshop: workshop, member: student)
+      invitation = Fabricate(:student_workshop_invitation, workshop:, member: student)
       student_invitation = described_class.add(invitation)
 
       expect(described_class.students_for(workshop)).to eq([student_invitation])

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -263,16 +263,16 @@ RSpec.describe Workshop do
 
     context 'with attendances' do
       it '#attendee? for students' do
-        attendee_invites = Array.new(1) { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
-        nonattendee_invites = Array.new(2) { Fabricate(:workshop_invitation, workshop: workshop, attending: false) }
+        attendee_invites = Array.new(1) { Fabricate(:workshop_invitation, workshop:, attending: true) }
+        nonattendee_invites = Array.new(2) { Fabricate(:workshop_invitation, workshop:, attending: false) }
 
         attendee_invites.each { |a| expect(workshop.attendee?(a.member)).to be true }
         nonattendee_invites.each { |a| expect(workshop.attendee?(a.member)).to be false }
       end
 
       it '#attendee? for coaches' do
-        attendee_invites = Array.new(1) { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
-        nonattendee_invites = Array.new(2) { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: false) }
+        attendee_invites = Array.new(1) { Fabricate(:coach_workshop_invitation, workshop:, attending: true) }
+        nonattendee_invites = Array.new(2) { Fabricate(:coach_workshop_invitation, workshop:, attending: false) }
 
         attendee_invites.each { |a| expect(workshop.attendee?(a.member)).to be true }
         nonattendee_invites.each { |a| expect(workshop.attendee?(a.member)).to be false }
@@ -281,18 +281,18 @@ RSpec.describe Workshop do
 
     context 'when waitlist attendance' do
       it '#waitlisted? for students' do
-        invitations = Array.new(2) { Fabricate(:workshop_invitation, workshop: workshop) }
+        invitations = Array.new(2) { Fabricate(:workshop_invitation, workshop:) }
         invitations.each { |invitation| WaitingList.add(invitation) }
-        attendee_invites = Array.new(1) { Fabricate(:workshop_invitation, workshop: workshop, attending: true) }
+        attendee_invites = Array.new(1) { Fabricate(:workshop_invitation, workshop:, attending: true) }
 
         invitations.each { |a| expect(workshop.waitlisted?(a.member)).to be true }
         attendee_invites.each { |a| expect(workshop.waitlisted?(a.member)).to be false }
       end
 
       it '#waitlisted? for coaches' do
-        invitations = Array.new(2) { Fabricate(:coach_workshop_invitation, workshop: workshop) }
+        invitations = Array.new(2) { Fabricate(:coach_workshop_invitation, workshop:) }
         invitations.each { |invitation| WaitingList.add(invitation) }
-        attendee_invites = Array.new(1) { Fabricate(:coach_workshop_invitation, workshop: workshop, attending: true) }
+        attendee_invites = Array.new(1) { Fabricate(:coach_workshop_invitation, workshop:, attending: true) }
 
         invitations.each { |a| expect(workshop.waitlisted?(a.member)).to be true }
         attendee_invites.each { |a| expect(workshop.waitlisted?(a.member)).to be false }

--- a/spec/presenters/chapter_presenter_spec.rb
+++ b/spec/presenters/chapter_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe ChapterPresenter do
 
   it '#upcoming_workshops' do
     travel_to(Time.current) do
-      Fabricate.times(2, :past_workshop, chapter: chapter)
-      workshops = Fabricate.times(3, :workshop, chapter: chapter,
+      Fabricate.times(2, :past_workshop, chapter:)
+      workshops = Fabricate.times(3, :workshop, chapter:,
                                                 date_and_time: 1.week.from_now)
 
       expect(presenter.upcoming_workshops).to match_array(workshops)

--- a/spec/presenters/how_you_found_us_presenter_spec.rb
+++ b/spec/presenters/how_you_found_us_presenter_spec.rb
@@ -1,18 +1,18 @@
 RSpec.describe HowYouFoundUsPresenter do
   def add_member(group, how)
     member = Fabricate(:member, how_you_found_us: how)
-    Fabricate(:subscription, member: member, group: group)
+    Fabricate(:subscription, member:, group:)
     member
   end
 
   def add_member_without_how(group)
     member = Fabricate(:member, how_you_found_us: nil)
-    Fabricate(:subscription, member: member, group: group)
+    Fabricate(:subscription, member:, group:)
     member
   end
 
   let(:chapter) { Fabricate(:chapter_without_organisers) }
-  let(:group) { Fabricate(:group, chapter: chapter) }
+  let(:group) { Fabricate(:group, chapter:) }
   let(:presenter) { described_class.new(chapter) }
 
   describe '#by_percentage' do

--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MeetingPresenter do
   end
 
   it '#attendees_emails' do
-    attendees = Fabricate.times(4, :attending_meeting_invitation, meeting: meeting)
+    attendees = Fabricate.times(4, :attending_meeting_invitation, meeting:)
     emails = attendees.map(&:member).map(&:email)
     emails.each do |email|
       expect(event.attendees_emails).to include(email)

--- a/spec/presenters/member_presenter_spec.rb
+++ b/spec/presenters/member_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe MemberPresenter do
     let(:event) { Fabricate(:event) }
 
     it 'returns true when member is attending event' do
-      Fabricate(:invitation, member: member, event: event, attending: true)
+      Fabricate(:invitation, member:, event:, attending: true)
       expect(member_presenter.attending?(event)).to be true
     end
 
@@ -45,7 +45,7 @@ RSpec.describe MemberPresenter do
 
   describe '#event_organiser?' do
     let(:chapter) { Fabricate(:chapter) }
-    let(:workshop) { Fabricate(:workshop_no_sponsor, chapter: chapter) }
+    let(:workshop) { Fabricate(:workshop_no_sponsor, chapter:) }
 
     it 'returns true when user is admin' do
       admin = Fabricate(:member)

--- a/spec/presenters/sponsor_presenter_spec.rb
+++ b/spec/presenters/sponsor_presenter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe SponsorPresenter do
   let(:sponsor_presenter) { described_class.new(sponsor) }
-  let(:sponsor) { Fabricate(:sponsor, contacts: contacts) }
+  let(:sponsor) { Fabricate(:sponsor, contacts:) }
   let(:contact) { Fabricate(:contact) }
   let(:contacts) { [contact] }
 
@@ -36,8 +36,8 @@ RSpec.describe SponsorPresenter do
 
   describe '#sponsorships_count' do
     before do
-      Fabricate(:workshop_sponsor, sponsor: sponsor)
-      Fabricate.times(2, :sponsorship, sponsor: sponsor)
+      Fabricate(:workshop_sponsor, sponsor:)
+      Fabricate.times(2, :sponsorship, sponsor:)
     end
 
     it 'returns the total number of event sponsorships associated with the sponsor' do

--- a/spec/presenters/virtual_workshop_presenter_spec.rb
+++ b/spec/presenters/virtual_workshop_presenter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe VirtualWorkshopPresenter do
   def double_workshop(attending_coaches:, attending_students:)
-    instance_double(Workshop, coach_spaces: 3, student_spaces: 5, chapter: chapter,
+    instance_double(Workshop, coach_spaces: 3, student_spaces: 5, chapter:,
                               attending_coaches: instance_double(Array, length: attending_coaches),
                               attending_students: instance_double(Array, length: attending_students))
   end

--- a/spec/presenters/workshop_presenter_capacity_spec.rb
+++ b/spec/presenters/workshop_presenter_capacity_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
         # Create 2 attending students (at capacity)
         2.times do
           member = Fabricate(:member)
-          Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student', attending: true)
+          Fabricate(:workshop_invitation, workshop:, member:, role: 'Student', attending: true)
         end
       end
 
@@ -26,7 +26,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       before do
         # Create 1 attending student (below capacity)
         member = Fabricate(:member)
-        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student', attending: true)
+        Fabricate(:workshop_invitation, workshop:, member:, role: 'Student', attending: true)
       end
 
       it 'returns true when spaces are available' do
@@ -41,7 +41,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       let(:sponsor) { Fabricate(:sponsor, seats: 20, number_of_coaches: 10) }
       let(:workshop_with_zero_spaces) do
         Fabricate(:workshop_no_sponsor, student_spaces: 0, coach_spaces: 0).tap do |ws|
-          Fabricate(:workshop_sponsor, workshop: ws, sponsor: sponsor, host: true)
+          Fabricate(:workshop_sponsor, workshop: ws, sponsor:, host: true)
         end
       end
       let(:presenter_zero_spaces) { WorkshopPresenter.new(workshop_with_zero_spaces) }
@@ -49,7 +49,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       before do
         # Create 1 attending student
         member = Fabricate(:member)
-        Fabricate(:workshop_invitation, workshop: workshop_with_zero_spaces, member: member, role: 'Student', attending: true)
+        Fabricate(:workshop_invitation, workshop: workshop_with_zero_spaces, member:, role: 'Student', attending: true)
       end
 
       it 'returns true because capacity comes from sponsor, not workshop.student_spaces' do
@@ -71,7 +71,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
         # Create 2 attending coaches (at capacity)
         2.times do
           member = Fabricate(:member)
-          Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: true)
+          Fabricate(:workshop_invitation, workshop:, member:, role: 'Coach', attending: true)
         end
       end
 
@@ -86,7 +86,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       before do
         # Create 1 attending coach (below capacity)
         member = Fabricate(:member)
-        Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Coach', attending: true)
+        Fabricate(:workshop_invitation, workshop:, member:, role: 'Coach', attending: true)
       end
 
       it 'returns true when coach spaces are available' do
@@ -100,7 +100,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       let(:sponsor) { Fabricate(:sponsor, seats: 20, number_of_coaches: 10) }
       let(:workshop_with_zero_spaces) do
         Fabricate(:workshop_no_sponsor, student_spaces: 0, coach_spaces: 0).tap do |ws|
-          Fabricate(:workshop_sponsor, workshop: ws, sponsor: sponsor, host: true)
+          Fabricate(:workshop_sponsor, workshop: ws, sponsor:, host: true)
         end
       end
       let(:presenter_zero_spaces) { WorkshopPresenter.new(workshop_with_zero_spaces) }
@@ -108,7 +108,7 @@ RSpec.describe 'WorkshopPresenter capacity checks', type: :model do
       before do
         # Create 1 attending coach
         member = Fabricate(:member)
-        Fabricate(:workshop_invitation, workshop: workshop_with_zero_spaces, member: member, role: 'Coach', attending: true)
+        Fabricate(:workshop_invitation, workshop: workshop_with_zero_spaces, member:, role: 'Coach', attending: true)
       end
 
       it 'returns true because capacity comes from sponsor, not workshop.coach_spaces' do

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe WorkshopPresenter do
   let(:chapter) { Fabricate(:chapter) }
   let(:host) { Fabricate(:sponsor, seats: 5, number_of_coaches: 15) }
-  let(:workshop) { instance_double(Workshop, host: host, chapter: chapter) }
+  let(:workshop) { instance_double(Workshop, host:, chapter:) }
   let(:presenter) { described_class.new(workshop) }
 
   def double_workshop(attending_coaches:, attending_students:)
-    instance_double(Workshop, host: host, chapter: chapter,
+    instance_double(Workshop, host:, chapter:,
                               attending_coaches: instance_double(Array, count: attending_coaches),
                               attending_students: instance_double(Array, count: attending_students))
   end
@@ -135,9 +135,9 @@ RSpec.describe WorkshopPresenter do
     members = Fabricate.times(2, :member)
     members.each_with_index do |member, index|
       if index.even?
-  Fabricate(:attending_workshop_invitation, member: member, workshop: workshop)
+  Fabricate(:attending_workshop_invitation, member:, workshop:)
       else
-  Fabricate(:attending_workshop_invitation, member: member, workshop: workshop, role: 'Coach')
+  Fabricate(:attending_workshop_invitation, member:, workshop:, role: 'Coach')
       end
     end
 

--- a/spec/queriers/admin_workshop_attendee_flags_spec.rb
+++ b/spec/queriers/admin_workshop_attendee_flags_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe AdminWorkshopAttendeeFlags do
   describe '.for_members' do
     context 'when determining if a member is a newbie' do
       it 'is true when the member has never attended a workshop' do
-        Fabricate(:attending_workshop_invitation, member: member, workshop: workshop)
+        Fabricate(:attending_workshop_invitation, member:, workshop:)
 
         expect(flags[:newbie]).to be(true)
       end
 
       it 'is false when the member has attended a workshop in the past' do
-        Fabricate(:attended_workshop_invitation, member: member)
+        Fabricate(:attended_workshop_invitation, member:)
 
         expect(flags[:newbie]).to be(false)
       end
@@ -28,21 +28,21 @@ RSpec.describe AdminWorkshopAttendeeFlags do
 
     context 'when determining the flag to organisers' do
       it 'is true when the member has multiple no-shows and two recent warnings' do
-        4.times { Fabricate(:past_attending_workshop_invitation, member: member) }
-        2.times { Fabricate(:attendance_warning, member: member) }
+        4.times { Fabricate(:past_attending_workshop_invitation, member:) }
+        2.times { Fabricate(:attendance_warning, member:) }
 
         expect(flags[:flag_to_organisers]).to be(true)
       end
 
       it 'is false when the member has few no-shows' do
-        Fabricate(:past_attending_workshop_invitation, member: member)
-        2.times { Fabricate(:attendance_warning, member: member) }
+        Fabricate(:past_attending_workshop_invitation, member:)
+        2.times { Fabricate(:attendance_warning, member:) }
 
         expect(flags[:flag_to_organisers]).to be(false)
       end
 
       it 'is false when the member has no recent warnings' do
-        4.times { Fabricate(:past_attending_workshop_invitation, member: member) }
+        4.times { Fabricate(:past_attending_workshop_invitation, member:) }
 
         expect(flags[:flag_to_organisers]).to be(false)
       end
@@ -50,15 +50,15 @@ RSpec.describe AdminWorkshopAttendeeFlags do
 
     context 'when determining recent notes' do
       it 'is true when a note exists after the member\'s fifth most recent attended workshop' do
-        5.times { Fabricate(:attended_workshop_invitation, member: member) }
+        5.times { Fabricate(:attended_workshop_invitation, member:) }
 
-        Fabricate(:member_note, member: member, created_at: 1.day.ago)
+        Fabricate(:member_note, member:, created_at: 1.day.ago)
 
         expect(flags[:recent_notes]).to be(true)
       end
 
       it 'is false when there are no notes' do
-        5.times { Fabricate(:attended_workshop_invitation, member: member) }
+        5.times { Fabricate(:attended_workshop_invitation, member:) }
 
         expect(flags[:recent_notes]).to be(false)
       end

--- a/spec/queries/dashboard_query_spec.rb
+++ b/spec/queries/dashboard_query_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe DashboardQuery do
   describe '.upcoming_events_for_user' do
     it 'returns events for the member chapters and accepted workshops' do
       chapter = Fabricate(:chapter)
-      member = Fabricate(:member, groups: [Fabricate(:students, chapter: chapter)])
-      workshop = Fabricate(:workshop, chapter: chapter)
-      Fabricate(:attending_workshop_invitation, member: member, workshop: workshop)
+      member = Fabricate(:member, groups: [Fabricate(:students, chapter:)])
+      workshop = Fabricate(:workshop, chapter:)
+      Fabricate(:attending_workshop_invitation, member:, workshop:)
 
       result = described_class.upcoming_events_for_user(member)
 

--- a/spec/queries/sponsors_search_spec.rb
+++ b/spec/queries/sponsors_search_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SponsorsSearch do
     it 'filters by chapter name' do
       chapter = Fabricate(:chapter, name: 'London')
       matching = Fabricate(:sponsor)
-      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter), sponsor: matching)
+      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter:), sponsor: matching)
       Fabricate(:sponsor)
 
       results = described_class.new(name: nil, chapter: 'London').call
@@ -58,7 +58,7 @@ RSpec.describe SponsorsSearch do
     it 'is case insensitive when filtering by chapter name' do
       chapter = Fabricate(:chapter, name: 'London')
       matching = Fabricate(:sponsor)
-      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter), sponsor: matching)
+      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter:), sponsor: matching)
 
       results = described_class.new(name: nil, chapter: 'london').call
       expect(results).to contain_exactly(matching)
@@ -70,7 +70,7 @@ RSpec.describe SponsorsSearch do
     it 'filters by chapter' do
       chapter = Fabricate(:chapter)
       matching = Fabricate(:sponsor)
-      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter), sponsor: matching)
+      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter:), sponsor: matching)
       Fabricate(:sponsor)
 
       results = described_class.new(name: nil, chapter: chapter.id.to_s).call
@@ -81,7 +81,7 @@ RSpec.describe SponsorsSearch do
     it 'filters by name and chapter combined' do
       chapter = Fabricate(:chapter)
       matching = Fabricate(:sponsor, name: 'Zebra Technologies')
-      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter: chapter), sponsor: matching)
+      Fabricate(:workshop_sponsor, workshop: Fabricate(:workshop_no_sponsor, chapter:), sponsor: matching)
       Fabricate(:sponsor, name: 'Zebra Technologies')
       Fabricate(:sponsor, name: 'Apple Inc')
 

--- a/spec/services/invitation_logger_spec.rb
+++ b/spec/services/invitation_logger_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe InvitationLogger do
   let(:workshop) { Fabricate(:workshop) }
   let(:initiator) { Fabricate(:member) }
   let(:member) { Fabricate(:member) }
-  let(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member) }
+  let(:invitation) { Fabricate(:workshop_invitation, workshop:, member:) }
 
   describe '#start_batch' do
     it 'creates an InvitationLog record' do
@@ -105,8 +105,8 @@ RSpec.describe InvitationLogger do
     let!(:log) { logger.start_batch }
 
     it 'updates status to completed with counts' do
-      2.times { logger.log_success(Fabricate(:member), Fabricate(:workshop_invitation, workshop: workshop)) }
-      logger.log_failure(Fabricate(:member), Fabricate(:workshop_invitation, workshop: workshop), StandardError.new('err'))
+      2.times { logger.log_success(Fabricate(:member), Fabricate(:workshop_invitation, workshop:)) }
+      logger.log_failure(Fabricate(:member), Fabricate(:workshop_invitation, workshop:), StandardError.new('err'))
 
       logger.finish_batch(5)
 

--- a/spec/services/invitation_manager_logging_spec.rb
+++ b/spec/services/invitation_manager_logging_spec.rb
@@ -2,14 +2,14 @@ RSpec.describe InvitationManager, :invitation_logging do
   subject(:manager) { described_class.new }
 
   let(:chapter) { Fabricate(:chapter) }
-  let(:workshop) { Fabricate(:workshop, chapter: chapter) }
+  let(:workshop) { Fabricate(:workshop, chapter:) }
   let(:initiator) { Fabricate(:member) }
   let(:students) { Fabricate.times(2, :member) }
   let(:coaches) { Fabricate.times(2, :member) }
 
   before do
-    Fabricate(:students, chapter: chapter, members: students)
-    Fabricate(:coaches, chapter: chapter, members: coaches)
+    Fabricate(:students, chapter:, members: students)
+    Fabricate(:coaches, chapter:, members: coaches)
   end
 
   describe '#send_workshop_emails with logging' do
@@ -97,7 +97,7 @@ RSpec.describe InvitationManager, :invitation_logging do
   end
 
   describe '#send_virtual_workshop_emails with logging' do
-    let(:workshop) { Fabricate(:virtual_workshop, chapter: chapter) }
+    let(:workshop) { Fabricate(:virtual_workshop, chapter:) }
 
     it 'creates an InvitationLog when initiator_id is provided' do
       expect do

--- a/spec/services/invitation_manager_spec.rb
+++ b/spec/services/invitation_manager_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe InvitationManager do
   subject(:manager) { described_class.new }
 
   let(:chapter) { Fabricate(:chapter) }
-  let(:workshop) { Fabricate(:workshop, chapter: chapter) }
+  let(:workshop) { Fabricate(:workshop, chapter:) }
   let(:students) { Fabricate.times(2, :member) }
   let(:coaches) { Fabricate.times(2, :member) }
 
@@ -22,26 +22,26 @@ RSpec.describe InvitationManager do
 
   describe '#send_event_emails' do
     before do
-      Fabricate(:students, chapter: chapter, members: students)
-      Fabricate(:coaches, chapter: chapter, members: coaches)
+      Fabricate(:students, chapter:, members: students)
+      Fabricate(:coaches, chapter:, members: coaches)
     end
 
     it 'can email only students' do
       event = Fabricate(:event, chapters: [chapter], audience: 'Students')
       students.each do |student|
         allow(Invitation).to receive(:find_or_create_by!).with(
-          event: event, member: student, role: 'Student'
+          event:, member: student, role: 'Student'
         ).and_call_original
       end
 
       manager.send_event_emails(event, chapter)
 
       students.each do |student|
-        expect(Invitation).to have_received(:find_or_create_by!).with(event: event, member: student, role: 'Student')
+        expect(Invitation).to have_received(:find_or_create_by!).with(event:, member: student, role: 'Student')
       end
 
       coaches.each do |student|
-        expect(Invitation).not_to have_received(:find_or_create_by!).with(event: event, member: student, role: 'Coach')
+        expect(Invitation).not_to have_received(:find_or_create_by!).with(event:, member: student, role: 'Coach')
       end
     end
 
@@ -50,18 +50,18 @@ RSpec.describe InvitationManager do
 
       coaches.each do |student|
         allow(Invitation).to receive(:find_or_create_by!).with(
-          event: event, member: student, role: 'Coach'
+          event:, member: student, role: 'Coach'
         ).and_call_original
       end
 
       manager.send_event_emails(event, chapter)
 
       students.each do |student|
-        expect(Invitation).not_to have_received(:find_or_create_by!).with(event: event, member: student, role: 'Student')
+        expect(Invitation).not_to have_received(:find_or_create_by!).with(event:, member: student, role: 'Student')
       end
 
       coaches.each do |student|
-        expect(Invitation).to have_received(:find_or_create_by!).with(event: event, member: student, role: 'Coach')
+        expect(Invitation).to have_received(:find_or_create_by!).with(event:, member: student, role: 'Coach')
       end
     end
 
@@ -70,24 +70,24 @@ RSpec.describe InvitationManager do
 
       students.each do |student|
         allow(Invitation).to receive(:find_or_create_by!).with(
-          event: event, member: student, role: 'Student'
+          event:, member: student, role: 'Student'
         ).and_call_original
       end
 
       coaches.each do |student|
         allow(Invitation).to receive(:find_or_create_by!).with(
-          event: event, member: student, role: 'Coach'
+          event:, member: student, role: 'Coach'
         ).and_call_original
       end
 
       manager.send_event_emails(event, chapter)
 
       students.each do |student|
-        expect(Invitation).to have_received(:find_or_create_by!).with(event: event, member: student, role: 'Student')
+        expect(Invitation).to have_received(:find_or_create_by!).with(event:, member: student, role: 'Student')
       end
 
       coaches.each do |student|
-        expect(Invitation).to have_received(:find_or_create_by!).with(event: event, member: student, role: 'Coach')
+        expect(Invitation).to have_received(:find_or_create_by!).with(event:, member: student, role: 'Coach')
       end
     end
 
@@ -100,17 +100,17 @@ RSpec.describe InvitationManager do
       other_students.each do |other_student|
         allow(Invitation).to(
           receive(:find_or_create_by!)
-          .with(event: event, member: other_student, role: 'Student')
+          .with(event:, member: other_student, role: 'Student')
           .and_call_original
         )
       end
 
       manager.send_event_emails(event, chapter)
 
-      expect(Invitation).not_to have_received(:find_or_create_by!).with(event: event, member: first_student, role: 'Student')
+      expect(Invitation).not_to have_received(:find_or_create_by!).with(event:, member: first_student, role: 'Student')
 
       other_students.each do |other_student|
-        expect(Invitation).to have_received(:find_or_create_by!).with(event: event, member: other_student, role: 'Student')
+        expect(Invitation).to have_received(:find_or_create_by!).with(event:, member: other_student, role: 'Student')
       end
     end
 
@@ -123,17 +123,17 @@ RSpec.describe InvitationManager do
       other_coaches.each do |other_coach|
         allow(Invitation).to(
           receive(:find_or_create_by!)
-          .with(event: event, member: other_coach, role: 'Coach')
+          .with(event:, member: other_coach, role: 'Coach')
           .and_call_original
         )
       end
 
       manager.send_event_emails(event, chapter)
 
-      expect(Invitation).not_to have_received(:find_or_create_by!).with(event: event, member: first_coach, role: 'Coach')
+      expect(Invitation).not_to have_received(:find_or_create_by!).with(event:, member: first_coach, role: 'Coach')
 
       other_coaches.each do |other_coach|
-        expect(Invitation).to have_received(:find_or_create_by!).with(event: event, member: other_coach, role: 'Coach')
+        expect(Invitation).to have_received(:find_or_create_by!).with(event:, member: other_coach, role: 'Coach')
       end
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe InvitationManager do
   describe '#send_monthly_attendance_reminder_emails' do
     it 'emails all attending members' do
       meeting = Fabricate(:meeting)
-      attendees = Fabricate.times(2, :attending_meeting_invitation, meeting: meeting).map(&:member)
+      attendees = Fabricate.times(2, :attending_meeting_invitation, meeting:).map(&:member)
 
       expect do
         manager.send_monthly_attendance_reminder_emails(meeting)
@@ -156,7 +156,7 @@ RSpec.describe InvitationManager do
   describe '#send_workshop_attendance_reminder_emails' do
     it 'emails all attending members' do
       workshop = Fabricate(:workshop)
-      invitations = Fabricate.times(2, :attending_workshop_invitation, workshop: workshop)
+      invitations = Fabricate.times(2, :attending_workshop_invitation, workshop:)
 
       expect do
         manager.send_workshop_attendance_reminders_without_delay(workshop)
@@ -174,9 +174,9 @@ RSpec.describe InvitationManager do
     # NOTE: This test is WIP because the method is async
     it 'emails everyone that hasn\'t already been reminded from the workshop\'s waitinglist' do
       workshop = Fabricate(:workshop)
-      invitations = Fabricate.times(2, :waitinglist_invitation, workshop: workshop)
+      invitations = Fabricate.times(2, :waitinglist_invitation, workshop:)
       reminded_at = 2.days.ago
-      reminded_invitations = Fabricate.times(2, :waitinglist_invitation_reminded, workshop: workshop)
+      reminded_invitations = Fabricate.times(2, :waitinglist_invitation_reminded, workshop:)
 
       expect do
         manager.send_workshop_waiting_list_reminders_without_delay(workshop)
@@ -195,7 +195,7 @@ RSpec.describe InvitationManager do
 
   describe '#send_waiting_list_emails' do
     it 'emails coaches when there are free coach spots' do
-      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Coach')
+      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop:, role: 'Coach')
 
       expect do
         manager.send_waiting_list_emails(workshop)
@@ -207,7 +207,7 @@ RSpec.describe InvitationManager do
 
     it 'does not email coaches when no coach spots are available' do
       workshop = Fabricate(:workshop, coach_count: 0)
-      Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Coach')
+      Fabricate(:waitinglist_invitation, workshop:, role: 'Coach')
 
       expect do
         manager.send_waiting_list_emails(workshop)
@@ -215,7 +215,7 @@ RSpec.describe InvitationManager do
     end
 
     it 'emails students when there are free student spots' do
-      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Student')
+      waitinglist_invitation = Fabricate(:waitinglist_invitation, workshop:, role: 'Student')
 
       expect do
         manager.send_waiting_list_emails(workshop)
@@ -227,7 +227,7 @@ RSpec.describe InvitationManager do
 
     it 'does not email students when no student spots are available' do
       workshop = Fabricate(:workshop, student_count: 0)
-      Fabricate(:waitinglist_invitation, workshop: workshop, role: 'Student')
+      Fabricate(:waitinglist_invitation, workshop:, role: 'Student')
 
       expect do
         manager.send_waiting_list_emails(workshop)
@@ -238,7 +238,7 @@ RSpec.describe InvitationManager do
   describe '#send_meeting_emails' do
     it 'emails all invitees that are not banned' do
       meeting = Fabricate(:meeting, chapters: [chapter])
-      Fabricate(:students, chapter: chapter, members: students)
+      Fabricate(:students, chapter:, members: students)
 
       # Ban one member
       Fabricate(:ban, member: students.last)
@@ -251,10 +251,10 @@ RSpec.describe InvitationManager do
 
     it 'emails valid invitees only once' do
       meeting = Fabricate(:meeting, chapters: [chapter])
-      Fabricate(:students, chapter: chapter, members: students)
+      Fabricate(:students, chapter:, members: students)
 
       # Emulate a member already invited
-      MeetingInvitation.create(meeting: meeting, member: students.last, role: 'Participant')
+      MeetingInvitation.create(meeting:, member: students.last, role: 'Participant')
       expected_student_count = students.count - 1
 
       expect do
@@ -325,7 +325,7 @@ RSpec.describe InvitationManager do
     end
 
     it 'continues processing when invitation creation fails for one member' do
-      Fabricate(:students, chapter: chapter, members: students)
+      Fabricate(:students, chapter:, members: students)
       call_count = 0
 
       allow(WorkshopInvitation).to receive(:find_or_create_by!) do
@@ -347,7 +347,7 @@ RSpec.describe InvitationManager do
     let(:initiator) { Fabricate(:member) }
 
     before do
-      Fabricate(:students, chapter: chapter, members: students)
+      Fabricate(:students, chapter:, members: students)
     end
 
     it 'logs skipped entries for already invited members when re-running batch' do
@@ -375,7 +375,7 @@ RSpec.describe InvitationManager do
 
       # Add a new student
       new_student = Fabricate(:member)
-      Fabricate(:students, chapter: chapter, members: [new_student])
+      Fabricate(:students, chapter:, members: [new_student])
 
       # Second invitation round - should only email the new student
       expect do
@@ -390,8 +390,8 @@ RSpec.describe InvitationManager do
 
   describe '#send_workshop_emails async delivery' do
     it 'sends invitation emails asynchronously for all chapters' do
-      Fabricate(:students, chapter: chapter, members: students)
-      Fabricate(:coaches, chapter: chapter, members: coaches)
+      Fabricate(:students, chapter:, members: students)
+      Fabricate(:coaches, chapter:, members: coaches)
 
       expect do
         manager.send_workshop_emails_without_delay(workshop, 'everyone')
@@ -401,7 +401,7 @@ RSpec.describe InvitationManager do
 
   describe '#send_workshop_attendance_reminders async delivery' do
     it 'sends attendance reminder emails asynchronously for all chapters' do
-      invitation = Fabricate(:attending_workshop_invitation, workshop: workshop)
+      invitation = Fabricate(:attending_workshop_invitation, workshop:)
 
       expect do
         manager.send_workshop_attendance_reminders_without_delay(workshop)
@@ -417,8 +417,8 @@ RSpec.describe InvitationManager do
     describe '#chapter_students' do
       context 'when a member has multiple subscriptions to the same group type' do
         before do
-          students_group1 = Fabricate(:group, name: 'Students', chapter: chapter)
-          students_group2 = Fabricate(:group, name: 'Students', chapter: chapter)
+          students_group1 = Fabricate(:group, name: 'Students', chapter:)
+          students_group2 = Fabricate(:group, name: 'Students', chapter:)
           students_group1.members << member_in_both_groups
           students_group2.members << member_in_both_groups
         end
@@ -435,8 +435,8 @@ RSpec.describe InvitationManager do
     describe '#chapter_coaches' do
       context 'when a member has multiple subscriptions to the same group type' do
         before do
-          coaches_group1 = Fabricate(:group, name: 'Coaches', chapter: chapter)
-          coaches_group2 = Fabricate(:group, name: 'Coaches', chapter: chapter)
+          coaches_group1 = Fabricate(:group, name: 'Coaches', chapter:)
+          coaches_group2 = Fabricate(:group, name: 'Coaches', chapter:)
           coaches_group1.members << member_in_both_groups
           coaches_group2.members << member_in_both_groups
         end
@@ -451,9 +451,9 @@ RSpec.describe InvitationManager do
     end
 
     describe 'sending invitations to members in both students and coaches groups' do
-      let(:workshop) { Fabricate(:workshop, chapter: chapter) }
-      let(:students_group) { Fabricate(:group, name: 'Students', chapter: chapter) }
-      let(:coaches_group) { Fabricate(:group, name: 'Coaches', chapter: chapter) }
+      let(:workshop) { Fabricate(:workshop, chapter:) }
+      let(:students_group) { Fabricate(:group, name: 'Students', chapter:) }
+      let(:coaches_group) { Fabricate(:group, name: 'Coaches', chapter:) }
 
       before do
         students_group.members << member_in_both_groups
@@ -465,8 +465,8 @@ RSpec.describe InvitationManager do
           manager.send_workshop_emails(workshop, 'everyone')
         end.to change(WorkshopInvitation, :count).by(2)
 
-        student_invitation = WorkshopInvitation.find_by(workshop: workshop, member: member_in_both_groups, role: 'Student')
-        coach_invitation = WorkshopInvitation.find_by(workshop: workshop, member: member_in_both_groups, role: 'Coach')
+        student_invitation = WorkshopInvitation.find_by(workshop:, member: member_in_both_groups, role: 'Student')
+        coach_invitation = WorkshopInvitation.find_by(workshop:, member: member_in_both_groups, role: 'Coach')
 
         expect(student_invitation).to be_present
         expect(coach_invitation).to be_present

--- a/spec/services/three_month_email_service_spec.rb
+++ b/spec/services/three_month_email_service_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe ThreeMonthEmailService, type: :service do
     end
 
     let(:chapter) { Fabricate(:chapter) }
-    let(:students_group) { Fabricate(:group, name: 'Students', chapter: chapter) }
-    let(:coaches_group) { Fabricate(:group, name: 'Coaches', chapter: chapter) }
+    let(:students_group) { Fabricate(:group, name: 'Students', chapter:) }
+    let(:coaches_group) { Fabricate(:group, name: 'Coaches', chapter:) }
 
     let!(:eligible_student) do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 6.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 6.months.ago),
         role: 'Student',
         attended: true
       )
@@ -29,8 +29,8 @@ RSpec.describe ThreeMonthEmailService, type: :service do
 
     let!(:already_emailed_student) do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
-      Fabricate(:member_email_delivery, member: member)
+      Fabricate(:subscription, member:, group: students_group)
+      Fabricate(:member_email_delivery, member:)
       member
     end
 
@@ -39,7 +39,7 @@ RSpec.describe ThreeMonthEmailService, type: :service do
       Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
+        member:,
         workshop: Fabricate(:workshop, chapter:, date_and_time: 6.months.ago),
         role: 'Student',
         attended: true
@@ -50,11 +50,11 @@ RSpec.describe ThreeMonthEmailService, type: :service do
 
     let!(:student_with_recent_attendance) do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 1.month.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 1.month.ago),
         role: 'Student',
         attended: true
       )
@@ -63,11 +63,11 @@ RSpec.describe ThreeMonthEmailService, type: :service do
 
     let!(:student_with_old_attendance) do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 4.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 4.months.ago),
         role: 'Student',
         attended: true
       )
@@ -76,29 +76,29 @@ RSpec.describe ThreeMonthEmailService, type: :service do
 
     let!(:coach_member) do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: coaches_group)
+      Fabricate(:subscription, member:, group: coaches_group)
       member
     end
 
     let!(:unsubscribed_member) { Fabricate(:member) }
     let!(:banned_student) do
       member = Fabricate(:banned_member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       member
     end
     let!(:student_without_toc) do
       member = Fabricate(:member_without_toc)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       member
     end
 
     let!(:student_with_very_old_attendance) do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 14.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 14.months.ago),
         role: 'Student',
         attended: true
       )
@@ -153,56 +153,56 @@ RSpec.describe ThreeMonthEmailService, type: :service do
       member = Fabricate(:member)
       other_chapter = Fabricate(:chapter)
       other_students_group = Fabricate(:group, name: 'Students', chapter: other_chapter)
-      Fabricate(:subscription, member: member, group: students_group)
-      Fabricate(:subscription, member: member, group: other_students_group)
+      Fabricate(:subscription, member:, group: students_group)
+      Fabricate(:subscription, member:, group: other_students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 6.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 6.months.ago),
         role: 'Student',
         attended: true
       )
 
       perform_enqueued_jobs { call }
 
-      expect(MemberEmailDelivery.where(member: member).count).to eq(1)
+      expect(MemberEmailDelivery.where(member:).count).to eq(1)
     end
 
     it 'sends only one chaser for a member with multiple qualifying old attendances' do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 5.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 5.months.ago),
         role: 'Student',
         attended: true
       )
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 4.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 4.months.ago),
         role: 'Student',
         attended: true
       )
 
       perform_enqueued_jobs { call }
 
-      expect(MemberEmailDelivery.where(member: member).count).to eq(1)
+      expect(MemberEmailDelivery.where(member:).count).to eq(1)
     end
 
     it 'does not send chasers when there are no eligible members' do
       Fabricate(
         :workshop_invitation,
         member: eligible_student,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 1.month.ago),
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 1.month.ago),
         role: 'Student',
         attended: true
       )
       Fabricate(
         :workshop_invitation,
         member: student_with_old_attendance,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 1.month.ago),
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 1.month.ago),
         role: 'Student',
         attended: true
       )
@@ -219,25 +219,25 @@ RSpec.describe ThreeMonthEmailService, type: :service do
 
     it 'emails a student member who has recent attendance only as a coach' do
       member = Fabricate(:member)
-      Fabricate(:subscription, member: member, group: students_group)
+      Fabricate(:subscription, member:, group: students_group)
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 6.months.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 6.months.ago),
         role: 'Student',
         attended: true
       )
       Fabricate(
         :workshop_invitation,
-        member: member,
-        workshop: Fabricate(:workshop, chapter: chapter, date_and_time: 1.month.ago),
+        member:,
+        workshop: Fabricate(:workshop, chapter:, date_and_time: 1.month.ago),
         role: 'Coach',
         attended: true
       )
 
       perform_enqueued_jobs { call }
 
-      expect(MemberEmailDelivery.where(member: member)).to exist
+      expect(MemberEmailDelivery.where(member:)).to exist
     end
   end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -4,11 +4,11 @@ module OmniauthMacros
   def mock_auth_hash(name: Faker::Name.name, email: Faker::Internet.email, provider: 'codebar', uid: 'uid',
     github_id: nil)
     OmniAuth.config.mock_auth[provider.to_sym] = {
-      provider: provider,
-      uid: uid,
+      provider:,
+      uid:,
       info: {
-        name: name,
-        email: email
+        name:,
+        email:
       },
       credentials: {
         token: 'mock_token',

--- a/spec/support/shared_examples/behaves_like_an_invitation_route.rb
+++ b/spec/support/shared_examples/behaves_like_an_invitation_route.rb
@@ -122,9 +122,9 @@ RSpec.shared_examples 'invitation route' do
     end
 
     scenario 'when already RSVPd to another event on same evening' do
-      invitation.update(attending: true, member: member)
+      invitation.update(attending: true, member:)
 
-      invitation2 = Fabricate(:coach_workshop_invitation, member: member)
+      invitation2 = Fabricate(:coach_workshop_invitation, member:)
       invitation2_route = invitation_path(invitation2)
 
       visit invitation2_route
@@ -135,9 +135,9 @@ RSpec.shared_examples 'invitation route' do
     end
 
     scenario 'when already RSVPd to another event on same evening and attempting to RSVP directly through the link' do
-      invitation.update(attending: true, member: member)
+      invitation.update(attending: true, member:)
 
-      invitation2 = Fabricate(:coach_workshop_invitation, member: member)
+      invitation2 = Fabricate(:coach_workshop_invitation, member:)
 
       visit accept_invitation_path(invitation2)
 

--- a/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
+++ b/spec/support/shared_examples/behaves_like_managing_workshop_attendance.rb
@@ -156,7 +156,7 @@ RSpec.shared_examples 'managing workshop attendance' do
           let(:member) { Fabricate(:member) }
 
           before do
-            Fabricate(:attending_workshop_invitation, member: member, workshop: workshop)
+            Fabricate(:attending_workshop_invitation, member:, workshop:)
           end
 
           it 'can manage details if they are already attending' do

--- a/spec/support/shared_examples/behaves_like_sending_workshop_emails.rb
+++ b/spec/support/shared_examples/behaves_like_sending_workshop_emails.rb
@@ -1,18 +1,18 @@
 RSpec.shared_examples 'sending workshop emails' do
   it 'creates an invitation for each student and sends emails' do
-    Fabricate(:students, chapter: chapter, members: students)
+    Fabricate(:students, chapter:, members: students)
 
     students.each do |student|
-      allow(WorkshopInvitation).to receive(:find_or_create_by!).with(workshop: workshop, member: student, role: 'Student').and_call_original
+      allow(WorkshopInvitation).to receive(:find_or_create_by!).with(workshop:, member: student, role: 'Student').and_call_original
     end
 
     expect do
       manager.send(send_email, workshop, 'students')
     end.to change { ActionMailer::Base.deliveries.count }.by(students.count)
-                                                         .and change { WorkshopInvitation.where(workshop: workshop, role: 'Student').count }.by(students.count)
+                                                         .and change { WorkshopInvitation.where(workshop:, role: 'Student').count }.by(students.count)
 
     students.each do |student|
-      expect(WorkshopInvitation).to have_received(:find_or_create_by!).with(workshop: workshop, member: student, role: 'Student')
+      expect(WorkshopInvitation).to have_received(:find_or_create_by!).with(workshop:, member: student, role: 'Student')
     end
 
     # Verify emails were sent to the right recipients
@@ -22,19 +22,19 @@ RSpec.shared_examples 'sending workshop emails' do
   end
 
   it 'creates an invitation for each coach and sends emails' do
-    Fabricate(:coaches, chapter: chapter, members: coaches)
+    Fabricate(:coaches, chapter:, members: coaches)
 
     coaches.each do |coach|
-      allow(WorkshopInvitation).to receive(:find_or_create_by!).with(workshop: workshop, member: coach, role: 'Coach').and_call_original
+      allow(WorkshopInvitation).to receive(:find_or_create_by!).with(workshop:, member: coach, role: 'Coach').and_call_original
     end
 
     expect do
       manager.send(send_email, workshop, 'coaches')
     end.to change { ActionMailer::Base.deliveries.count }.by(coaches.count)
-                                                         .and change { WorkshopInvitation.where(workshop: workshop, role: 'Coach').count }.by(coaches.count)
+                                                         .and change { WorkshopInvitation.where(workshop:, role: 'Coach').count }.by(coaches.count)
 
     coaches.each do |coach|
-      expect(WorkshopInvitation).to have_received(:find_or_create_by!).with(workshop: workshop, member: coach, role: 'Coach')
+      expect(WorkshopInvitation).to have_received(:find_or_create_by!).with(workshop:, member: coach, role: 'Coach')
     end
 
     # Verify emails were sent to the right recipients
@@ -45,23 +45,23 @@ RSpec.shared_examples 'sending workshop emails' do
 
   it 'does not invite banned coaches' do
     banned_coach = Fabricate(:banned_member)
-    Fabricate(:coaches, chapter: chapter, members: coaches + [banned_coach])
+    Fabricate(:coaches, chapter:, members: coaches + [banned_coach])
 
     coaches.each do |coach|
-      allow(WorkshopInvitation).to receive(:find_or_create_by!).with(workshop: workshop, member: coach, role: 'Coach').and_call_original
+      allow(WorkshopInvitation).to receive(:find_or_create_by!).with(workshop:, member: coach, role: 'Coach').and_call_original
     end
 
     manager.send(send_email, workshop, 'coaches')
 
     coaches.each do |coach|
-      expect(WorkshopInvitation).to have_received(:find_or_create_by!).with(workshop: workshop, member: coach, role: 'Coach')
+      expect(WorkshopInvitation).to have_received(:find_or_create_by!).with(workshop:, member: coach, role: 'Coach')
     end
-    expect(WorkshopInvitation).not_to have_received(:find_or_create_by!).with(workshop: workshop, member: banned_coach, role: 'Coach')
+    expect(WorkshopInvitation).not_to have_received(:find_or_create_by!).with(workshop:, member: banned_coach, role: 'Coach')
   end
 
   it 'sends emails when a WorkshopInvitation is created' do
-    Fabricate(:students, chapter: chapter, members: students)
-    Fabricate(:coaches, chapter: chapter, members: coaches)
+    Fabricate(:students, chapter:, members: students)
+    Fabricate(:coaches, chapter:, members: coaches)
 
     expect do
       manager.send(send_email, workshop, 'everyone')
@@ -69,7 +69,7 @@ RSpec.shared_examples 'sending workshop emails' do
   end
 
   it 'does not send emails when invitation creation returns nil' do
-    Fabricate(:students, chapter: chapter, members: students)
+    Fabricate(:students, chapter:, members: students)
 
     allow(WorkshopInvitation).to receive(:find_or_create_by!).and_return(nil).exactly(students.count)
 
@@ -81,7 +81,7 @@ RSpec.shared_examples 'sending workshop emails' do
   end
 
   it 'does not send duplicate emails when members are already invited' do
-    Fabricate(:students, chapter: chapter, members: students)
+    Fabricate(:students, chapter:, members: students)
 
     # First invitation round - creates invitations and sends emails
     manager.send(send_email, workshop, 'students')


### PR DESCRIPTION
Closes #2833

## Problem

`Style/HashSyntax` was enabled with `EnforcedShorthandSyntax` left at the default `either`, so both `member: member` and `member:` were accepted and which one to write came down to reviewer preference.

## Change

- Set `EnforcedShorthandSyntax: always` on the existing `Style/HashSyntax` cop in `.rubocop.yml`, so hash keywords matching a same-named local variable or method must use Ruby 3.1+ shorthand.
- Ran `bundle exec rubocop -a` to autocorrect the existing backlog: 465 offenses across 105 files, all safe corrections (`x: x` → `x:`). `rubocop` is now clean.
- No `.rubocop_todo.yml` entry needed — the sweep fixes everything, nothing deferred.