### PR TITLE
feat: signup nudge email sequence for members without a chapter

### DIFF
--- a/app/jobs/send_signup_nudge_email_job.rb
+++ b/app/jobs/send_signup_nudge_email_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SendSignupNudgeEmailJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    SignupNudgeEmailService.send_nudges
+  end
+end

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -2,7 +2,26 @@ class MemberMailer < ApplicationMailer
   include EmailHeaderHelper
   include EmailDelivery
 
-  after_deliver :log_sent_email, only: [:chaser]
+  after_deliver :log_sent_email, only: %i[chaser signup_nudge signup_nudge_followup]
+
+  def signup_nudge
+    @member = params[:member]
+    subject = 'Let’s get you connected with codebar!'
+
+    mail_to_member(@member, subject, 'hello@codebar.io') do |format|
+      format.html { render 'signup_nudge' }
+    end
+  end
+
+  # Same copy as the nudge until Kimberley supplies follow-up copy (issue #2384).
+  def signup_nudge_followup
+    @member = params[:member]
+    subject = 'Let’s get you connected with codebar!'
+
+    mail_to_member(@member, subject, 'hello@codebar.io') do |format|
+      format.html { render 'signup_nudge' }
+    end
+  end
 
   def chaser
     @member = params[:member]

--- a/app/services/signup_nudge_email_service.rb
+++ b/app/services/signup_nudge_email_service.rb
@@ -1,0 +1,42 @@
+class SignupNudgeEmailService
+  NUDGE = 'signup_nudge'.freeze
+  FOLLOWUP = 'signup_nudge_followup'.freeze
+
+  def self.send_nudges
+    send_signup_nudge
+    send_signup_nudge_followup
+  end
+
+  def self.send_signup_nudge
+    Member.not_banned
+          .where(created_at: nudge_window)
+          .merge(unemailed(NUDGE))
+          .merge(never_subscribed)
+          .find_each { |member| MemberMailer.with(member:).signup_nudge.deliver_later }
+  end
+
+  def self.send_signup_nudge_followup
+    Member.not_banned
+          .joins(:member_email_deliveries)
+          .where(member_email_deliveries: { email_type: NUDGE, created_at: ..1.month.ago })
+          .merge(unemailed(FOLLOWUP))
+          .merge(never_subscribed)
+          .distinct
+          .find_each { |member| MemberMailer.with(member:).signup_nudge_followup.deliver_later }
+  end
+
+  def self.unemailed(email_type)
+    Member.where.not(id: MemberEmailDelivery.where(email_type:).select(:member_id))
+  end
+
+  def self.never_subscribed
+    Member.where.not(id: Subscription.select(:member_id))
+  end
+
+  def self.nudge_window
+    30.days.ago.beginning_of_day..7.days.ago.end_of_day
+  end
+
+  private_class_method :send_signup_nudge, :send_signup_nudge_followup, :unemailed, :never_subscribed,
+                       :nudge_window
+end

--- a/app/services/signup_nudge_email_service.rb
+++ b/app/services/signup_nudge_email_service.rb
@@ -25,12 +25,13 @@ class SignupNudgeEmailService
           .find_each { |member| MemberMailer.with(member:).signup_nudge_followup.deliver_later }
   end
 
+  # NULL-safe NOT IN: a NULL member_id in the subquery would exclude every member
   def self.unemailed(email_type)
-    Member.where.not(id: MemberEmailDelivery.where(email_type:).select(:member_id))
+    Member.where.not(id: MemberEmailDelivery.where(email_type:).where.not(member_id: nil).select(:member_id))
   end
 
   def self.never_subscribed
-    Member.where.not(id: Subscription.select(:member_id))
+    Member.where.not(id: Subscription.where.not(member_id: nil).select(:member_id))
   end
 
   def self.nudge_window

--- a/app/views/member_mailer/signup_nudge.html.haml
+++ b/app/views/member_mailer/signup_nudge.html.haml
@@ -1,0 +1,25 @@
+%h1 Hi #{@member.name},
+
+%p
+  Thanks for signing up to codebar, we can’t wait to see you!
+
+%p
+  We noticed you haven’t joined a chapter yet, and we’d love to help you get started.
+
+%p
+  Codebar chapters are where the magic happens, you can meet fellow members whether they’re students or coaches, and of course attend our workshops and events.
+
+%p
+  👉 #{link_to 'Find your local chapter and join today', subscriptions_url}
+
+%p
+  If you’re not sure which chapter is right for you, or you’d like tips on getting started, we’re happy to help, just hit reply to this email and we’ll guide you.
+
+%p
+  We can’t wait to see you at a workshop or event very soon!
+
+%p
+  #{"-- "}
+%br
+Warmly,
+The codebar Team

--- a/lib/tasks/chaser.rake
+++ b/lib/tasks/chaser.rake
@@ -1,7 +1,11 @@
 namespace :chaser do
   desc "Send emails to users who've not attended in a while"
-
   task three_months: :environment do
     SendThreeMonthEmailJob.perform_later
+  end
+
+  desc 'Send emails to new members who have not subscribed to a chapter'
+  task signup_nudges: :environment do
+    SendSignupNudgeEmailJob.perform_later
   end
 end

--- a/spec/lib/tasks/chaser_rake_spec.rb
+++ b/spec/lib/tasks/chaser_rake_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe 'rake chaser:signup_nudges', type: :task do
+  it 'preloads the Rails environment' do
+    expect(task.prerequisites).to include 'environment'
+  end
+
+  it 'enqueues the signup nudge email job' do
+    allow(SendSignupNudgeEmailJob).to receive(:perform_later)
+
+    task.invoke
+
+    expect(SendSignupNudgeEmailJob).to have_received(:perform_later)
+  end
+end

--- a/spec/lib/tasks/chaser_rake_spec.rb
+++ b/spec/lib/tasks/chaser_rake_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'rake chaser:signup_nudges', type: :task do
   it 'preloads the Rails environment' do
     expect(task.prerequisites).to include 'environment'

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -196,4 +196,43 @@ RSpec.describe MemberMailer do
       end.to change(MemberEmailDelivery, :count).by(1)
     end
   end
+
+  describe 'signup nudge' do
+    let(:mail) { described_class.with(member:).signup_nudge.deliver_now }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Let’s get you connected with codebar!')
+      expect(mail.to).to eq([member.email])
+      expect(mail.from).to eq(['hello@codebar.io'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('Find your local chapter')
+      expect(mail.body.encoded).to match(subscriptions_url)
+    end
+
+    it 'logs with its own email_type' do
+      expect { mail }
+        .to change { MemberEmailDelivery.where(member:, email_type: 'signup_nudge').count }.by(1)
+    end
+  end
+
+  describe 'signup nudge follow-up' do
+    let(:mail) { described_class.with(member:).signup_nudge_followup.deliver_now }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Let’s get you connected with codebar!')
+      expect(mail.to).to eq([member.email])
+      expect(mail.from).to eq(['hello@codebar.io'])
+    end
+
+    it 'renders the same body as the nudge' do
+      expect(mail.body.encoded).to match('Find your local chapter')
+    end
+
+    it 'logs with its own email_type' do
+      expect { mail }
+        .to change { MemberEmailDelivery.where(member:, email_type: 'signup_nudge_followup').count }.by(1)
+    end
+  end
 end

--- a/spec/services/signup_nudge_email_service_spec.rb
+++ b/spec/services/signup_nudge_email_service_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe SignupNudgeEmailService, type: :service do
   describe '#send_nudges' do
     subject(:call) { described_class.send_nudges }
@@ -95,6 +97,16 @@ RSpec.describe SignupNudgeEmailService, type: :service do
         .not_to(change do
           MemberEmailDelivery.where(member: subscribed_after_nudge, email_type: 'signup_nudge_followup').count
         end)
+    end
+
+    # DB allows NULL member_id on both tables; one such row would make NOT IN exclude everyone
+    it 'still sends nudges when log or subscription rows have no member_id' do
+      Fabricate(:member_email_delivery, email_type: 'signup_nudge').update_column(:member_id, nil)
+      Fabricate(:subscription).update_column(:member_id, nil)
+
+      expect { perform_enqueued_jobs { call } }
+        .to change { MemberEmailDelivery.where(member: nudge_eligible, email_type: 'signup_nudge').count }
+        .by(1)
     end
   end
 end

--- a/spec/services/signup_nudge_email_service_spec.rb
+++ b/spec/services/signup_nudge_email_service_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe SignupNudgeEmailService, type: :service do
+  describe '#send_nudges' do
+    subject(:call) { described_class.send_nudges }
+
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+    ensure
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
+    let!(:nudge_eligible) { Fabricate(:member, created_at: 10.days.ago) }
+    let!(:followup_eligible) { Fabricate(:member, created_at: 6.weeks.ago) }
+    let!(:subscribed_in_window) { Fabricate(:member, created_at: 10.days.ago) }
+    let!(:banned_in_window) { Fabricate(:banned_member, created_at: 10.days.ago) }
+    let!(:too_young) { Fabricate(:member, created_at: 2.days.ago) }
+    let!(:too_old) { Fabricate(:member, created_at: 5.weeks.ago) }
+    let!(:recently_nudged) { Fabricate(:member, created_at: 10.days.ago) }
+    let!(:completed_sequence) { Fabricate(:member, created_at: 7.weeks.ago) }
+    let!(:subscribed_after_nudge) { Fabricate(:member, created_at: 6.weeks.ago) }
+
+    before do
+      Fabricate(:subscription, member: subscribed_in_window)
+      Fabricate(:member_email_delivery, member: followup_eligible, email_type: 'signup_nudge',
+                                        created_at: 5.weeks.ago)
+      Fabricate(:member_email_delivery, member: recently_nudged, email_type: 'signup_nudge')
+      Fabricate(:member_email_delivery, member: completed_sequence, email_type: 'signup_nudge',
+                                        created_at: 6.weeks.ago)
+      Fabricate(:member_email_delivery, member: completed_sequence, email_type: 'signup_nudge_followup',
+                                        created_at: 5.weeks.ago)
+      Fabricate(:member_email_delivery, member: subscribed_after_nudge, email_type: 'signup_nudge',
+                                        created_at: 5.weeks.ago)
+      Fabricate(:subscription, member: subscribed_after_nudge)
+    end
+
+    it 'nudges members created 7-14 days ago who have no subscription' do
+      expect { perform_enqueued_jobs { call } }
+        .to change { MemberEmailDelivery.where(member: nudge_eligible, email_type: 'signup_nudge').count }
+        .by(1)
+    end
+
+    it 'sends the follow-up to members nudged more than a month ago' do
+      expect { perform_enqueued_jobs { call } }
+        .to change {
+          MemberEmailDelivery.where(member: followup_eligible, email_type: 'signup_nudge_followup').count
+        }
+        .by(1)
+    end
+
+    it 'does not nudge subscribed members' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: subscribed_in_window).count })
+    end
+
+    it 'does not nudge banned members' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: banned_in_window).count })
+    end
+
+    it 'nudges members created 15-30 days ago who have no subscription' do
+      older_eligible = Fabricate(:member, created_at: 20.days.ago)
+      expect { perform_enqueued_jobs { call } }
+        .to change { MemberEmailDelivery.where(member: older_eligible, email_type: 'signup_nudge').count }
+        .by(1)
+    end
+
+    it 'does not nudge members younger than 7 days' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: too_young).count })
+    end
+
+    it 'does not nudge members older than 30 days without a nudge row' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: too_old).count })
+    end
+
+    it 'does not re-nudge a member already nudged' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: recently_nudged, email_type: 'signup_nudge').count })
+    end
+
+    it 'does not send a follow-up while the nudge is less than a month old' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: recently_nudged, email_type: 'signup_nudge_followup').count })
+    end
+
+    it 'sends nothing further to members who completed the sequence' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change { MemberEmailDelivery.where(member: completed_sequence).count })
+    end
+
+    it 'does not send a follow-up to a member who has since subscribed' do
+      expect { perform_enqueued_jobs { call } }
+        .not_to(change do
+          MemberEmailDelivery.where(member: subscribed_after_nudge, email_type: 'signup_nudge_followup').count
+        end)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Implements #2384: automated emails to members who signed up via the website but haven't subscribed to a chapter.

A bounded two-stage sequence, recorded in `member_email_deliveries` (typed log from #2832):

1. **Signup nudge** — members created 7–30 days ago with no chapter subscription, not banned
2. **Follow-up** — members whose nudge row is at least a month old, still no subscription, not banned

Stage eligibility is derived from the typed log rows; delivery-confirmed writes (via the `EmailDelivery` concern, `email_type: signup_nudge` / `signup_nudge_followup`) mean a lost send retries within the stage-1 window and no member receives the same stage twice — enforced by the `(member_id, email_type)` unique index. Members who subscribe at any point exit the sequence.

**Email copy:** both emails currently use the copy from Kimberley's first-email draft (subject "Let's get you connected with codebar!"). Dedicated follow-up copy is pending from Kimberley (issue #2384) and will land as a small follow-up commit.

## What happens when (plain language)

Every day, one scheduled job looks at recent sign-ups and sends at most two emails — then never bothers anyone again:

- **A week after someone signs up**, they get a short nudge: pick a codebar chapter. Sent exactly once — the send is recorded in a log whose database index makes a second copy impossible, even if the job re-runs.
- **One month after that nudge**, if they still haven't subscribed to any chapter, they get one follow-up.
- **After that, silence.** Even a member who never subscribes gets no third email, ever.

People who are exempt at every stage:

- anyone who **subscribes to a chapter** (they leave the sequence immediately and get the normal chapter welcome email instead),
- anyone **banned** from codebar,
- anyone who signed up **more than a month before this ships** (the sequence only looks forward — nobody gets a backfilled backlog of old nudges).

Members who signed up but never finished the signup form are included — the nudge is for everyone who created an account and walked away.

Driving it: one daily task (`rake chaser:signup_nudges`) that must be added to the Heroku Scheduler after merge — see the ops note above.

## Ops note ⚠️

After merge, add a Heroku Scheduler entry: `rake chaser:signup_nudges`, daily — same mechanism as `rake chaser:three_months`. Without it the feature ships dark. Post-merge verification (first scheduled run creates `signup_nudge` rows for the current cohort): Morgan.

## Steps to verify

- `make test` — service spec covers the full stage matrix (window edges, subscribed/banned, both rows = terminal, follow-up anchored to the nudge's send time); mailer specs cover headers, body, and typed logging; rake spec covers the entry point.
