### PR TITLE
Fix DoubleRenderError on unsubscribe link for members with incomplete details

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -38,8 +38,7 @@ class MembersController < ApplicationController
     session[:member_id] = member.id
 
     authenticate_member!
-
-    redirect_to subscriptions_path
+    redirect_to subscriptions_path unless performed?
   rescue StandardError
     redirect_to root_path, notice: 'Your token is invalid. '
   end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe MembersController do
       expect(response).to redirect_to(subscriptions_path)
     end
 
+    it 'does not render twice when the member has incomplete details' do
+      member = Fabricate.build(:member, about_you: nil)
+      member.save(validate: false)
+      get :unsubscribe, params: { token: member_token(member) }
+      expect(response).to redirect_to(edit_member_details_path)
+    end
+
     it 'redirects to the root path when token is invalid' do
       get :unsubscribe, params: { token: 'foo' }
       expect(response).to redirect_to(root_path)


### PR DESCRIPTION
## Problem

Rollbar items [660](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/660#detail) and [559](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/559#detail) report `AbstractController::DoubleRenderError` on `GET /unsubscribe/:token`.

`MembersController#unsubscribe` sets the member's session, then calls `authenticate_member!` and afterwards unconditionally redirects to `subscriptions_path`. For members whose profile is incomplete, `finish_registration` (inside `authenticate_member!`) already redirects to `edit_member_details_path`, so the second redirect raised `DoubleRenderError`. The cascade then bounced twice more: the inline `rescue StandardError` caught it and called `redirect_to root_path` on the already-performed response (#559), and the production `rescue_from Exception` handler failed to render the already-committed response (#660). One click, three chained render errors.

This only affects members who click an unsubscribe email link before completing registration details. Every other `authenticate_member!` caller runs it as a `before_action`, where Rails halts the chain on redirect — this was the only explicit call site.

## Change

- Guard the second redirect in `unsubscribe` with `unless performed?` (`app/controllers/members_controller.rb:40`). Members with incomplete details now land on the details page (the intended redirect); everyone else still reaches their subscriptions page. With the first conflict gone, neither the rescue arm nor the error handler can fire on a performed response, so both Rollbar items are fixed.
- Add a controller spec for the incomplete-details path (`spec/controllers/members_controller_spec.rb`). The spec fails with the exact production error when the guard is reverted.

## Verification

- `bundle exec rspec spec/controllers/members_controller_spec.rb` — 3 examples, 0 failures
- `bundle exec rubocop` on both changed files — no offenses
- Mutation check: reverting the guard reproduces the production `DoubleRenderError` in the new spec
