### PR TITLE
chore: autocorrect Style/HashSyntax offenses in check-in files

### DIFF
--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -102,9 +102,9 @@ class CheckInsController < ApplicationController
 
   def find_or_create_invitation(role)
     if @check_in_target.is_a?(Event)
-      Invitation.create_or_find_by(event: @check_in_target, member: current_user, role: role)
+      Invitation.create_or_find_by(event: @check_in_target, member: current_user, role:)
     else
-      WorkshopInvitation.create_or_find_by(workshop: @check_in_target, member: current_user, role: role)
+      WorkshopInvitation.create_or_find_by(workshop: @check_in_target, member: current_user, role:)
     end
   end
 

--- a/spec/controllers/check_ins_controller_spec.rb
+++ b/spec/controllers/check_ins_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CheckInsController do
 
       it 'creates an invitation with source=check_in' do
         post :create, params: { code: event.check_in_code, role: 'Student' }
-        invitation = Invitation.find_by(event: event, member: member)
+        invitation = Invitation.find_by(event:, member:)
         expect(invitation.source).to eq(InvitationConcerns::SOURCE_CHECK_IN)
         expect(invitation.attending).to be true
         expect(invitation.verified).to be true
@@ -56,20 +56,20 @@ RSpec.describe CheckInsController do
 
       it 'ignores unpermitted parameters' do
         post :create, params: { code: event.check_in_code, role: 'Student', hacker_field: 'malicious' }
-        invitation = Invitation.find_by(event: event, member: member)
+        invitation = Invitation.find_by(event:, member:)
         expect(invitation.source).to eq(InvitationConcerns::SOURCE_CHECK_IN)
         expect(response).to redirect_to(check_in_e_confirm_path(code: event.check_in_code))
       end
 
       it 'redirects to confirm when already checked in' do
-        invitation = Fabricate(:invitation, event: event, member: member, role: 'Student', attending: true, verified: true)
+        invitation = Fabricate(:invitation, event:, member:, role: 'Student', attending: true, verified: true)
         post :create, params: { code: event.check_in_code, role: 'Student' }
         expect(response).to redirect_to(check_in_e_confirm_path(code: event.check_in_code))
         expect(Invitation.find(invitation.id).verified).to be true
       end
 
       it 'rejects selecting a different role than the existing invitation' do
-        Fabricate(:invitation, event: event, member: member, role: 'Student')
+        Fabricate(:invitation, event:, member:, role: 'Student')
         post :create, params: { code: event.check_in_code, role: 'Coach' }
         expect(response).to redirect_to(check_in_e_path(code: event.check_in_code))
         expect(flash[:alert]).to include('Student')
@@ -77,7 +77,7 @@ RSpec.describe CheckInsController do
 
       it 'rejects check-in when the role is at capacity' do
         event.update!(student_spaces: 1)
-        Fabricate(:invitation, event: event, member: Fabricate(:member), role: 'Student',
+        Fabricate(:invitation, event:, member: Fabricate(:member), role: 'Student',
                                attending: true, verified: true)
         post :create, params: { code: event.check_in_code, role: 'Student' }
         expect(response).to redirect_to(check_in_e_path(code: event.check_in_code))
@@ -89,7 +89,7 @@ RSpec.describe CheckInsController do
                              date_and_time: Time.zone.now - 30.minutes,
                              ends_at: Time.zone.now + 30.minutes)
         post :create, params: { code: workshop.check_in_code, role: 'Student' }
-        invitation = WorkshopInvitation.find_by(workshop: workshop, member: member)
+        invitation = WorkshopInvitation.find_by(workshop:, member:)
         expect(invitation.source).to eq(InvitationConcerns::SOURCE_CHECK_IN)
         expect(invitation.attending).to be true
         expect(invitation.attended).to be true
@@ -101,7 +101,7 @@ RSpec.describe CheckInsController do
         workshop = Fabricate(:workshop,
                              date_and_time: Time.zone.now - 30.minutes,
                              ends_at: Time.zone.now + 30.minutes)
-        invitation = Fabricate(:workshop_invitation, workshop: workshop, member: member, role: 'Student')
+        invitation = Fabricate(:workshop_invitation, workshop:, member:, role: 'Student')
         WaitingList.add(invitation)
         post :create, params: { code: workshop.check_in_code, role: 'Student' }
         expect(response).to redirect_to(check_in_w_path(code: workshop.check_in_code))


### PR DESCRIPTION
## Problem

Every pull request's RuboCop CI job fails because the job runs on the PR-into-master merge commit, and master itself carries 15 pre-existing `Style/HashSyntax: Omit the hash value` offenses: 2 in `app/controllers/check_ins_controller.rb` and 13 in `spec/controllers/check_ins_controller_spec.rb`. Master's push runs have not exercised the RuboCop job since June, so these drifted in unnoticed.

## Change

- `rubocop -a` autocorrect on the two check-in files: 15 offenses corrected, all mechanical `member: member` -> `member:` shorthand rewrites. No behavior change.

## Verification

- `bundle exec rubocop` (full repo, on this branch): 374 files inspected, 0 offenses
- `bundle exec rspec spec/controllers/check_ins_controller_spec.rb`: 12 examples, 0 failures
