### PR TITLE
Skip CSRF protection for token-keyed invitation RSVP actions

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,4 +1,10 @@
 class InvitationsController < ApplicationController
+  # The invitation token in the URL is the authenticator for these actions;
+  # CSRF is redundant and fails when browsers withhold the session cookie
+  # (e.g. Safari/WebKit ITP on cross-site navigation). Same rationale as
+  # FeedbackController#submit (PR #2641, Rollbar #535).
+  skip_forgery_protection only: %i[attend reject]
+
   before_action :require_login, only: [:index]
   before_action :set_invitation, only: %i[show attend reject]
 

--- a/app/controllers/waiting_lists_controller.rb
+++ b/app/controllers/waiting_lists_controller.rb
@@ -1,6 +1,12 @@
 class WaitingListsController < ApplicationController
   include WorkshopInvitationConcerns
 
+  # The invitation token in the URL is the authenticator for these actions;
+  # CSRF is redundant and fails when browsers withhold the session cookie
+  # (e.g. Safari/WebKit ITP on cross-site navigation). Same rationale as
+  # FeedbackController#submit (PR #2641, Rollbar #535).
+  skip_forgery_protection only: %i[create destroy]
+
   def create
     @invitation.assign_attributes(invitation_params)
 

--- a/app/controllers/workshop_invitation_controller.rb
+++ b/app/controllers/workshop_invitation_controller.rb
@@ -5,6 +5,12 @@ class WorkshopInvitationController < ApplicationController
   # It provides accept/reject RSVP actions for workshop attendees via token-based links.
   # Routes: /invitation/:token (legacy) and /workshop_invitation/:token
 
+  # The invitation token in the URL is the authenticator for these actions;
+  # CSRF is redundant and fails when browsers withhold the session cookie
+  # (e.g. Safari/WebKit ITP on cross-site navigation). Same rationale as
+  # FeedbackController#submit (PR #2641, Rollbar #535).
+  skip_forgery_protection only: %i[update accept]
+
   def show
     @announcements = @invitation.member.announcements.active
     @tutorial_titles = Tutorial.all_titles

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe FeedbackController do
     end
 
     context 'without a CSRF token (browser did not send session cookie)' do
-      it 'still accepts the feedback submission' do
-        # Simulate the real-world scenario where the browser withholds the
-        # session cookie (e.g. Safari ITP, cross-site navigation, or cookie
-        # blocking). With protect_from_forgery enabled, this would normally
-        # raise ActionController::InvalidAuthenticityToken.
-        ActionController::Base.allow_forgery_protection = true
+      # Simulate the real-world scenario where the browser withholds the
+      # session cookie (e.g. Safari/WebKit ITP, cross-site navigation, or cookie
+      # blocking). With protect_from_forgery enabled, this would normally
+      # raise ActionController::InvalidAuthenticityToken.
+      include_context 'with forgery protection enforced'
 
+      it 'still accepts the feedback submission' do
         patch :submit, params: {
           id: feedback_request.token,
           feedback: {
@@ -84,8 +84,6 @@ RSpec.describe FeedbackController do
         expect(response).to redirect_to(root_path)
         expect(flash[:notice]).to eq(I18n.t('messages.feedback_saved'))
         expect(feedback_request.reload.submited).to be true
-      ensure
-        ActionController::Base.allow_forgery_protection = false
       end
     end
   end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe InvitationsController do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'without a CSRF token (browser did not send session cookie)' do
+      # Simulate the real-world scenario where the browser withholds the
+      # session cookie (e.g. Safari/WebKit ITP on cross-site navigation).
+      # The invitation token in the URL is the authenticator.
+      include_context 'with forgery protection enforced'
+      let(:invitation) { Fabricate(:coach_invitation, event:) }
+
+      it 'still accepts the RSVP' do
+        post :attend, params: { event_id: event.id, token: invitation.token }
+
+        expect(invitation.reload.attending).to be true
+      end
+    end
   end
 
   describe 'POST #reject' do
@@ -24,6 +38,17 @@ RSpec.describe InvitationsController do
       it 'returns http not found' do
         post :reject, params: { event_id: event.id, token: 'invalid_token' }
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'without a CSRF token (browser did not send session cookie)' do
+      include_context 'with forgery protection enforced'
+      let(:invitation) { Fabricate(:attending_event_invitation, event:) }
+
+      it 'still cancels the RSVP' do
+        post :reject, params: { event_id: event.id, token: invitation.token }
+
+        expect(invitation.reload.attending).to be false
       end
     end
   end

--- a/spec/controllers/waiting_lists_controller_spec.rb
+++ b/spec/controllers/waiting_lists_controller_spec.rb
@@ -30,5 +30,33 @@ RSpec.describe WaitingListsController do
 
       expect(WaitingList.where(invitation:).count).to eq(1)
     end
+
+    context 'without a CSRF token (browser did not send session cookie)' do
+      # Simulate the real-world scenario where the browser withholds the
+      # session cookie (e.g. Safari/WebKit ITP on cross-site navigation).
+      # The invitation token in the URL is the authenticator.
+      include_context 'with forgery protection enforced'
+
+      it 'still adds the member to the waiting list' do
+        expect do
+          post :create, params: { invitation_id: invitation.token }
+        end.to change(WaitingList, :count).by(1)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'without a CSRF token (browser did not send session cookie)' do
+      include_context 'with forgery protection enforced'
+
+      it 'still removes the member from the waiting list' do
+        waiting_list = Fabricate(:waiting_list)
+        invitation = waiting_list.invitation
+
+        expect do
+          delete :destroy, params: { invitation_id: invitation.token }
+        end.to change(WaitingList, :count).by(-1)
+      end
+    end
   end
 end

--- a/spec/controllers/workshop_invitation_controller_spec.rb
+++ b/spec/controllers/workshop_invitation_controller_spec.rb
@@ -93,6 +93,19 @@ RSpec.describe WorkshopInvitationController, type: :controller do
         expect(flash[:notice].join).to include('Tutorial')
       end
     end
+
+    context 'without a CSRF token (browser did not send session cookie)' do
+      # Simulate the real-world scenario where the browser withholds the
+      # session cookie (e.g. Safari/WebKit ITP on cross-site navigation).
+      # The invitation token in the URL is the authenticator.
+      include_context 'with forgery protection enforced'
+
+      it 'still accepts the RSVP' do
+        post :accept, params: { id: invitation.token }
+
+        expect(invitation.reload.attending).to be true
+      end
+    end
   end
 
   describe 'POST #reject' do
@@ -182,6 +195,18 @@ RSpec.describe WorkshopInvitationController, type: :controller do
       it 'redirects with error message' do
         patch :update, params: { id: invitation.token, workshop_invitation: { tutorial: '' } }
         expect(flash[:notice].join).to include('Tutorial')
+      end
+    end
+
+    context 'without a CSRF token (browser did not send session cookie)' do
+      include_context 'with forgery protection enforced'
+
+      it 'still updates the invitation details' do
+        new_tutorial = Fabricate(:tutorial)
+
+        patch :update, params: { id: invitation.token, workshop_invitation: { tutorial: new_tutorial.title } }
+
+        expect(invitation.reload.tutorial).to eq(new_tutorial.title)
       end
     end
   end

--- a/spec/support/shared_contexts/forgery_protection.rb
+++ b/spec/support/shared_contexts/forgery_protection.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with forgery protection enforced' do
+  before { ActionController::Base.allow_forgery_protection = true }
+  after  { ActionController::Base.allow_forgery_protection = false }
+end


### PR DESCRIPTION
Members who open invitation links from mail apps cannot RSVP: their browser withholds the session cookie, so CSRF verification fails with `ActionController::InvalidAuthenticityToken` (Rollbar [535](https://app.rollbar.com/a/codebar-production/fix/item/codebar-production/535#detail)). The invitation token in the URL already authenticates these actions, so this change removes the redundant CSRF check from them.

Key changes:

- `skip_forgery_protection` for the six token-keyed RSVP actions: `InvitationsController#attend/#reject`, `WorkshopInvitationController#update/#accept`, and `WaitingListsController#create/#destroy` (scoped `only:`).
- Each action looks up the invitation by a 128-bit `SecureRandom` token carried in the URL. The request carries no session authority, which is the only thing CSRF protects — an attacker who cannot guess the token cannot forge the request. PR #2641 applied the same reasoning to the feedback form.
- Regression specs for all six actions: each posts without a CSRF token and asserts the mutation still happens.

<details>
<summary>Background and scope</summary>

Web browsers withhold cookies when they classify a navigation as cross-site. WebKit's Intelligent Tracking Prevention does this for every iOS browser, including Chrome, so members arriving from Mail, Gmail, or Slack reach the invitation page with an ephemeral session. The RSVP POST then arrives without a matching session and fails CSRF verification.

The failure first surfaced on the feedback form and was fixed for that form alone in PR #2641. An audit of all mutating routes found six more token-keyed actions with the same structure; everything else (self check-in, account settings, admin, OAuth) is session-gated and keeps CSRF protection.

Related, not addressed here: the workshop invitation "reject" link mutates via a GET request, which email prefetchers can trigger. That needs its own change.
</details>
