### PR TITLE
spec: add canary for forgery protection shared context

### DIFF
--- a/spec/shared_contexts/forgery_protection_spec.rb
+++ b/spec/shared_contexts/forgery_protection_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Canary for the 'with forgery protection enforced' shared context. All
+# no-CSRF regression specs depend on its before hook actually enabling
+# protection; if that hook stops applying, they pass vacuously. This
+# example fails loudly if the toggle breaks.
+# rubocop:disable RSpec/DescribeClass -- the subject is a shared context, not a class
+RSpec.describe 'with forgery protection enforced' do
+  include_context 'with forgery protection enforced'
+
+  it 'enables forgery protection for examples that include it' do
+    expect(ActionController::Base.allow_forgery_protection).to be true
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
All no-CSRF regression specs depend on one shared-context hook with nothing pinning it works: if the hook stops applying, tokenless requests succeed trivially and the whole regression net passes vacuously. This PR adds a canary example that fails loudly when the toggle breaks.

Key changes:

- New `spec/shared_contexts/forgery_protection_spec.rb` — includes the `with forgery protection enforced` shared context (introduced in PR #2838) and asserts `ActionController::Base.allow_forgery_protection` is true inside an example.

<details>
<summary>Why this matters</summary>

The shared context's `before` hook is the only thing enabling forgery protection for the no-CSRF regression specs across four controller spec files. The test environment defaults `allow_forgery_protection` to false, so if the hook is removed or no-ops, tokenless requests succeed anyway, every regression spec still passes, and the suite silently stops guarding the production `skip_forgery_protection` lines. Nothing in the suite would detect that: disabling the hook leaves all 41 examples green.
</details>
