### PR TITLE
Upgrade image_processing to 2.0.3 with explicit mini_magick backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,12 @@ gem 'jquery-rails'
 gem 'jwt'
 
 # Use Active Storage variant
+# image_processing 2.0 made its backends soft dependencies; mini_magick is
+# required by CarrierWave::MiniMagick (avatar/image uploads). Active Storage's
+# variant processor is set to :mini_magick in config/application.rb so the
+# vips backend is never loaded.
 gem 'image_processing'
+gem 'mini_magick'
 gem 'mutex_m' # LOCKED: Added because of activesupport 7.0
 gem 'nokogiri'
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,12 +137,12 @@ GEM
       addressable
       capybara
       playwright-ruby-client (>= 1.16.0)
-    carrierwave (3.1.3)
+    carrierwave (3.1.4)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
       addressable (~> 2.6)
-      image_processing (~> 1.1)
-      marcel (~> 1.0.0)
+      image_processing (>= 1.1, < 3)
+      marcel (>= 1.0.0, < 3)
       ssrf_filter (~> 1.0)
     carrierwave-aws (1.6.1)
       aws-sdk-s3 (~> 1.0)
@@ -234,9 +234,7 @@ GEM
       logger
       ostruct
     ice_cube (0.17.0)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.0.3)
     iniparse (1.5.0)
     io-console (0.9.2)
     irb (1.18.0)
@@ -281,7 +279,7 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0701)
-    mini_magick (5.3.1)
+    mini_magick (5.4.0)
       logger
     mini_mime (1.1.5)
     minitest (6.0.6)
@@ -533,9 +531,6 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.3.0)
-      ffi (~> 1.12)
-      logger
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -671,6 +666,7 @@ DEPENDENCIES
   launchy
   letter_opener
   listen (~> 3.10)
+  mini_magick
   msgpack
   mutex_m
   nokogiri
@@ -763,7 +759,7 @@ CHECKSUMS
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.10) sha256=e48e572d72bc1043c644fab44985be0a1e75d7d6917dc298355581848982a2c3
-  carrierwave (3.1.3) sha256=b99324c5ea63c55ce0776bc0e997c1c70cdd3a490a7458d23a8978930c76541a
+  carrierwave (3.1.4) sha256=9814a21c25ac5bf17e1f28473cd30ebb3c3efdca414b2554ce76e2532425adcc
   carrierwave-aws (1.6.1) sha256=ad9eb8cc677c0b9371bd3534b53689ca731ddc6d04fe764e131e298f36adb13b
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
@@ -813,7 +809,7 @@ CHECKSUMS
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   icalendar (2.12.4) sha256=acf9b8b166dad4679b8be2cc3202260896c199ab7302f748c760c97e9d32e3a2
   ice_cube (0.17.0) sha256=32deb45dda4b4acc53505c2f581f6d32b5afc04d29b9004769944a0df5a5fcbe
-  image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
+  image_processing (2.0.3) sha256=793e33f38470edd0a2d6bfd00acf8cb239c76284ba2e3dfb76633ac2b457f23a
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
@@ -834,7 +830,7 @@ CHECKSUMS
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0701) sha256=cd8811e1fb89d836499ba0582368a10ee74cef929ba956d1d5ddca045e6a730f
-  mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
+  mini_magick (5.4.0) sha256=f120af581d9ed4ec52c57f35a67a605d112bb1d8f582d1415b147fda42d11d78
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.4) sha256=4411c22d350dd1c20250f7eada3cca2695438c2f769cf0782f0cd065d90a3e7b
@@ -924,7 +920,6 @@ CHECKSUMS
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   rubocop-rspec_rails (2.32.0) sha256=4a0d641c72f6ebb957534f539d9d0a62c47abd8ce0d0aeee1ef4701e892a9100
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
   sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5
   scout_apm (6.3.0) sha256=ed4f77534f8cd4d358838f010103b35e7e55c9bd1182b3d61bc02ccfc33f5ace

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,11 @@ module Planner
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
+
+    # Active Storage variants are unused by this app; keep the mini_magick
+    # transformer (the same backend CarrierWave uses) so the vips backend and
+    # its native libvips dependency are never loaded.
+    config.active_storage.variant_processor = :mini_magick
     
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
Upgrading image_processing to 2.0.3 breaks this app on its own: 2.0 made the mini_magick and ruby-vips backends soft dependencies, so dependabot's re-resolution (#2840) dropped both from the lockfile, Active Storage's boot path failed without ruby-vips, and the first avatar or image upload would fail without mini_magick. This PR takes the upgrade with the two changes image_processing 2.0's migration requires, scoped so the vips backend and its native libvips system dependency are never needed.

Key changes:

- `gem "mini_magick"` added as a direct dependency — `CarrierWave::MiniMagick` (`avatar_uploader.rb`, `image_uploader.rb`) processes every avatar and event image upload through it. Depending on it transitively is what let the lockfile drop it.
- `config.active_storage.variant_processor = :mini_magick` in `config/application.rb` — Active Storage variants are unused by this app, so the transformer keeps the same backend CarrierWave already uses and the vips backend (which needs a native libvips install in CI and production) is never loaded.
- `ruby-vips` is therefore not needed anywhere and stays out of the lockfile.

<details>
<summary>Why this upgrade is worth taking</summary>

image_processing 2.0.1-2.0.3 fix several remote-code-execution paths (shell execution through loader/saver options, operation names from user input). The app never calls ImageProcessing directly and uses no Active Storage variants, so the vulnerable surface is not reachable today; the upgrade keeps the gem current and closes those paths if variant processing is ever adopted. Replacing dependabot PR #2840, whose lockfile dropped the backends and failed to boot.
</details>
