### PR TITLE
Record member activity in the activities log

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 $primary: $dark-codebar-blue !default;
 
 @import "bootstrap-custom";
+@import "partials/activity_strip";
 
 /* Bootstrap's Reboot sets legends to float: left, which puts the first check box in a fieldset off to the
    right instead of underneath the legend. This overrides that. */

--- a/app/assets/stylesheets/partials/_activity_strip.scss
+++ b/app/assets/stylesheets/partials/_activity_strip.scss
@@ -1,0 +1,8 @@
+// app/assets/stylesheets/partials/_activity_strip.scss
+.activity-strip {
+  .activity-cell {
+    &-empty { fill: $gray-200; }
+    &-login_only { fill: $gray-400; }
+    &-active { fill: $codebar-pink; }
+  }
+}

--- a/app/components/admin/members/activity_strip_component.html.erb
+++ b/app/components/admin/members/activity_strip_component.html.erb
@@ -1,0 +1,13 @@
+<%# app/components/admin/members/activity_strip_component.html.erb %>
+<div class="activity-strip">
+  <h5>Activity — last 12 months</h5>
+  <svg viewBox="0 0 <%= svg_width %> 32" width="100%" height="32"
+       role="img" aria-label="Weekly activity, last 12 months">
+    <% weeks.each_with_index do |week, i| %>
+      <rect x="<%= i * (CELL_WIDTH + CELL_GAP) %>" y="0"
+            width="<%= CELL_WIDTH %>" height="32" rx="2"
+            class="activity-cell activity-cell-<%= week.state %>"
+            title="<%= title_for(week) %>" />
+    <% end %>
+  </svg>
+</div>

--- a/app/components/admin/members/activity_strip_component.rb
+++ b/app/components/admin/members/activity_strip_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  module Members
+    class ActivityStripComponent < ViewComponent::Base
+      CELL_WIDTH = 8
+      CELL_GAP = 4
+
+      def initialize(weeks:)
+        @weeks = weeks
+      end
+
+      private
+
+      attr_reader :weeks
+
+      def title_for(week)
+        summary = week.counts.map { |key, count| "#{count} #{key.tr('.', ' ')}" }.join(', ')
+        "Week of #{week.week_start.strftime('%-d %b %Y')}: #{summary.presence || 'no activity'}"
+      end
+
+      def svg_width
+        weeks.size * (CELL_WIDTH + CELL_GAP)
+      end
+    end
+  end
+end

--- a/app/components/admin/members/activity_strip_component.rb
+++ b/app/components/admin/members/activity_strip_component.rb
@@ -7,6 +7,7 @@ module Admin
       CELL_GAP = 4
 
       def initialize(weeks:)
+        super()
         @weeks = weeks
       end
 

--- a/app/controllers/admin/bans_controller.rb
+++ b/app/controllers/admin/bans_controller.rb
@@ -10,6 +10,8 @@ class Admin::BansController < Admin::ApplicationController
     @ban.added_by = current_user
 
     if @ban.save
+      MemberActivityRecorder.record(actor: current_user, key: 'member.banned',
+                                    recipient: @ban.member, trackable: @ban)
       MemberMailer.ban(@ban.member, @ban).deliver_now
       redirect_to [:admin, @member], notice: t('.success')
     else

--- a/app/controllers/admin/chapters/organisers_controller.rb
+++ b/app/controllers/admin/chapters/organisers_controller.rb
@@ -14,6 +14,8 @@ class Admin::Chapters::OrganisersController < Admin::ApplicationController
 
     member = Member.find(params[:organiser][:organiser])
     member.add_role(:organiser, @chapter)
+    MemberActivityRecorder.record(actor: current_user, key: 'organiser_role.granted',
+                                  recipient: member, trackable: @chapter)
 
     redirect_to admin_chapter_organisers_path(@chapter), notice: 'Successfully added organiser.'
   end
@@ -24,6 +26,8 @@ class Admin::Chapters::OrganisersController < Admin::ApplicationController
     member = Member.find(params[:id])
 
     member.remove_role(:organiser, @chapter)
+    MemberActivityRecorder.record(actor: current_user, key: 'organiser_role.revoked',
+                                  recipient: member, trackable: @chapter)
     redirect_to admin_chapter_organisers_path(@chapter), notice: 'Successfully removed organiser.'
   end
 

--- a/app/controllers/admin/invitation_controller.rb
+++ b/app/controllers/admin/invitation_controller.rb
@@ -3,9 +3,12 @@ class Admin::InvitationController < Admin::ApplicationController
 
   # event invitations
 
+  # rubocop:disable Metrics/AbcSize
   def update
     invitation = Invitation.find_by(token: params[:invitation][:id])
     invitation.update(attending: true, verified: true, verified_by: current_user, source: Invitation::SOURCE_ADMIN)
+    MemberActivityRecorder.record(actor: current_user, key: 'invitation.verified',
+                                  trackable: invitation, recipient: invitation.member)
 
     EventInvitationMailer.attending(invitation.event, invitation.member, invitation).deliver_now
 
@@ -14,10 +17,14 @@ class Admin::InvitationController < Admin::ApplicationController
       notice: "You have verified #{invitation.member.full_name}'s spot at the event!"
     )
   end
+  # rubocop:enable Metrics/AbcSize
 
+  # rubocop:disable Metrics/AbcSize
   def verify
     invitation = Invitation.find_by(token: params[:invitation_id])
     invitation.update(verified: true, verified_by_id: current_user.id, source: Invitation::SOURCE_ADMIN)
+    MemberActivityRecorder.record(actor: current_user, key: 'invitation.verified',
+                                  trackable: invitation, recipient: invitation.member)
 
     EventInvitationMailer.attending(invitation.event, invitation.member, invitation).deliver_now
 
@@ -26,6 +33,7 @@ class Admin::InvitationController < Admin::ApplicationController
       notice: "You have verified #{invitation.member.full_name}'s spot at the event!"
     )
   end
+  # rubocop:enable Metrics/AbcSize
 
   def cancel
     invitation = Invitation.find_by(token: params[:invitation_id])

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -40,6 +40,8 @@ class Admin::InvitationsController < Admin::ApplicationController
 
   def update_to_attended
     @invitation.update(attended: true, source: Invitation::SOURCE_ADMIN)
+    MemberActivityRecorder.record(actor: current_user, key: 'invitation.rsvp_override',
+                                  trackable: @invitation, recipient: @invitation.member)
   end
 
   def update_to_unattended
@@ -54,6 +56,11 @@ class Admin::InvitationsController < Admin::ApplicationController
       last_overridden_by_id: current_user.id,
       source: Invitation::SOURCE_ADMIN
     )
+
+    if update_successful
+      MemberActivityRecorder.record(actor: current_user, key: 'invitation.rsvp_override',
+                                    trackable: @invitation, recipient: @invitation.member)
+    end
 
     {
       message: update_successful ? attending_successful : attending_failed,
@@ -74,6 +81,8 @@ class Admin::InvitationsController < Admin::ApplicationController
 
   def update_to_not_attending
     @invitation.update!(attending: false, last_overridden_by_id: current_user.id)
+    MemberActivityRecorder.record(actor: current_user, key: 'invitation.rsvp_override',
+                                  trackable: @invitation, recipient: @invitation.member)
 
     {
       message: "You have removed #{@invitation.member.full_name} from the workshop.",

--- a/app/controllers/admin/meeting_invitations_controller.rb
+++ b/app/controllers/admin/meeting_invitations_controller.rb
@@ -6,6 +6,8 @@ class Admin::MeetingInvitationsController < Admin::ApplicationController
     attended = params.permit(:attended)[:attended]
 
     @invitation.update(attending: status, attended:)
+    MemberActivityRecorder.record(actor: current_user, key: 'meeting_invitation.updated',
+                                  trackable: @invitation, recipient: @invitation.member)
 
     redirect_to [:admin, @invitation.meeting],
                 notice: t('admin.messages.invitation.update_rsvp', name: @invitation.member.full_name)
@@ -25,6 +27,8 @@ class Admin::MeetingInvitationsController < Admin::ApplicationController
 
     if invitation.save
       MeetingInvitationMailer.approve_from_waitlist(meeting, member).deliver_now
+      MemberActivityRecorder.record(actor: current_user, key: 'meeting_invitation.created',
+                                    trackable: invitation, recipient: member)
       redirect_to [:admin, meeting], notice: t('admin.messages.invitation.rsvp_member', name: member.full_name)
     else
       redirect_to [:admin, meeting], notice: t('admin.messages.invitation.rsvp_error', name: member.full_name)

--- a/app/controllers/admin/member_notes_controller.rb
+++ b/app/controllers/admin/member_notes_controller.rb
@@ -4,7 +4,12 @@ class Admin::MemberNotesController < Admin::ApplicationController
     authorize @note
 
     @note.author = current_user
-    flash[:error] = @note.errors.full_messages unless @note.save
+    if @note.save
+      MemberActivityRecorder.record(actor: current_user, key: 'member_note.created',
+                                    trackable: @note, recipient: @note.member)
+    else
+      flash[:error] = @note.errors.full_messages
+    end
     redirect_back fallback_location: root_path
   end
 

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -24,9 +24,10 @@ class Admin::MembersController < Admin::ApplicationController
   end
 
   def show
-    @member = MemberPresenter.new(Member.find(params[:id]))
+    member = Member.find(params[:id])
+    @member = MemberPresenter.new(member)
     load_attendance_data(@member)
-
+    @activity_weeks = Admin::Members::ActivityStrip.new(member).rows
     @actions = admin_actions(@member).sort_by(&:created_at).reverse
   end
 

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -39,11 +39,14 @@ class Admin::MembersController < Admin::ApplicationController
 
   def update_subscriptions
     subscription = @member.subscriptions.find_by!(group_id: params[:group])
+    group = subscription.group
     SubscriptionMailingListService.unsubscribe(subscription)
     flash[:notice] = t('.unsubscribe', member: @member.full_name,
-                                       chapter: subscription.group.chapter.city,
-                                       group: subscription.group.name)
+                                       chapter: group.chapter.city,
+                                       group: group.name)
     subscription.destroy
+    MemberActivityRecorder.record(actor: current_user, key: 'subscription.admin_updated',
+                                  trackable: group, recipient: @member)
     redirect_back fallback_location: root_path
   end
 

--- a/app/controllers/admin/workshops_controller.rb
+++ b/app/controllers/admin/workshops_controller.rb
@@ -24,11 +24,14 @@ class Admin::WorkshopsController < Admin::ApplicationController
     authorize @workshop
   end
 
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     resolve_chapter_name_to_id
     @workshop = Workshop.new(workshop_params)
     authorize(@workshop)
     if workshop_type_valid? && @workshop.save
+      @workshop.update_column(:created_by_id, current_user.id) # rubocop:disable Rails/SkipsModelValidations
+      MemberActivityRecorder.record(actor: current_user, key: 'workshop.created',
+                                    trackable: @workshop)
       assign_organisers_or_default
       assign_host(host_id)
       redirect_to admin_workshop_path(@workshop), notice: I18n.t('admin.messages.workshop.created')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,6 +103,8 @@ class ApplicationController < ActionController::Base
   end
 
   def logout!
+    member = current_user
+    MemberActivityRecorder.record(actor: member, key: 'member.logout') if member
     @current_member = nil
     reset_session
   end

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -68,10 +68,12 @@ class AuthServicesController < ApplicationController
   end
 
   def destroy
-    service = current_user.services.find(params[:id])
+    service = current_user.auth_services.find(params[:id])
     if service.respond_to?(:destroy) && service.destroy
       flash[:notice] = I18n.t('notifications.provider_unlinked',
                               provider: service.provider)
+      MemberActivityRecorder.record(actor: current_user, key: 'auth_service.removed',
+                                    trackable: service)
       redirect_to redirect_path
     end
   end
@@ -114,6 +116,6 @@ class AuthServicesController < ApplicationController
   end
 
   def redirect_path
-    :services
+    root_path
   end
 end

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -19,10 +19,7 @@ class AuthServicesController < ApplicationController
       end
       redirect_to root_path
     elsif current_service
-      session[:member_id] = current_service.member.id
-      session[:service_id]         = current_service.id
-      session[:oauth_token]        = omnihash[:credentials][:token]
-      session[:oauth_token_secret] = omnihash[:credentials][:secret]
+      sign_in!(current_service.member, current_service)
 
       finish_registration || redirect_to(referer_or_dashboard_path)
     else
@@ -59,10 +56,7 @@ class AuthServicesController < ApplicationController
           new_member = false
         end
 
-        session[:member_id]          = member.id
-        session[:service_id]         = member_service.id
-        session[:oauth_token]        = omnihash[:credentials][:token]
-        session[:oauth_token_secret] = omnihash[:credentials][:secret]
+        sign_in!(member, member_service)
 
         if member.requires_additional_details?
           session[:new_member] = new_member
@@ -88,6 +82,15 @@ class AuthServicesController < ApplicationController
   end
 
   private
+
+  def sign_in!(member, auth_service)
+    session[:member_id]          = member.id
+    session[:service_id]         = auth_service.id
+    session[:oauth_token]        = omnihash[:credentials][:token]
+    session[:oauth_token_secret] = omnihash[:credentials][:secret]
+
+    MemberActivityRecorder.record(actor: member, key: 'member.login')
+  end
 
   def member_from_github_id
     return unless omnihash[:provider] == 'codebar'

--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -117,6 +117,8 @@ class CheckInsController < ApplicationController
       attrs[:automated_rsvp] = true
     end
     invitation.update!(attrs)
+    MemberActivityRecorder.record(actor: invitation.member, key: 'member.checked_in',
+                                  trackable: invitation)
   end
 
   def permitted_role

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -35,6 +35,9 @@ class InvitationsController < ApplicationController
     if @invitation.student_spaces? || @invitation.coach_spaces?
       @invitation.update!(attending: true)
 
+      MemberActivityRecorder.record(actor: current_user, key: 'event_invitation.rsvp',
+                                    trackable: @invitation)
+
       notice = t('messages.invitations.spot_confirmed', event: @invitation.event.name)
 
       unless event.confirmation_required || event.surveys_required
@@ -61,6 +64,8 @@ class InvitationsController < ApplicationController
     end
 
     @invitation.update!(attending: false)
+    MemberActivityRecorder.record(actor: current_user, key: 'event_invitation.rejected',
+                                  trackable: @invitation)
     redirect_back(
       fallback_location: root_path,
       notice: t('messages.rejected_invitation', name: @invitation.member.name)
@@ -74,6 +79,8 @@ class InvitationsController < ApplicationController
     meeting = invitation.meeting
 
     if invitation.update(attending: true)
+      MemberActivityRecorder.record(actor: current_user, key: 'meeting_invitation.rsvp',
+                                    trackable: invitation)
       MeetingInvitationMailer.attending(meeting, current_user).deliver_now
       redirect_to meeting_path(meeting, token: invitation.token),
                   notice: t('messages.invitations.meeting.rsvp')
@@ -86,6 +93,9 @@ class InvitationsController < ApplicationController
     @invitation = MeetingInvitation.find_by!(token: params[:token])
 
     @invitation.update!(attending: false)
+
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'meeting_invitation.cancelled',
+                                  trackable: @invitation)
 
     redirect_back fallback_location: root_path, notice: t('messages.invitations.meeting.cancel')
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -35,7 +35,7 @@ class InvitationsController < ApplicationController
     if @invitation.student_spaces? || @invitation.coach_spaces?
       @invitation.update!(attending: true)
 
-      MemberActivityRecorder.record(actor: current_user, key: 'event_invitation.rsvp',
+      MemberActivityRecorder.record(actor: @invitation.member, key: 'event_invitation.rsvp',
                                     trackable: @invitation)
 
       notice = t('messages.invitations.spot_confirmed', event: @invitation.event.name)
@@ -64,7 +64,7 @@ class InvitationsController < ApplicationController
     end
 
     @invitation.update!(attending: false)
-    MemberActivityRecorder.record(actor: current_user, key: 'event_invitation.rejected',
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'event_invitation.rejected',
                                   trackable: @invitation)
     redirect_back(
       fallback_location: root_path,

--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -4,6 +4,7 @@ class MailingListsController < ApplicationController
   before_action :require_access
 
   def create
+    MemberActivityRecorder.record(actor: current_user, key: 'mailing_list.subscribe')
     subscribe_to_newsletter(current_user)
     flash[:notice] = I18n.t('subscriptions.messages.mailing_list.subscribe')
 
@@ -11,6 +12,7 @@ class MailingListsController < ApplicationController
   end
 
   def destroy
+    MemberActivityRecorder.record(actor: current_user, key: 'mailing_list.unsubscribe')
     unsubscribe_from_newsletter(current_user)
     flash[:notice] = I18n.t('subscriptions.messages.mailing_list.unsubscribe')
 

--- a/app/controllers/member/details_controller.rb
+++ b/app/controllers/member/details_controller.rb
@@ -24,6 +24,7 @@ class Member::DetailsController < ApplicationController
     return render :edit unless @member.update(attrs)
 
     @member.newsletter ? subscribe_to_newsletter(@member) : unsubscribe_from_newsletter(@member)
+    MemberActivityRecorder.record(actor: @member, key: 'profile.updated')
     redirect_to step2_member_path
   end
 

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -24,6 +24,7 @@ class MembersController < ApplicationController
 
   def update
     if @member.update(member_params)
+      MemberActivityRecorder.record(actor: current_user, key: 'profile.updated')
       notice = 'Your details have been updated.'
       redirect_to profile_path, notice:
     else

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -7,11 +7,13 @@ class SubscriptionsController < ApplicationController
     @member = MemberPresenter.new(current_user)
   end
 
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     subscription = Subscription.new(group_id:, member: current_user)
 
     if subscription.save
       SubscriptionMailingListService.subscribe(subscription)
+      MemberActivityRecorder.record(actor: current_user, key: 'subscription.created',
+                                    trackable: subscription.group)
       send_welcome_email(current_user, subscription)
       flash[:notice] = I18n.t('subscriptions.messages.group.subscribe', chapter: subscription.group.chapter.city,
                                                                         role: subscription.group.name)
@@ -21,14 +23,18 @@ class SubscriptionsController < ApplicationController
     redirect_back fallback_location: root_path
   end
 
-  def destroy
+  def destroy # rubocop:disable Metrics/MethodLength
     # Don't error if subscription is not found
     subscription = current_user.subscriptions.find_by(group_id:)
     SubscriptionMailingListService.unsubscribe(subscription) if subscription
     subscription&.destroy
 
-    # Instead, rely on the group's existence (rather than the subscription)
     group = Group.find(group_id)
+    if subscription
+      MemberActivityRecorder.record(actor: current_user, key: 'subscription.removed',
+                                    trackable: group)
+    end
+
     flash[:notice] = I18n.t('subscriptions.messages.group.unsubscribe',
                             chapter: group.chapter.city,
                             role: group.name)

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -22,6 +22,7 @@ class TermsAndConditionsController < ApplicationController
       member = current_user
       member.accepted_toc_at = Time.zone.now
       member.save(validate: false)
+      MemberActivityRecorder.record(actor: member, key: 'toc.accepted')
       redirect_to previous_path
     else
       flash[notice] = I18n.t('terms_and_conditions.messages.notice')

--- a/app/controllers/waiting_lists_controller.rb
+++ b/app/controllers/waiting_lists_controller.rb
@@ -7,12 +7,14 @@ class WaitingListsController < ApplicationController
   # FeedbackController#submit (PR #2641, Rollbar #535).
   skip_forgery_protection only: %i[create destroy]
 
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @invitation.assign_attributes(invitation_params)
 
     return back_with_message(@invitation.errors.full_messages) unless @invitation.valid?(:waitinglist)
 
     @invitation.save && WaitingList.add(@invitation, auto_rsvp)
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'waiting_list.joined',
+                                  trackable: @invitation)
 
     message = if auto_rsvp
       'You have been added to the waiting list'
@@ -25,6 +27,8 @@ class WaitingListsController < ApplicationController
 
   def destroy
     WaitingList.find_by(invitation_id: @invitation.id).destroy
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'waiting_list.left',
+                                  trackable: @invitation)
 
     redirect_to invitation_path(@invitation), notice: 'You have been removed from the waiting list'
   end

--- a/app/controllers/workshop_invitation_controller.rb
+++ b/app/controllers/workshop_invitation_controller.rb
@@ -45,6 +45,8 @@ class WorkshopInvitationController < ApplicationController
     return back_with_message(t('messages.no_available_seats')) unless available_spaces?(@workshop, @invitation)
 
     if @invitation.update(invitation_params.merge!(attending: true, rsvp_time: Time.zone.now))
+      MemberActivityRecorder.record(actor: @invitation.member, key: 'workshop_invitation.rsvp',
+                                    trackable: @invitation)
       @workshop.send_attending_email(@invitation)
       back_with_message(t('messages.accepted_invitation', name: @invitation.member.name))
     else
@@ -63,6 +65,8 @@ class WorkshopInvitationController < ApplicationController
                       notice: t('messages.not_attending_already'))
       else
         @invitation.update!(attending: false)
+        MemberActivityRecorder.record(actor: @invitation.member, key: 'workshop_invitation.rejected',
+                                      trackable: @invitation)
 
         next_spot = WaitingList.next_spot(@invitation.workshop, @invitation.role)
 

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -21,6 +21,7 @@ class Workshop < ApplicationRecord
   has_many :invitation_logs, as: :loggable
 
   belongs_to :chapter
+  belongs_to :created_by, class_name: 'Member', optional: true, inverse_of: false
 
   default_scope { order('date_and_time DESC') }
   scope :students, -> { joins(:invitations).where(invitation: { name: 'Student', attended: true }) }

--- a/app/services/admin/members/activity_strip.rb
+++ b/app/services/admin/members/activity_strip.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Admin
+  module Members
+    # Buckets a member's activity log into the 52 ISO weeks ending the current week.
+    # Sole owner of strip state classification; the component renders, never classifies.
+    class ActivityStrip
+      WEEK_COUNT = 52
+      LOGIN_ONLY_KEYS = %w[member.login member.logout].freeze
+
+      Row = Struct.new(:week_start, :state, :counts, keyword_init: true)
+
+      def initialize(member, now: Time.zone.now)
+        @member = member
+        @now = now
+      end
+
+      def rows # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        activities = PublicActivity::Activity
+                     .where(owner: @member)
+                     .where(created_at: window_start..@now)
+                     .order(:created_at)
+
+        grouped = activities.group_by { |a| a.created_at.to_date.beginning_of_week.beginning_of_day }
+
+        weeks.map do |week_start|
+          week_activities = grouped[week_start] || []
+          counts = week_activities.map(&:key).tally
+          state = classify(counts)
+
+          Row.new(week_start:, state:, counts:)
+        end
+      end
+
+      private
+
+      def classify(counts)
+        return :empty if counts.empty?
+        return :login_only if counts.keys.all? { |key| LOGIN_ONLY_KEYS.include?(key) }
+
+        :active
+      end
+
+      def weeks
+        @weeks ||= Array.new(WEEK_COUNT) { |i| current_week_start - (WEEK_COUNT - 1 - i).weeks }
+      end
+
+      def window_start
+        @window_start ||= current_week_start - (WEEK_COUNT - 1).weeks
+      end
+
+      def current_week_start
+        @current_week_start ||= @now.to_date.beginning_of_week.beginning_of_day
+      end
+    end
+  end
+end

--- a/app/services/invitation_logger.rb
+++ b/app/services/invitation_logger.rb
@@ -8,7 +8,7 @@ class InvitationLogger
     @log = nil
   end
 
-  def start_batch
+  def start_batch # rubocop:disable Metrics/MethodLength
     @log = InvitationLog.create!(
       loggable: @loggable,
       initiator: @initiator,
@@ -18,6 +18,10 @@ class InvitationLogger
       started_at: Time.current,
       status: :running
     )
+
+    MemberActivityRecorder.record(actor: @initiator, key: 'invitation.send_batch', trackable: @loggable)
+
+    @log
   end
 
   def log_success(member, invitation = nil)

--- a/app/services/member_activity_recorder.rb
+++ b/app/services/member_activity_recorder.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Single funnel for member-activity rows on the public_activity `activities` table.
+# Explicit call sites only — no model callbacks — so nothing is double-logged.
+# Recording is observability: persistence failures are logged, never raised.
+class MemberActivityRecorder
+  # Key vocabulary in use; extend when adding sites. New keys classify as :active in the strip.
+  KEYS = %w[
+    member.login
+    member.logout
+    member.checked_in
+    member_note.created
+    member.banned
+    profile.updated
+    toc.accepted
+    auth_service.removed
+    subscription.created
+    subscription.removed
+    subscription.admin_updated
+    mailing_list.subscribe
+    mailing_list.unsubscribe
+    event_invitation.rsvp
+    event_invitation.rejected
+    meeting_invitation.rsvp
+    meeting_invitation.cancelled
+    workshop_invitation.rsvp
+    workshop_invitation.rejected
+    waiting_list.joined
+    waiting_list.left
+    organiser_role.granted
+    organiser_role.revoked
+    invitation.send_batch
+    invitation.rsvp_override
+    invitation.verified
+    workshop.created
+    meeting_invitation.created
+    meeting_invitation.updated
+  ].freeze
+
+  def self.record(actor:, key:, trackable: nil, recipient: nil)
+    trackable ||= actor
+    PublicActivity::Activity.create!(owner: actor, key:, trackable:, recipient:)
+  rescue StandardError => e
+    Rails.logger.warn("MemberActivityRecorder failed (#{key}): #{e.class}: #{e.message}")
+  end
+end

--- a/app/views/admin/members/_profile.html.haml
+++ b/app/views/admin/members/_profile.html.haml
@@ -6,6 +6,9 @@
   %span.d-block
     %p.lead= @member.about_you
 
+  - if @member.organiser?
+    = render Admin::Members::ActivityStripComponent.new(weeks: @activity_weeks)
+
   - if @member.skills.any?
     .mb-4
       %h5 Skills

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
   get   '/login', to: 'auth_services#new'
   match '/auth/:service/callback' => 'auth_services#create', via: %i[get post]
   match '/auth/failure' => 'auth_services#failure', via: %i[get post]
+  delete '/auth/services/:id' => 'auth_services#destroy', as: :auth_service
   match '/logout' => 'auth_sessions#destroy', via: %i[get delete], as: :logout
   match '/register' => 'auth_sessions#create', via: %i[get], as: :registration
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,7 +176,6 @@ Rails.application.routes.draw do
   get   '/login', to: 'auth_services#new'
   match '/auth/:service/callback' => 'auth_services#create', via: %i[get post]
   match '/auth/failure' => 'auth_services#failure', via: %i[get post]
-  delete '/auth/services/:id' => 'auth_services#destroy', as: :auth_service
   match '/logout' => 'auth_sessions#destroy', via: %i[get delete], as: :logout
   match '/register' => 'auth_sessions#create', via: %i[get], as: :registration
 

--- a/db/migrate/20260908085056_add_created_by_id_to_workshops.rb
+++ b/db/migrate/20260908085056_add_created_by_id_to_workshops.rb
@@ -1,0 +1,11 @@
+class AddCreatedByIdToWorkshops < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :workshops, :created_by_id, :integer
+    add_index :workshops, :created_by_id, algorithm: :concurrently
+    safety_assured do
+      add_foreign_key :workshops, :members, column: :created_by_id, on_delete: :nullify
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_100100) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_085056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -634,6 +634,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_100100) do
     t.string "check_in_code"
     t.integer "coach_spaces", default: 0
     t.datetime "created_at", precision: nil
+    t.integer "created_by_id"
     t.datetime "date_and_time", precision: nil
     t.text "description"
     t.datetime "ends_at", precision: nil
@@ -647,12 +648,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_100100) do
     t.string "title"
     t.datetime "updated_at", precision: nil
     t.boolean "virtual", default: false
-    t.index ["check_in_code"], name: "index_workshops_on_check_in_code", unique: true
     t.index ["chapter_id"], name: "index_workshops_on_chapter_id"
+    t.index ["check_in_code"], name: "index_workshops_on_check_in_code", unique: true
+    t.index ["created_by_id"], name: "index_workshops_on_created_by_id"
     t.index ["date_and_time"], name: "index_workshops_on_date_and_time"
   end
 
   add_foreign_key "invitation_log_entries", "invitation_logs"
   add_foreign_key "invitation_logs", "members", column: "initiator_id"
   add_foreign_key "member_email_deliveries", "members"
+  add_foreign_key "workshops", "members", column: "created_by_id", on_delete: :nullify
 end

--- a/docs/plans/2026-08-09-001-feat-workshop-organisers-creation-plan.md
+++ b/docs/plans/2026-08-09-001-feat-workshop-organisers-creation-plan.md
@@ -1,0 +1,159 @@
+---
+title: Allow Adding Organisers During Workshop Creation - Plan
+type: feat
+date: 2026-08-09
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Allow Adding Organisers During Workshop Creation
+
+## Goal Capsule
+
+- **Objective:** Let admins choose a workshop's organisers while creating the workshop from a chapter page, so the workshop can be fully configured in one step.
+- **Authority hierarchy:** Issue [#2398](https://github.com/codebar/planner/issues/2398) and maintainer comments in that issue set the scope and approach.
+- **Execution profile:** Small Rails view/controller change, additive feature with no data migration.
+- **Stop conditions:** The feature works when creating from a chapter page and does not change the existing general `/admin/workshops/new` flow.
+- **Tail ownership:** ce-work or manual implementation; this plan is the handoff artifact.
+
+---
+
+## Product Contract
+
+### Summary
+
+When an admin clicks **New workshop** from a chapter's admin page, the new-workshop form will pre-select that chapter, hide the chapter dropdown, and show the chapter's organisers pre-selected but editable. Submitting the form creates the workshop and assigns the selected organisers. Creating a workshop from any other context continues to work exactly as it does today.
+
+### Problem Frame
+
+Today an admin must create a workshop and then edit it to manage organisers. The create form has no organisers field because the set of valid organisers depends on the chosen chapter, and the chapter is not known until the form is submitted. The chapter page already knows which chapter the admin is viewing, so it can seed the create form with that context.
+
+### Requirements
+
+- R1. The **New workshop** link on the chapter admin page passes the chapter id to the create form.
+- R2. When the create form receives a chapter id, it pre-selects that chapter and hides the chapter dropdown.
+- R3. When the create form receives a chapter id, it shows the chapter's organisers as pre-selected but editable.
+- R4. Submitting the create form with selected organisers assigns those organisers to the new workshop.
+- R5. Creating a workshop without a chapter id continues to auto-grant all chapter organisers after save, matching current behavior.
+
+### Scope Boundaries
+
+- **Deferred for later:** Dynamic update of the organisers list when the chapter dropdown changes in the general create form.
+- **Outside this product's identity:** Changing how organisers are managed on the edit page, changing chapter-organiser membership, or adding organiser management outside the admin area.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Pre-selection signal:** Use a `chapter_id` query parameter on `new_admin_workshop_path`, as proposed by maintainers in the issue comments.
+- KTD2. **Form branching:** Render the chapter select and organisers input conditionally based on a pre-selected chapter passed to the view. This keeps the existing general create form unchanged when no chapter is pre-selected.
+- KTD3. **Organiser assignment:** Reuse the existing `assign_organisers` helper in `create` when organiser params are submitted; otherwise keep the current auto-grant-all-chapter-organisers behavior.
+
+### Sources & Research
+
+- `app/controllers/admin/workshops_controller.rb` — current `new`, `create`, and organiser helper methods.
+- `app/views/admin/workshops/_form.html.haml` and `app/views/admin/workshops/_shared_form.html.haml` — current new-workshop form structure and chapter select.
+- `app/views/admin/workshops/_edit_form.html.haml` — existing organisers input pattern to mirror.
+- `app/views/admin/chapters/show.html.haml` — the **New workshop** entry point.
+- `spec/features/admin/workshops_spec.rb` — existing feature coverage for workshop creation.
+- No institutional learnings were found in `docs/solutions/` for this area.
+
+---
+
+## Implementation Units
+
+### U1. Pass chapter_id from chapter show page
+
+- **Goal:** Seed the new-workshop form with the chapter context when the admin starts from a chapter page.
+- **Requirements:** R1.
+- **Dependencies:** None.
+- **Files:** `app/views/admin/chapters/show.html.haml`.
+- **Approach:** Update the **New workshop** link to pass `chapter_id: @chapter.id`.
+- **Patterns to follow:** Existing `link_to` with route helper.
+- **Test scenarios:**
+  - Happy path: link from chapter show page includes the chapter id parameter.
+- **Verification:** Visiting a chapter show page renders a **New workshop** link whose href includes `chapter_id=<id>`.
+
+### U2. Pre-select chapter in new action
+
+- **Goal:** Build a workshop pre-associated with the chapter when `chapter_id` is present.
+- **Requirements:** R2.
+- **Dependencies:** U1.
+- **Files:** `app/controllers/admin/workshops_controller.rb`.
+- **Approach:** In `new`, when `params[:chapter_id]` is present and valid, build `Workshop.new(chapter_id: params[:chapter_id])`. The view should derive the pre-selected chapter from `@workshop.chapter` / `@workshop.chapter_id` so the same form state survives a failed `create` re-render.
+- **Patterns to follow:** Existing `Workshop.new` build pattern and Pundit authorization.
+- **Test scenarios:**
+  - Happy path: `GET /admin/workshops/new?chapter_id=X` builds a workshop with `chapter_id` set.
+  - Edge case: invalid or missing `chapter_id` falls back to an empty workshop without raising an error.
+- **Verification:** The new action renders successfully with the correct chapter pre-selected.
+
+### U3. Permit and assign organisers on create
+
+- **Goal:** Persist the selected organisers when the chapter-prefixed form is submitted.
+- **Requirements:** R4, R5.
+- **Dependencies:** U2.
+- **Files:** `app/controllers/admin/workshops_controller.rb`.
+- **Approach:**
+  1. Permit `organisers` as an array in `workshop_params`.
+  2. After saving the workshop, if organiser params were submitted, call `assign_organisers(organiser_ids)` instead of auto-granting all chapter organisers.
+  3. Keep auto-grant behavior when no organiser params are present.
+- **Patterns to follow:** Existing `assign_organisers`, `grant_organiser_access`, and `params.expect` array syntax (`{ organisers: [] }`).
+- **Test scenarios:**
+  - Happy path: submitting selected organisers assigns those members as workshop organisers.
+  - Happy path: creating without a pre-selected chapter still auto-grants all chapter organisers.
+  - Edge case: submitting an empty organisers list removes any auto-granted organisers.
+- **Verification:** Workshop organisers match the submitted selection after create.
+
+### U4. Conditionally render chapter select and organisers input
+
+- **Goal:** Show the chapter dropdown only when no chapter is pre-selected, and show the organisers input only when a chapter is pre-selected.
+- **Requirements:** R2, R3.
+- **Dependencies:** U2.
+- **Files:** `app/views/admin/workshops/_form.html.haml`, `app/views/admin/workshops/_shared_form.html.haml`.
+- **Approach:**
+  1. Wrap the chapter association in `_shared_form.html.haml` so it can be hidden when a chapter is pre-selected.
+  2. Add the organisers input to the new form, mirroring `_edit_form.html.haml`, when a chapter is pre-selected.
+- **Patterns to follow:** `_edit_form.html.haml` organisers input (`collection: chapter.organisers`, `value_method: :id`, `label_method: :full_name`, `input_html: { multiple: true }`).
+- **Test scenarios:**
+  - Happy path: form with `chapter_id` shows organisers input and hides chapter select.
+  - Happy path: form without `chapter_id` shows chapter select and no organisers input.
+  - Edge case: a failed `create` re-render keeps the chapter select hidden and the organisers input visible.
+- **Verification:** Both form variants render without errors and submit the expected parameters.
+
+### U5. Feature test coverage
+
+- **Goal:** Cover the end-to-end chapter-prefixed create flow with organisers.
+- **Requirements:** R1, R2, R3, R4.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:** `spec/features/admin/workshops_spec.rb`.
+- **Approach:** Add a feature spec that navigates to a chapter show page, clicks **New workshop**, adjusts the pre-selected organisers, submits, and asserts the created workshop has the expected organisers.
+- **Patterns to follow:** Existing feature specs in `spec/features/admin/workshops_spec.rb` using Fabrication and Capybara.
+- **Test scenarios:**
+  - Happy path: create workshop from chapter page with a subset of chapter organisers assigned.
+  - Edge case: create workshop from chapter page and remove all pre-selected organisers.
+- **Verification:** New feature spec passes and existing feature specs still pass.
+
+---
+
+## Verification Contract
+
+| Gate | Command | When it applies |
+|---|---|---|
+| Feature tests | `bundle exec rspec spec/features/admin/workshops_spec.rb` | Always |
+| Controller tests | `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb` | Always |
+| Full suite | `make test` | Before considering done |
+| Lint | `bundle exec rubocop` | Before considering done |
+
+## Definition of Done
+
+- [ ] All implementation units above are complete.
+- [ ] `bundle exec rspec spec/features/admin/workshops_spec.rb` passes.
+- [ ] `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb` passes.
+- [ ] `bundle exec rubocop` reports no new offenses.
+- [ ] Creating a workshop from a chapter page allows selecting organisers before save.
+- [ ] Creating a workshop from `/admin/workshops/new` without a chapter id behaves exactly as before.
+- [ ] No abandoned or experimental code remains in the diff.

--- a/docs/superpowers/plans/2025-03-31-self-check-in-implementation.md
+++ b/docs/superpowers/plans/2025-03-31-self-check-in-implementation.md
@@ -1,0 +1,921 @@
+# Self Check-In Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let event/workshop attendees mark themselves as attended by scanning a QR code. Organisers download a landscape PDF displayed at the venue entrance.
+
+**Architecture:** New `check_in_code` column on events/workshops (3-word EFF code). New `source` column on invitation tables. A `CheckInPdf` service generates landscape PDFs. Two new controllers: `Admin::CheckInsController` (instructions + PDF download) and public `CheckInsController` (auth + role selection + check-in). QR encodes a short URL resolved by `check_in_code`.
+
+**Tech Stack:** Rails 8.1, PostgreSQL, HAML, Prawn (PDF), RQRCode (QR), EFF large word list
+
+## Global Constraints
+
+- Every new code path that creates an invitation must set `source` explicitly
+- `source` column is nullable — NULL = legacy records, no backfill
+- `check_in_code` generated on `before_create` for new records; lazy generation on first PDF download for existing records
+- QR encodes the full absolute URL (use `_url` helpers, not `_path`)
+- Admin check-in controller uses `respond_to` for HTML (instructions) and PDF (download)
+- Public check-in controller polymorphic — handles both events and workshops
+- No rake task for backfill; codes generated lazily
+
+---
+### Task 1: Database migration
+
+**Files:**
+- Create: `db/migrate/YYYYMMDDHHMMSS_add_check_in_code_to_events.rb`
+- Create: `db/migrate/YYYYMMDDHHMMSS_add_check_in_code_to_workshops.rb`
+- Create: `db/migrate/YYYYMMDDHHMMSS_add_source_to_invitations.rb`
+- Create: `db/migrate/YYYYMMDDHHMMSS_add_source_to_workshop_invitations.rb`
+
+**Interfaces:**
+- Produces: `events.check_in_code` (string, unique, indexed), `workshops.check_in_code` (string, unique, indexed), `invitations.source` (string, nullable), `workshop_invitations.source` (string, nullable)
+
+- [ ] **Step 1: Add `check_in_code` to events**
+
+```ruby
+class AddCheckInCodeToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :events, :check_in_code, :string
+    add_index :events, :check_in_code, unique: true
+  end
+end
+```
+
+- [ ] **Step 2: Add `check_in_code` to workshops**
+
+```ruby
+class AddCheckInCodeToWorkshops < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workshops, :check_in_code, :string
+    add_index :workshops, :check_in_code, unique: true
+  end
+end
+```
+
+- [ ] **Step 3: Add `source` to invitations**
+
+```ruby
+class AddSourceToInvitations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :invitations, :source, :string
+  end
+end
+```
+
+- [ ] **Step 4: Add `source` to workshop_invitations**
+
+```ruby
+class AddSourceToWorkshopInvitations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workshop_invitations, :source, :string
+  end
+end
+```
+
+- [ ] **Step 5: Run migrations**
+
+```bash
+bundle exec rails db:migrate
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/migrate/
+git commit -m "feat: add check_in_code and source columns for self check-in"
+```
+
+---
+### Task 2: Word list + model concern for check_in_code generation
+
+**Files:**
+- Create: `lib/words/check_in_words.txt`
+- Create: `app/models/concerns/check_in_code.rb`
+- Modify: `app/models/event.rb`
+- Modify: `app/models/workshop.rb`
+
+**Interfaces:**
+- Consumes: `events.check_in_code` column, `workshops.check_in_code` column
+- Produces: `CheckInCode` concern with `generate_check_in_code!` and `check_in_url` methods, included in Event and Workshop
+
+- [ ] **Step 1: Download and bundle EFF word list**
+
+```bash
+curl -sL "https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt" \
+  | awk '{print $2}' > lib/words/check_in_words.txt
+```
+
+Verify line count:
+```bash
+wc -l lib/words/check_in_words.txt
+# Expected: 7776
+```
+
+- [ ] **Step 2: Write the CheckInCode concern**
+
+Key details:
+- Word list loaded lazily (memoized class method) to avoid 7776-line read on every class reload in dev
+- `set_check_in_code` runs in `before_create`
+- `generate_check_in_code!` is for lazy generation on existing records
+- `check_in_url` builds the full URL for the QR
+
+```ruby
+# app/models/concerns/check_in_code.rb
+module CheckInCode
+  extend ActiveSupport::Concern
+
+  WORD_LIST_PATH = Rails.root.join("lib", "words", "check_in_words.txt")
+
+  class_methods do
+    def word_list
+      @word_list ||= File.readlines(WORD_LIST_PATH).map(&:strip).freeze
+    end
+  end
+
+  included do
+    before_create :set_check_in_code
+  end
+
+  def generate_check_in_code!
+    loop do
+      code = self.class.word_list.sample(3).join("-")
+      unless self.class.exists?(check_in_code: code)
+        update_column(:check_in_code, code)
+        return code
+      end
+    end
+  end
+
+  def check_in_url
+    prefix = model_name.singular == "event" ? "e" : "w"
+    route_name = :"check_in_#{prefix}_url"
+    Rails.application.routes.url_helpers.public_send(
+      route_name, check_in_code
+    )
+  end
+
+  private
+
+  def set_check_in_code
+    loop do
+      self.check_in_code = self.class.word_list.sample(3).join("-")
+      break unless self.class.exists?(check_in_code: check_in_code)
+    end
+  end
+end
+```
+
+Note: `check_in_url` relies on `default_url_options[:host]` being configured. Verify `config/environments/development.rb` and `production.rb` have `config.action_mailer.default_url_options` set (they should already for existing email functionality).
+
+- [ ] **Step 3: Include concern in Event**
+
+```ruby
+# app/models/event.rb — add alongside other includes
+include CheckInCode
+```
+
+- [ ] **Step 4: Include concern in Workshop**
+
+```ruby
+# app/models/workshop.rb — add alongside other includes
+include CheckInCode
+```
+
+- [ ] **Step 5: Write model tests**
+
+In `spec/models/event_spec.rb`:
+```ruby
+describe "check_in_code" do
+  it "generates a check_in_code on create" do
+    event = create(:event)
+    expect(event.check_in_code).to be_present
+    expect(event.check_in_code.split("-").length).to eq(3)
+  end
+
+  it "generates a unique check_in_code" do
+    codes = 3.times.map { create(:event).check_in_code }
+    expect(codes.uniq.length).to eq(3)
+  end
+end
+```
+
+Same pattern in `spec/models/workshop_spec.rb`.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+bundle exec rspec spec/models/event_spec.rb spec/models/workshop_spec.rb
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/words/check_in_words.txt app/models/concerns/check_in_code.rb app/models/event.rb app/models/workshop.rb
+git commit -m "feat: add check_in_code generation from EFF word list"
+```
+
+---
+### Task 3: Add gems + CheckInPdf service
+
+**Files:**
+- Modify: `Gemfile`
+- Create: `app/services/check_in_pdf.rb`
+
+**Interfaces:**
+- Consumes: Event or Workshop with `check_in_code` and `check_in_url` methods
+- Produces: `CheckInPdf#render` returning PDF binary string
+
+- [ ] **Step 1: Add gems**
+
+```ruby
+# Gemfile — add alongside other gems
+gem "rqrcode"
+gem "prawn"
+```
+
+- [ ] **Step 2: Bundle install**
+
+```bash
+bundle install
+```
+
+- [ ] **Step 3: Write the CheckInPdf service**
+
+Landscape A4 layout: header → event info → venue → sponsors → QR code centered.
+
+```ruby
+# app/services/check_in_pdf.rb
+
+class CheckInPdf
+  def initialize(parent)
+    @parent = parent
+  end
+
+  def render
+    Prawn::Document.new(page_layout: :landscape, page_size: "A4", margin: 20) do |pdf|
+      # Header
+      pdf.text "codebar", size: 16, color: "333333"
+      pdf.move_down 8
+
+      # Event info
+      pdf.text @parent.to_s, size: 28, style: :bold
+      pdf.move_down 4
+      pdf.text formatted_date, size: 16, color: "555555"
+      pdf.move_down 8
+
+      # Venue
+      if @parent.respond_to?(:venue) && @parent.venue.present?
+        venue = @parent.venue
+        pdf.text venue.name, size: 14, color: "555555"
+        if venue.respond_to?(:address) && venue.address.present?
+          pdf.text venue.address.to_s, size: 12, color: "777777"
+        end
+        pdf.move_down 4
+      end
+
+      # Sponsors
+      if @parent.respond_to?(:sponsors) && @parent.sponsors.any?
+        pdf.text "Sponsored by: #{@parent.sponsors.map(&:name).join(', ')}", size: 12, color: "777777"
+        pdf.move_down 8
+      end
+
+      # QR code — centered
+      qrcode = RQRCode::QRCode.new(@parent.check_in_url)
+      png = qrcode.as_png(module_size: 6)
+      qr_width = 160
+
+      pdf.bounding_box([(pdf.bounds.width - qr_width) / 2.0, pdf.cursor],
+                       width: qr_width, height: pdf.cursor - 20) do
+        pdf.image StringIO.new(png.to_blob), width: qr_width, position: :center
+        pdf.move_down 4
+        pdf.text "Scan to check in", size: 11, align: :center, color: "999999"
+        pdf.move_down 2
+        pdf.text @parent.check_in_url.sub(%r{^https?://}, ""),
+                 size: 10, align: :center, color: "999999"
+      end
+    end.render
+  end
+
+  private
+
+  def formatted_date
+    dt = @parent.date_and_time
+    dt.strftime("%A, %B %d, %Y at %H:%M")
+  end
+end
+```
+
+- [ ] **Step 4: Write service test**
+
+```ruby
+# spec/services/check_in_pdf_spec.rb
+require "rails_helper"
+
+RSpec.describe CheckInPdf do
+  let(:event) { create(:event, check_in_code: "sunny-ocean-breeze") }
+
+  subject { described_class.new(event) }
+
+  it "generates a PDF" do
+    pdf = subject.render
+    expect(pdf).to start_with("%PDF")
+  end
+
+  it "includes the check-in URL in the PDF" do
+    pdf = subject.render
+    expect(pdf).to include(event.check_in_url)
+  end
+end
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+bundle exec rspec spec/services/check_in_pdf_spec.rb
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Gemfile Gemfile.lock app/services/check_in_pdf.rb spec/services/check_in_pdf_spec.rb
+git commit -m "feat: add CheckInPdf service for landscape QR check-in PDF"
+```
+
+---
+### Task 4: Admin::CheckInsController + instructions page
+
+**Files:**
+- Create: `app/controllers/admin/check_ins_controller.rb`
+- Create: `app/views/admin/check_ins/show.html.haml`
+- Modify: `config/routes.rb` (add admin check-in routes)
+
+**Interfaces:**
+- Consumes: Event/Workshop with `check_in_code`, `generate_check_in_code!`, `check_in_url`, `CheckInPdf`
+- Produces: HTML instructions page and PDF download via `respond_to`
+
+- [ ] **Step 1: Write the controller**
+
+```ruby
+# app/controllers/admin/check_ins_controller.rb
+class Admin::CheckInsController < Admin::ApplicationController
+  before_action :load_parent
+
+  def show
+    authorize @parent
+    @parent.generate_check_in_code! if @parent.check_in_code.blank?
+
+    respond_to do |format|
+      format.html
+      format.pdf do
+        pdf = CheckInPdf.new(@parent).render
+        send_data pdf,
+                  filename: "check-in-#{@parent.to_param}.pdf",
+                  type: "application/pdf",
+                  disposition: "attachment"
+      end
+    end
+  end
+
+  private
+
+  def load_parent
+    if params[:event_id]
+      @parent = Event.find_by!(slug: params[:event_id])
+    elsif params[:workshop_id]
+      @parent = Workshop.find(params[:workshop_id])
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Write the instructions view**
+
+```haml
+-# app/views/admin/check_ins/show.html.haml
+
+%h2 Check-in for #{@parent.to_s}
+
+.alert.alert-info
+  %p.mb-0
+    Let attendees mark themselves as attended by scanning the QR code on the PDF.
+    Once scanned, they sign in with GitHub and confirm their role.
+    You'll see their attendance update in the event admin page.
+
+.card.mb-4
+  .card-body
+    %h5.card-title Check-in URL
+    %p.lead.mb-1= @parent.check_in_code
+    %p.text-muted.small= @parent.check_in_url
+    %p.text-muted.small Share this URL with anyone who can't scan the QR code.
+
+.card.mb-4
+  .card-body
+    %h5.card-title How to use
+    %ol
+      %li Download the PDF below.
+      %li Print it or display it on a screen at the venue entrance.
+      %li Attendees scan the QR code with their phone.
+      %li They sign in with GitHub and select their role (Student/Coach).
+      %li They're checked in! You can see attendance on the event/workshop admin page.
+
+= link_to admin_event_check_in_path(@parent, format: :pdf),
+          class: 'btn btn-primary btn-lg' do
+  %i.fas.fa-download
+  Download PDF
+```
+
+- [ ] **Step 3: Add admin routes**
+
+Inside `namespace :admin` block in `config/routes.rb`:
+
+```ruby
+resources :events, only: [] do
+  resource :check_in, only: [:show], controller: "check_ins"
+end
+
+resources :workshops, only: [] do
+  resource :check_in, only: [:show], controller: "check_ins"
+end
+```
+
+Singular `resource` since there's one check-in per event/workshop. Helpers: `admin_event_check_in_path(@event)`, `admin_workshop_check_in_path(@workshop)`.
+
+- [ ] **Step 4: Write controller test**
+
+```ruby
+# spec/controllers/admin/check_ins_controller_spec.rb
+require "rails_helper"
+
+RSpec.describe Admin::CheckInsController do
+  let(:admin) { create(:member, :admin) }
+  let(:event) { create(:event) }
+
+  before { sign_in admin }
+
+  describe "GET show" do
+    it "renders the instructions page" do
+      get :show, params: { event_id: event.slug }
+      expect(response).to be_successful
+    end
+
+    it "generates check_in_code if missing" do
+      expect { get :show, params: { event_id: event.slug } }
+        .to change { event.reload.check_in_code }.from(nil)
+    end
+
+    it "returns PDF for .pdf format" do
+      get :show, params: { event_id: event.slug, format: :pdf }
+      expect(response.content_type).to eq("application/pdf")
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+bundle exec rspec spec/controllers/admin/check_ins_controller_spec.rb
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/controllers/admin/check_ins_controller.rb \
+       app/views/admin/check_ins/show.html.haml \
+       config/routes.rb \
+       spec/controllers/admin/check_ins_controller_spec.rb
+git commit -m "feat: add admin check-in controller with instructions and PDF download"
+```
+
+---
+### Task 5: Admin toolbar buttons
+
+**Files:**
+- Modify: `app/views/admin/events/show.html.haml`
+- Modify: `app/views/admin/workshops/show.html.haml`
+
+**Interfaces:**
+- Consumes: Admin event/workshop show page toolbar
+- Produces: "Check-in" button in toolbar linking to instructions page
+
+- [ ] **Step 1: Add button to events show page**
+
+In `app/views/admin/events/show.html.haml`, add to the `.container-fluid.btn-group.p-0` toolbar:
+
+```haml
+= link_to admin_event_check_in_path(@original_event), class: 'btn btn-primary py-3' do
+  %i.fas.fa-qrcode
+  %label.text-white Check-in
+```
+
+Note: Events show page uses `@original_event` for non-presenter model instance. Verify this variable exists and points to the right model.
+
+- [ ] **Step 2: Add button to workshops show page**
+
+In `app/views/admin/workshops/show.html.haml`:
+
+```haml
+= link_to admin_workshop_check_in_path(@workshop), class: 'btn btn-primary py-3' do
+  %i.fas.fa-qrcode
+  %label.text-white Check-in
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/views/admin/events/show.html.haml app/views/admin/workshops/show.html.haml
+git commit -m "feat: add Check-in button to admin event/workshop toolbar"
+```
+
+---
+### Task 6: Public CheckInsController (check-in flow)
+
+**Files:**
+- Create: `app/controllers/check_ins_controller.rb`
+- Create: `app/views/check_ins/new.html.haml`
+- Create: `app/views/check_ins/confirm.html.haml`
+- Modify: `config/routes.rb` (add public check-in routes)
+
+**Interfaces:**
+- Consumes: Event/Workshop with `check_in_code`, `check_in_url`, invitation models with `source`
+- Produces: Role-selection page, confirmation page, invitation records with `source: "check_in"`
+
+- [ ] **Step 1: Write the controller**
+
+Key design:
+- Don't override `authenticate_member!` — set `session[:referer_path]` before it runs
+- `load_parent` tries both Event and Workshop by `check_in_code` (collision probability negligible)
+- Already-checked-in handled inline in view, not a separate render
+- Helper methods for form/redirect URLs, polymorphic between e/w routes
+
+```ruby
+# app/controllers/check_ins_controller.rb
+class CheckInsController < ApplicationController
+  before_action :load_parent
+  before_action :store_referer_path, only: [:new]
+  before_action :authenticate_member!, only: [:new]
+
+  def new
+    @invitation = find_invitation
+    @suggested_role = infer_role
+    @already_checked_in = already_checked_in?(@invitation)
+  end
+
+  def create
+    role = params[:role]
+    invitation = find_or_create_invitation(role)
+    mark_attended(invitation)
+    redirect_to check_in_confirm_path
+  end
+
+  def confirm
+    @invitation = find_invitation
+  end
+
+  private
+
+  def load_parent
+    @parent = Event.find_by(check_in_code: params[:code]) ||
+              Workshop.find_by(check_in_code: params[:code])
+    raise ActiveRecord::RecordNotFound unless @parent
+  end
+
+
+  helper_method :check_in_submit_path, :check_in_confirm_path
+
+  def check_in_submit_path
+    @parent.is_a?(Event) ?
+      check_in_e_path(code: @parent.check_in_code) :
+      check_in_w_path(code: @parent.check_in_code)
+  end
+
+  def check_in_confirm_path
+    @parent.is_a?(Event) ?
+      check_in_e_confirm_path(code: @parent.check_in_code) :
+      check_in_w_confirm_path(code: @parent.check_in_code)
+  end
+
+  def store_referer_path
+    session[:referer_path] = request.path unless logged_in?
+  end
+
+  def already_checked_in?(invitation)
+    return false unless invitation
+
+    if @parent.is_a?(Event)
+      invitation.verified?
+    else
+      invitation.attended?
+    end
+  end
+
+  def find_invitation
+    if @parent.is_a?(Event)
+      Invitation.find_by(event: @parent, member: current_user)
+    else
+      WorkshopInvitation.find_by(workshop: @parent, member: current_user)
+    end
+  end
+
+  def find_or_create_invitation(role)
+    if @parent.is_a?(Event)
+      Invitation.find_or_create_by!(event: @parent, member: current_user, role: role)
+    else
+      WorkshopInvitation.find_or_create_by!(workshop: @parent, member: current_user, role: role)
+    end
+  end
+
+  def mark_attended(invitation)
+    attrs = { attending: true, source: "check_in" }
+    if @parent.is_a?(Event)
+      attrs[:verified] = true
+    else
+      attrs[:attended] = true
+    end
+    invitation.update!(attrs)
+  end
+
+  def infer_role
+    return @invitation.role if @invitation.present?
+
+    groups = current_user.groups
+    student = groups.students.any?
+    coach = groups.coaches.any?
+
+    if student && !coach
+      "Student"
+    elsif coach && !student
+      "Coach"
+    else
+      nil
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Write the role-selection view**
+
+Handles both first-visit and already-checked-in states:
+
+```haml
+-# app/views/check_ins/new.html.haml
+
+%h1= @parent.to_s
+%p.lead= l(@parent.date_and_time, format: :long)
+
+- if @already_checked_in
+  .text-center.py-4
+    %h2.text-success ✓ Already checked in!
+    %p.lead As a #{@invitation.role}
+    = link_to "Back to Dashboard", dashboard_path, class: "btn btn-primary mt-3"
+- else
+  %h3 Welcome, #{current_user.name}!
+
+  - if @invitation.present?
+    %p You were invited as a #{@invitation.role}. Confirm below.
+
+  - if @suggested_role
+    %p.text-muted We think you're here as a #{@suggested_role}.
+
+  .row.mt-4
+    .col-6
+      = form_tag check_in_submit_path, method: :post do
+        = hidden_field_tag :role, "Student"
+        = submit_tag "I'm a Student",
+          class: "btn btn-lg btn-block #{"btn-primary" if @suggested_role == "Student"} #{"btn-outline-secondary" unless @suggested_role == "Student"}",
+          style: "width: 100%; min-height: 80px; font-size: 1.5rem;"
+
+    .col-6
+      = form_tag check_in_submit_path, method: :post do
+        = hidden_field_tag :role, "Coach"
+        = submit_tag "I'm a Coach",
+          class: "btn btn-lg btn-block #{"btn-primary" if @suggested_role == "Coach"} #{"btn-outline-secondary" unless @suggested_role == "Coach"}",
+          style: "width: 100%; min-height: 80px; font-size: 1.5rem;"
+```
+
+- [ ] **Step 3: Write the confirmation view**
+
+```haml
+-# app/views/check_ins/confirm.html.haml
+
+.text-center.py-5
+  %h1.text-success ✓ You're checked in!
+  %p.lead As a #{@invitation.role} at #{@parent.to_s}
+  %p.text-muted= l(@parent.date_and_time, format: :long)
+  = link_to "Back to Dashboard", dashboard_path, class: "btn btn-primary mt-4"
+```
+
+- [ ] **Step 4: Add public check-in routes**
+
+At the top level of `config/routes.rb` (outside any namespace). All use `:code` as the param name:
+
+```ruby
+get  "check-in/e/:code" => "check_ins#new", as: :check_in_e
+post "check-in/e/:code" => "check_ins#create"
+get  "check-in/e/:code/confirm" => "check_ins#confirm", as: :check_in_e_confirm
+get  "check-in/w/:code" => "check_ins#new", as: :check_in_w
+post "check-in/w/:code" => "check_ins#create"
+get  "check-in/w/:code/confirm" => "check_ins#confirm", as: :check_in_w_confirm
+```
+
+- [ ] **Step 5: Write controller tests**
+
+Uses request specs (not controller specs) since the polymorphic `load_parent` relies on request path to determine type. Or use `params` only since `load_parent` tries both lookups:
+
+```ruby
+# spec/controllers/check_ins_controller_spec.rb
+require "rails_helper"
+
+RSpec.describe CheckInsController do
+  let(:member) { create(:member) }
+  let(:event) { create(:event, check_in_code: "test-code-abc") }
+
+  before { sign_in member }
+
+  describe "GET new" do
+    it "renders the role selection page" do
+      get :new, params: { code: event.check_in_code }
+      expect(response).to be_successful
+    end
+
+    it "redirects to auth if not logged in" do
+      sign_out member
+      get :new, params: { code: event.check_in_code }
+      expect(response).to redirect_to("/auth/github")
+    end
+  end
+
+  describe "POST create" do
+    it "creates an invitation with source=check_in" do
+      post :create, params: { code: event.check_in_code, role: "Student" }
+      invitation = Invitation.last
+      expect(invitation.source).to eq("check_in")
+      expect(invitation.attending).to be true
+      expect(invitation.verified).to be true
+    end
+  end
+end
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+bundle exec rspec spec/controllers/check_ins_controller_spec.rb
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/controllers/check_ins_controller.rb \
+       app/views/check_ins/ \
+       config/routes.rb \
+       spec/controllers/check_ins_controller_spec.rb
+git commit -m "feat: add public check-in flow with role selection and confirmation"
+```
+
+---
+### Task 7: Update existing code paths to set `source`
+
+**Files:**
+- Modify: `app/services/invitation_manager.rb`
+- Modify: `app/controllers/admin/invitations_controller.rb`
+- Modify: `app/controllers/admin/invitation_controller.rb`
+- Modify: `app/controllers/events_controller.rb`
+- Modify: `app/controllers/workshops_controller.rb`
+
+**Interfaces:**
+- Consumes: Invitation and WorkshopInvitation models with `source` column
+- Produces: All invitation-creation paths set `source` explicitly
+
+- [ ] **Step 1: Update InvitationManager**
+
+`app/services/invitation_manager.rb`:
+
+```ruby
+# invite_students_to_event — add source:
+Invitation.new(event: event, member: student, role: 'Student', source: "email")
+
+# invite_coaches_to_event — add source:
+Invitation.new(event: event, member: coach, role: 'Coach', source: "email")
+
+# create_invitation — add source to find_or_initialize_by:
+invitation = WorkshopInvitation.find_or_initialize_by(
+  workshop: workshop, member: member, role: role, source: "email"
+)
+```
+
+- [ ] **Step 2: Update Admin::InvitationsController**
+
+`app/controllers/admin/invitations_controller.rb`, in `update_to_attending`:
+
+```ruby
+def update_to_attending
+  update_successful = @invitation.update(
+    attending: true,
+    rsvp_time: Time.zone.now,
+    automated_rsvp: true,
+    last_overridden_by_id: current_user.id,
+    source: "admin"
+  )
+```
+
+- [ ] **Step 3: Update Admin::InvitationController (event verification)**
+
+`app/controllers/admin/invitation_controller.rb`:
+
+```ruby
+# In update:
+invitation.update(attending: true, verified: true, verified_by: current_user, source: "admin")
+
+# In verify:
+invitation.update(verified: true, verified_by_id: current_user.id, source: "admin")
+```
+
+- [ ] **Step 4: Update EventsController**
+
+`app/controllers/events_controller.rb`:
+
+```ruby
+# rsvp action:
+Invitation.create(event: @event, member: member, role: 'Student', source: "email")
+
+# find_invitation_and_redirect_to_event:
+Invitation.find_or_create_by(event: @event, member: current_user, role: role, source: "email")
+```
+
+- [ ] **Step 5: Update WorkshopsController**
+
+`app/controllers/workshops_controller.rb`:
+
+```ruby
+# find_or_create_invitation:
+WorkshopInvitation.find_or_create_by(
+  workshop: workshop, member: user, role: role, source: "email"
+)
+```
+
+- [ ] **Step 6: Run existing tests to verify no regressions**
+
+```bash
+bundle exec rspec spec/controllers/admin/invitations_controller_spec.rb \
+  spec/controllers/admin/invitation_controller_spec.rb \
+  spec/services/invitation_manager_spec.rb \
+  spec/controllers/events_controller_spec.rb \
+  spec/controllers/workshops_controller_spec.rb
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/invitation_manager.rb \
+       app/controllers/admin/invitations_controller.rb \
+       app/controllers/admin/invitation_controller.rb \
+       app/controllers/events_controller.rb \
+       app/controllers/workshops_controller.rb
+git commit -m "feat: set source column in all invitation-creation code paths"
+```
+
+---
+### Task 8: Final integration check
+
+**Files:**
+- No file changes — verification only
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+bundle exec parallel_rspec spec/ -n 3
+```
+
+Verify all tests pass. Investigate and fix any failures.
+
+- [ ] **Step 2: Manual smoke test — admin flow**
+
+```bash
+bundle exec rails server
+```
+
+1. Log in as admin
+2. Navigate to an existing event admin page
+3. Verify "Check-in" button appears in toolbar
+4. Click to open instructions page
+5. Verify check_in_code is displayed
+6. Click "Download PDF"
+7. Verify PDF downloads
+
+- [ ] **Step 3: Manual smoke test — public check-in flow**
+
+1. Open a private/incognito window
+2. Navigate to `/check-in/e/<code>` (from step 2)
+3. Verify redirect to GitHub auth
+4. Sign in with GitHub
+5. Verify role-selection page renders
+6. Select a role
+7. Verify confirmation page shows "You're checked in!"
+8. Verify invitation record exists with `source: "check_in"`
+
+- [ ] **Step 4: Commit if any fixes made**
+
+```bash
+git commit -m "fix: post-integration adjustments"
+```

--- a/docs/superpowers/plans/2026-07-07-rsvp-close-time.md
+++ b/docs/superpowers/plans/2026-07-07-rsvp-close-time.md
@@ -1,0 +1,267 @@
+# RSVP Close Time Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add UI fields and wiring so organisers can set an RSVP closing date/time on workshops.
+
+**Architecture:** Mirror the existing `rsvp_opens_at` pattern — virtual attributes `rsvp_close_local_date`/`rsvp_close_local_time` convert to UTC-stored `rsvp_closes_at` via `datetime_from_fields`. The already-existing `rsvp_available?` method is wired into `available_for_rsvp?` and the invitation-accept path. Admin attendance management is unaffected.
+
+**Tech Stack:** Rails 8.1, HAML, SimpleForm, RSpec
+
+## Global Constraints
+
+- Follow existing patterns: virtual date+time fields, `before_validation` callback, `datetime_from_fields`, timezone-aware getter
+- `rsvp_closes_at` nil means RSVPs stay open until workshop starts (current default behaviour)
+- Only one validation: close time must be before workshop start time
+- `WorkshopInvitationController#accept` uses `workshop.rsvp_available?` to gate
+- `Admin::InvitationsController#update` is not gated (organisers bypass)
+- Labels on form: "Close RSVPs at"
+
+---
+### Task 1: Model Changes
+
+**Files:**
+- Modify: `app/models/workshop.rb`
+- Test: `spec/models/workshop_spec.rb`
+
+**Interfaces:**
+- Consumes: `datetime_from_fields` (already in model), `Workshop#time_zone` (delegated to chapter)
+- Produces: `Workshop#rsvp_closes_at` (timezone-aware getter), `Workshop#available_for_rsvp?` (updated)
+
+- [ ] **Step 1: Write the failing model tests**
+
+Add to `spec/models/workshop_spec.rb` in the `context 'time zone fields'` block:
+
+```ruby
+context 'rsvp_closes_at' do
+  it 'saves the local time in UTC' do
+    workshop.update!(
+      rsvp_close_local_date: '12/06/2015',
+      rsvp_close_local_time: '18:30'
+    )
+
+    expect(workshop.read_attribute(:rsvp_closes_at)).to eq(utc_time)
+  end
+
+  it 'retrieves the local time from the saved UTC value' do
+    workshop.update_attribute(:rsvp_closes_at, utc_time)
+
+    expect(workshop.rsvp_closes_at).to eq(pacific_time)
+    expect(workshop.rsvp_closes_at.zone).to eq('PDT')
+  end
+end
+```
+
+Add validation tests in the `validates` block:
+
+```ruby
+context '#rsvp_closes_at' do
+  it 'must be before the workshop start time' do
+    workshop.date_and_time = Time.zone.now + 1.hour
+    workshop.rsvp_closes_at = Time.zone.now + 2.hours
+
+    workshop.valid?
+    expect(workshop.errors[:rsvp_close_local_date]).to include("must be before the workshop start time")
+  end
+
+  it 'is valid when close time is before workshop start' do
+    workshop.date_and_time = Time.zone.now + 2.hours
+    workshop.rsvp_closes_at = Time.zone.now + 1.hour
+
+    expect(workshop.valid?).to be(true)
+  end
+
+  it 'is valid when no close time is set' do
+    workshop.rsvp_closes_at = nil
+    expect(workshop.valid?).to be(true)
+  end
+end
+```
+
+- [ ] **Step 2: Run model tests to verify they fail**
+
+Run: `bundle exec rspec spec/models/workshop_spec.rb -n 3`
+Expected: the new tests fail (methods/virtual attrs not defined), existing tests still pass
+
+- [ ] **Step 3: Implement model changes**
+
+In `app/models/workshop.rb`:
+
+Add `:rsvp_close_local_date, :rsvp_close_local_time` to `attr_accessor`:
+```ruby
+attr_accessor :local_date, :local_time, :local_end_time, :rsvp_open_local_date, :rsvp_open_local_time,
+              :rsvp_close_local_date, :rsvp_close_local_time
+```
+
+Add `before_validation :set_closes_at` callback:
+```ruby
+before_validation :set_date_and_time, :set_end_date_and_time, if: proc { |model| model.chapter_id.present? }
+before_validation :set_opens_at
+before_validation :set_closes_at
+```
+
+Add the timezone-aware getter after the existing `rsvp_opens_at` override:
+```ruby
+def rsvp_closes_at
+  return nil unless super
+
+  super.in_time_zone(time_zone)
+end
+```
+
+Change `available_for_rsvp?`:
+```ruby
+def available_for_rsvp?
+  invitable_yet? && rsvp_available?
+end
+```
+
+Add validation and private method in the `private` section, after `set_opens_at`:
+```ruby
+validate :rsvp_close_before_workshop_start
+
+# ... existing methods ...
+
+def set_closes_at
+  new_closes_at = datetime_from_fields(rsvp_close_local_date, rsvp_close_local_time)
+  self.rsvp_closes_at = new_closes_at if new_closes_at
+end
+
+def rsvp_close_before_workshop_start
+  return unless rsvp_closes_at && date_and_time
+  return if rsvp_closes_at < date_and_time
+  errors.add(:rsvp_close_local_date, "must be before the workshop start time")
+end
+```
+
+- [ ] **Step 4: Run model tests to verify they pass**
+
+Run: `bundle exec rspec spec/models/workshop_spec.rb -n 3`
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/workshop.rb spec/models/workshop_spec.rb
+git commit -m "feat: add rsvp_closes_at model support with validation"
+```
+
+---
+### Task 2: Controller + I18n Changes
+
+**Files:**
+- Modify: `app/controllers/admin/workshops_controller.rb`, `app/controllers/workshop_invitation_controller.rb`, `config/locales/en.yml`
+- Test: `spec/features/accepting_invitation_spec.rb`
+
+**Interfaces:**
+- Consumes: `Workshop#rsvp_available?`, I18n key
+- Produces: permitted params, gated accept action
+
+- [ ] **Step 1: Write test + implementation together**
+
+Add I18n key to `config/locales/en.yml` under `messages.invitations:` (around line 191):
+```yaml
+      closed: "RSVPs for this workshop are now closed."
+```
+
+Verify YAML: `bundle exec ruby -e "require 'yaml'; YAML.load_file('config/locales/en.yml')"`
+
+Add permitted params to `app/controllers/admin/workshops_controller.rb`, `workshop_params`:
+```ruby
+:rsvp_open_local_date, :rsvp_open_local_time, :description,
+:rsvp_close_local_date, :rsvp_close_local_time,
+:coach_spaces, :student_spaces,
+```
+
+Add accept guard to `app/controllers/workshop_invitation_controller.rb`, inside `def accept`, after the `already_rsvped` check:
+```ruby
+return back_with_message(t('messages.already_rsvped')) if @invitation.attending?
+return back_with_message(t('messages.invitations.closed')) unless @invitation.workshop.rsvp_available?
+```
+
+Add test to `spec/features/accepting_invitation_spec.rb` inside the `context '#workshop'` block:
+```ruby
+context 'when RSVPs are closed' do
+  scenario 'cannot accept an invitation after the close time' do
+    invitation.workshop.update(rsvp_closes_at: 1.hour.ago)
+
+    visit invitation_route
+    click_on 'Attend'
+
+    expect(page).to have_content('RSVPs for this workshop are now closed.')
+    expect(invitation.reload.attending).not_to be(true)
+  end
+end
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bundle exec rspec spec/features/accepting_invitation_spec.rb -n 1`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/controllers/admin/workshops_controller.rb app/controllers/workshop_invitation_controller.rb config/locales/en.yml spec/features/accepting_invitation_spec.rb
+git commit -m "feat: gate invitation acceptance by rsvp_closes_at"
+```
+
+---
+### Task 3: Form Fields
+
+**Files:**
+- Modify: `app/views/admin/workshops/_shared_form.html.haml`
+- Test: `spec/controllers/admin/workshops_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: `Workshop#rsvp_closes_at` (timezone-aware), `Workshop#rsvp_close_local_date`, `Workshop#rsvp_close_local_time` (virtual attrs)
+- Produces: form fields posted in `workshop_params`
+
+- [ ] **Step 1: Write controller param test**
+
+Add to `spec/controllers/admin/workshops_controller_spec.rb` inside the existing `context '#create'` block:
+
+```ruby
+it 'permits rsvp_close_local_date and rsvp_close_local_time' do
+  expect { post :create, params: { workshop: { rsvp_close_local_date: '01/12/2020', rsvp_close_local_time: '15:00' } } }
+    .not_to raise_error(ActionController::UnpermittedParameters)
+end
+```
+
+- [ ] **Step 2: Add form fields**
+
+In `app/views/admin/workshops/_shared_form.html.haml`, inside the RSVP details card, after the existing `rsvp_open_local_time` field:
+
+```haml
+        = f.input :rsvp_close_local_date, label: 'Close RSVPs at', as: :string, input_html: { data: { value: @workshop.rsvp_closes_at.try(:strftime, '%d/%m/%Y') } }
+        = f.input :rsvp_close_local_time, label: false, as: :string, input_html: { data: { value: @workshop.rsvp_closes_at.try(:time).try(:strftime, '%H:%M') } }
+```
+
+The first field gets the label "Close RSVPs at", the second has no label (time is implied). Matches the existing open-RSVP fields.
+
+- [ ] **Step 3: Run the param test**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb -n 1`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/views/admin/workshops/_shared_form.html.haml spec/controllers/admin/workshops_controller_spec.rb
+git commit -m "feat: add RSVP close time fields to workshop form"
+```
+
+---
+### Task 4: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `bundle exec parallel_rspec spec/ -n 3`
+Expected: all tests pass
+
+- [ ] **Step 2: Commit any final fixes**
+
+```bash
+git add -A
+git commit -m "chore: fix test adjustments after full suite run"
+```

--- a/docs/superpowers/plans/2026-07-19-switch-navigation-to-codebar-auth.md
+++ b/docs/superpowers/plans/2026-07-19-switch-navigation-to-codebar-auth.md
@@ -1,0 +1,200 @@
+# Switch navigation and auth redirects to `/auth/codebar` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route all user-facing sign-in flows to `/auth/codebar` instead of `/auth/github`.
+
+**Architecture:** Reuse the existing `ApplicationController#redirect_path` helper for the navigation and terms page links, change the helper to return the new auth path, and update the remaining hardcoded redirects in controllers and their specs.
+
+**Tech Stack:** Rails 8.1, HAML, RSpec, RuboCop.
+
+## Branch
+
+Create the feature branch from `master` before starting work:
+
+```bash
+git checkout -b feature/switch-auth-to-codebar
+```
+
+## Global Constraints
+- No new constants, helpers, or routes.
+- All `/auth/github` strings in the auth flow must become `/auth/codebar`.
+- `AuthServicesController#destroy` is intentionally left unchanged (it overrides `redirect_path` to `:services`).
+- Follow the repo’s Conventional Commits and branch-from-`master` workflow.
+
+---
+
+## File Structure
+
+- `app/controllers/application_controller.rb` — change `redirect_path` return value.
+- `app/views/layouts/_navigation.html.haml` — use `redirect_path` helper for Sign in link.
+- `app/views/terms_and_conditions/show.html.haml` — use `redirect_path` helper for login link.
+- `app/controllers/auth_services_controller.rb` — change `/login` redirect string.
+- `app/controllers/terms_and_conditions_controller.rb` — change unauthenticated POST redirect string.
+- `spec/controllers/auth_services_controller_spec.rb` — update redirect expectations.
+
+---
+
+### Task 1: Update the central redirect helper
+
+**Files:**
+- Modify: `app/controllers/application_controller.rb:111-112`
+- Test: `spec/controllers/auth_services_controller_spec.rb` (indirectly), plus any controller specs that exercise `authenticate_member!` or `AuthSessionsController#create`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `ApplicationController#redirect_path` returns `'/auth/codebar'`
+
+- [ ] **Step 1: Change the helper return value**
+
+```ruby
+  helper_method :redirect_path
+  def redirect_path
+    '/auth/codebar'
+  end
+```
+
+- [ ] **Step 2: Run the auth services controller specs**
+
+Run: `bundle exec rspec spec/controllers/auth_services_controller_spec.rb`
+Expected: 2 passes (controller still uses the hardcoded `/auth/github` path at this stage)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/controllers/application_controller.rb
+git commit -m "feat: redirect unauthenticated users to /auth/codebar"
+```
+
+---
+
+### Task 2: Update navigation and terms page links
+
+**Files:**
+- Modify: `app/views/layouts/_navigation.html.haml:46`
+- Modify: `app/views/terms_and_conditions/show.html.haml:18`
+- Test: existing feature/request specs that render the navigation or terms page
+
+**Interfaces:**
+- Consumes: `ApplicationController#redirect_path` (now `/auth/codebar`)
+- Produces: both views link to the new auth path
+
+- [ ] **Step 1: Update navigation sign-in link**
+
+```haml
+        - if !logged_in?
+          %li.nav-item
+            = link_to redirect_path, class: 'nav-link border-0' do
+              Sign in
+```
+
+- [ ] **Step 2: Update terms page login link**
+
+```haml
+          = link_to t('terms_and_conditions.login_link_text'), redirect_path
+```
+
+- [ ] **Step 3: Run any relevant view/feature specs**
+
+Run: `bundle exec rspec spec/views/layouts/ spec/features/ 2>/dev/null || true`
+Expected: no failures related to auth links
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/views/layouts/_navigation.html.haml app/views/terms_and_conditions/show.html.haml
+git commit -m "feat: use codebar auth for sign-in links"
+```
+
+---
+
+### Task 3: Update remaining hardcoded redirects
+
+**Files:**
+- Modify: `app/controllers/auth_services_controller.rb:7`
+- Modify: `app/controllers/terms_and_conditions_controller.rb:16`
+- Test: `spec/controllers/auth_services_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `GET /login` and unauthenticated `PATCH /terms_and_conditions` redirect to `/auth/codebar`
+
+- [ ] **Step 1: Update `/login` redirect**
+
+```ruby
+    redirect_to '/auth/codebar'
+```
+
+- [ ] **Step 2: Update terms POST redirect**
+
+```ruby
+      redirect_to '/auth/codebar'
+```
+
+- [ ] **Step 3: Update controller specs**
+
+```ruby
+      expect(response).to redirect_to("/auth/codebar")
+```
+
+```ruby
+      expect(response).to redirect_to("/auth/codebar")
+```
+
+- [ ] **Step 4: Run the updated controller specs**
+
+Run: `bundle exec rspec spec/controllers/auth_services_controller_spec.rb spec/controllers/terms_and_conditions_controller_spec.rb`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/auth_services_controller.rb app/controllers/terms_and_conditions_controller.rb spec/controllers/auth_services_controller_spec.rb
+git commit -m "feat: update hardcoded auth redirects to /auth/codebar"
+```
+
+---
+
+### Task 4: Verify and lint
+
+**Files:**
+- All files modified above
+
+**Interfaces:**
+- Consumes: all previous changes
+- Produces: clean test and lint output
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `make test`
+Expected: all green
+
+- [ ] **Step 2: Run RuboCop**
+
+Run: `bundle exec rubocop`
+Expected: no offences
+
+- [ ] **Step 3: Run HAML lint**
+
+Run: `bundle exec haml-lint app/views/layouts/_navigation.html.haml app/views/terms_and_conditions/show.html.haml`
+Expected: no offences
+
+- [ ] **Step 4: Commit any auto-corrected lint fixes**
+
+```bash
+git commit -am "style: lint fixes for auth url changes" || true
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** every item from the design doc is captured:
+  - `ApplicationController#redirect_path` → Task 1
+  - Navigation link → Task 2
+  - Terms page link → Task 2
+  - `/login` redirect → Task 3
+  - Terms POST redirect → Task 3
+  - Spec updates → Task 3
+- **Placeholder scan:** no TBDs, TODOs, or vague instructions.
+- **Type consistency:** no new types introduced; all paths are strings.

--- a/docs/superpowers/plans/2026-08-01-squash-pre-2026-migrations.md
+++ b/docs/superpowers/plans/2026-08-01-squash-pre-2026-migrations.md
@@ -1,0 +1,293 @@
+# Squash Pre-2026 Migrations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all 163 pre-2026 migration files with a single guarded baseline migration so that, going forward, the only individually-reviewed migrations are the 13 in strong_migrations' window (2026+), matching the practice Olle described in PR #2774.
+
+**Architecture:** Delete the pre-2026 migration files and add one baseline migration at timestamp `20251230000000` whose `up` rebuilds the pre-2026 schema and is a **no-op** on already-migrated DBs (guarded by `table_exists?`). The 13 in-window 2026 migrations stay untouched. `db/schema.rb` remains the source of truth for fresh builds via `db:prepare`/`db:schema:load`; the baseline preserves the documented `rake db:migrate` bootstrap path and Heroku's `release: db:migrate`.
+
+**Tech Stack:** Rails 8.1, ActiveRecord migrations, PostgreSQL, strong_migrations 2.8.
+
+## Global Constraints
+
+- `StrongMigrations.start_after = 20260101000000` — **unchanged**. Any migration with timestamp `<= 20260101000000` is not checked by strong_migrations (verified in `strong_migrations-2.8.0/lib/strong_migrations/checker.rb:149` and `strong_migrations.rb:83`). So the baseline `20251230000000` is never audited.
+- Heroku `Procfile` runs `release: bundle exec rake db:migrate` on every deploy, staging AND production. Both DBs already carry all 176 schema-migration versions.
+- Fresh dev bootstrap (AGENTS.md) is `rake db:create db:migrate db:seed` — `db:migrate` from an empty DB must succeed after the squash.
+- CI tests boot via `bundle exec rake parallel:setup` (= `db:create` + `db:schema:load`) — already schema-based, immune to migration deletion, but must stay green.
+- Keep **all 13** in-window (≥20260101000000) migrations. Do not attempt to keep only the 6 annotated ones: they interleave with the other 7 in-window migrations and are not a contiguous suffix, so they cannot be replayed against a baseline.
+- Do not hand-write the baseline from the committed `db/schema.rb` at the cutoff — it is stale (last regenerated at `2025_08_23_151717`, missing 2025-11-20 indexes). Generate the baseline from a live migration run.
+- Do not bypass the `table_exists?` guard — it is what makes Heroku's `release: db:migrate` a no-op on deployed DBs.
+- Each task ends with a commit; never commit to `master`.
+
+---
+
+### Task 1: Generate the true pre-2026 schema snapshot
+
+**Files:**
+- Create: `tmp/schema_pre_2026.rb` (gitignored scratch snapshot; generated, not committed)
+
+**Interfaces:**
+- Produces: `tmp/schema_pre_2026.rb`, a live dump of the exact post-migrate state of the 163 pre-2026 migrations. Tasks 2–4 depend on this snapshot being exact — it is the source the baseline is generated from.
+
+- [ ] **Step 1: Produce the snapshot**
+
+1. Set aside the 13 kept migrations so only the 163 pre-2026 remain:
+   ```bash
+   mkdir -p tmp/kept_2026 && mv db/migrate/2026*.rb tmp/kept_2026/
+   ```
+2. Point at a scratch database and migrate from empty:
+   ```bash
+   DATABASE_URL=postgresql://localhost/codebar_squash_scratch bundle exec rails db:create db:migrate
+   ```
+   Expected: exactly the 163 pre-2026 migrations run; no strong_migrations block (all pre-2026 are below `start_after`).
+3. Dump the resulting schema as the snapshot:
+   ```bash
+   DATABASE_URL=postgresql://localhost/codebar_squash_scratch bundle exec rails db:schema:dump
+   cp db/schema.rb tmp/schema_pre_2026.rb
+   ```
+4. Restore the 13 and drop the scratch DB:
+   ```bash
+   mv tmp/kept_2026/2026*.rb db/migrate/ && git checkout db/schema.rb
+   DATABASE_URL=postgresql://localhost/codebar_squash_scratch bundle exec rails db:drop
+   ```
+
+- [ ] **Step 2: Verify the snapshot**
+
+```bash
+grep -n "version:" tmp/schema_pre_2026.rb | head -1
+# Expected: 2025_11_20_090000 (the last, 2025-11-20 migration) — NOT 2025_08_23
+grep -c "add_foreign_key" tmp/schema_pre_2026.rb
+grep -c "t.index\|add_index" tmp/schema_pre_2026.rb  # > 0, indexes present
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "chore(migrations): capture pre-2026 schema snapshot for squash"
+```
+
+---
+
+## Task 2: Generate the guarded baseline migration
+
+**Files:**
+- Create: `db/migrate/20251230000000_squash_pre_2026_migrations.rb`
+- Create: `scripts/generate_squash_migration.rb` (real, working generator this time)
+
+**Interfaces:**
+- Consumes: `tmp/schema_pre_2026.rb` (Task 1).
+- Produces: `SquashPre2026Migrations.up` — a self-contained `up` that (a) returns early on any already-populated DB, and (b) otherwise rebuilds the pre-2026 schema. Task 3 deletes files; Task 4 verifies.
+
+- [ ] **Step 1: Write the generator**
+
+Create `scripts/generate_squash_migration.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+# Generates db/migrate/20251230000000_squash_pre_2026_migrations.rb from a
+# live dump of the pre-2026 schema (tmp/schema_pre_2026.rb).
+#
+# Run from repo root:  ruby scripts/generate_squash_migration.rb
+
+require "date"
+
+SNAPSHOT = File.expand_path("tmp/schema_pre_2026.rb", Dir.pwd)
+OUT      = File.expand_path("db/migrate/20251230000000_squash_pre_2026_migrations.rb", Dir.pwd)
+VERSION  = 2025_11_20_090000 # last pre-2026 migration version
+
+raise "no snapshot" unless File.exist?(SNAPSHOT)
+
+# Pull just the body of the ActiveRecord::Schema[8.1].define(...) block.
+text = File.read(SNAPSHOT)
+body = text[/\bdefine\s*\([^)]*\)\s*do\s*\n(.*)\n\s*end\s*\z/m, 1] or raise "could not extract schema body"
+
+migration = <<~RB
+  # frozen_string_literal: true
+
+  # ONE-TIME SQUASH of all pre-2026 migrations (163 files). Generated by
+  # scripts/generate_squash_migration.rb from #{SNAPSHOT} (#{VERSION}).
+  # db/schema.rb -- not the per-year migration files -- is the source of truth
+  # for new databases. Guarded so existing deployments are unaffected by the
+  # Heroku `release: db:migrate` step.
+  class SquashPre2026Migrations < ActiveRecord::Migration[8.1]
+    def up
+      return if table_exists?(:members) # no-op on already-migrated databases
+
+  #{body.lines.map { |l| '      ' + l }.join}
+    end
+
+    def down
+      raise ActiveRecord::IrreversibleMigration
+    end
+  end
+RB
+
+File.write(OUT, migration)
+puts "wrote #{OUT}"
+```
+
+- [ ] **Step 2: Run the generator**
+
+```bash
+ruby scripts/generate_squash_migration.rb
+```
+
+- [ ] **Step 3: Lint the generated file (essential auto-generated clean-up)**
+
+```bash
+bundle exec rubocop db/migrate/20251230000000_squash_pre_2026_migrations.rb -A
+# fix any auto-fixable style so the file passes the repo's rubocop gate
+bundle exec rubocop db/migrate/20251230000000_squash_pre_2026_migrations.rb # must be clean
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add db/migrate/20251230000000_squash_pre_2026_migrations.rb scripts/generate_squash_migration.rb
+git commit -m "feat(migrations): add guarded baseline for pre-2026 schema"
+```
+
+---
+
+## Task 3: Delete the 163 pre-2026 migrations
+
+**Files:**
+- Delete: every `db/migrate/*.rb` whose filename does NOT start with `2026` (163 files), plus `tmp/schema_pre_2026.rb`.
+
+**Interfaces:**
+- Consumes none directly; prerequisites Task 1 + Task 2 (baseline exists and guard confirmed to compile).
+
+- [ ] **Step 1: Delete the files**
+
+```bash
+# Confirm exactly 163 non-2026 migration files will be removed:
+{ ls db/migrate | grep -v '^2026' | grep -c '\.rb$'; }   # expect 163
+{ ls db/migrate | grep '^2026'; }                          # expect the 13 kept
+```
+
+Then remove them:
+
+```bash
+git rm db/migrate/*.rb --ignore-unmatch \
+  | while read -r path; do [[ "$(basename "$path")" == 2026* ]] || rm -f "$path"; done
+```
+*Prefer an explicit `git rm` of the 163 listed filenames; the glob/pipe is only a fallback. Reviewer must be able to see the keep-list (13) and the deleted-count (163).*
+
+- [ ] **Step 2: Remove the now-surplus snapshot**
+
+```bash
+git rm tmp/schema_pre_2026.rb 2>/dev/null || true
+```
+
+- [ ] **Step 3: Confirm file counts and strong_migrations window**
+
+```bash
+ls db/migrate | grep -c '\.rb$'    # expect 14 (baseline + 13)
+grep -n "start_after" config/initializers/strong_migrations.rb  # unchanged: 20260101000000
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "chore(migrations): drop 163 pre-2026 migration files in favour of the squashed baseline"
+```
+
+---
+
+## Task 4: Verify fresh-build and existing-DB parity
+
+**Files:**
+- Read-only verification; no production code changes.
+
+- [ ] **Step 1: Fresh DB replay = current schema (the core assertion)**
+
+On a scratch DB, migrate from empty then dump, and require equality with HEAD `db/schema.rb`:
+
+```bash
+DATABASE_URL=postgresql://localhost/codebar_squash_verify bundle exec rails db:create db:migrate
+DATABASE_URL=postgresql://localhost/codebar_squash_verify bundle exec rails db:schema:dump
+git diff --exit-code db/schema.rb   # MUST be empty: baseline + 13 reproduces the committed schema exactly
+```
+
+If this diff shows anything other than zero, the square is wrong: the baseline body drifted from the true pre-2026 schema or a 2026 migration was folded/omitted. Fix by regenerating (Task 2) — never hand-edit.
+
+- [ ] **Step 2: Existing-DB no-op (Heroku release path)**
+
+Copy the produced baseline onto a DB that already carries all 176 schema-migration stamps (e.g. a local clone of prod schema state), then migrate:
+
+```bash
+DATABASE_URL=postgresql://localhost/codebar_squash_existing bundle exec rails db:migrate
+# Expected: only the baseline applies and its `table_exists?(:members)` guard returns, no-op.
+DATABASE_URL=postgresql://localhost/codebar_squash_existing bundle exec rails db:schema:dump
+git diff -- db/schema.rb   # must remain empty
+```
+
+- [ ] **Step 3: strong_migrations window still enforced on fresh boot**
+
+```bash
+# on the fresh DB (Step 1) re-run migrate with strong_migrations active:
+RAILS_ENV=test DATABASE_URL=postgresql://localhost/codebar_squash_verify bundle exec rails db:migrate:status
+# expect: the 6 annotated 2026 migrations listed with their safety_assured blocks; baseline not flagged
+```
+
+- [ ] **Step 4: CI seeds and tests still boot**
+
+```bash
+bundle exec rake parallel:setup   # schema-based, must stay green
+bundle exec parallel_rspec spec/ -n 3    # or `make test` — full suite green
+```
+
+- [ ] **Step 5: Commit (no code change if golden)**
+
+```bash
+git checkout -- db/schema.rb 2>/dev/null || true
+git log --oneline -- db/migrate | head -30   # shows the baseline + 13 recent
+```
+
+---
+
+## Task 5: PR split & docs
+
+**Files:**
+- Modify: `docs/AGENTS.md` (migration section) - optional.
+
+- [ ] **Step 1: Add a one-paragraph note in AGENTS.md**
+
+Precisely this wording:
+
+```
+## Migrations
+
+Pre-2026 migrations were squashed into a single baseline migration
+(`20251230000000_squash_pre_2026_migrations`) that rebuilds the pre-2026
+schema and is a no-op on already-migrated databases. `db/schema.rb` is the
+source of truth for new databases. New migrations are audited by
+strong_migrations from 2026-01-01 onwards; the baseline predates that window
+and is intentionally not audited.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/AGENTS.md
+git commit -m "docs: note migration squash baseline"
+```
+
+---
+
+## Risks / Costs
+
+- **Fork divergence:** deleting upstream `codebar/planner` history means every future upstream `git pull`/merge conflicts on the 163 deleted files. Accepted by the author; mitigate by merging upstream with `-X theirs` on `db/migrate` or via a rebase-on-demand.
+- **Fresh Heroku bootstrap** relies on the baseline (guarded) + schema:load; already-deployed prod/staging are untouched because the guard returns.
+- **Lost `down` migrations** for the pre-2026 set — accepted (many were already irreversible).
+- **Baseline drift** — mitigated by Task 4's diff-assertion; regenerate, never hand-edit.
+- **Only the 6 annotated migrations are *not* kept; all 13 in-window are.** Kept so `db:migrate` bootstrap and the interleaved ordering stay replayable.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** squash ✓ (Tasks 1–3), strong_migrations window preserved ✓ (constraint + Task 3), Heroku parity ✓ (Task 4), dev bootstrap ✓ (Task 4), docs ✓ (Task 5).
+- **Placeholder scan:** no TBD; generator (Task 2) is complete code; Task 1 is pure shell procedure. Clean.
+- **Consistency:** version guard `table_exists?(:members)`; strong_migrations cutoff `20260101000000`; baseline `20251230000000` (< cutoff, so unaudited); 13 kept, 163 deleted; all used consistently across tasks.

--- a/docs/superpowers/plans/2026-08-08-workshop-rsvp-page.md
+++ b/docs/superpowers/plans/2026-08-08-workshop-rsvp-page.md
@@ -1,0 +1,415 @@
+# Workshop "RSVP members" Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 4,000-item RSVP dropdown on the admin workshop show page with a dedicated, search-driven "RSVP members" page where organisers search invited members by name and toggle their RSVP state.
+
+**Architecture:** A new member route (`GET /admin/workshops/:id/rsvp`) on `Admin::WorkshopsController` renders a view that shows the eligible invited-member count, a name-search form, and paginated (Pagy, 20/page) results for the workshop's invited members (any invitation state — attending, pending, declined). Each result row posts the inverted `attending` value to the **existing** `Admin::InvitationsController#update`, which already handles both directions (email, waiting-list removal, `redirect_back`). The show page's `<select>` is replaced by a link to the new page.
+
+**Tech Stack:** Rails 8.1, HAML, Bootstrap 5, Pagy (existing `shared/pagination` partial), RSpec + Fabrication.
+
+## Global Constraints
+
+- Branch from `fix/admin-workshop-nplus1` (PR #2797 is not yet merged): the `count_queries` test helper and the capped `recent_invites` dropdown block this plan relies on exist on that branch, not on `master`. Create the feature branch from that branch's tip.
+- HAML for views; no new CSS abstractions; Bootstrap 5 classes.
+- No JavaScript; plain GET (search) and PUT (toggle) forms.
+- Mutations MUST go through the existing `Admin::InvitationsController#update` — do not add new mutation logic.
+- Search pool = members with an invitation row for this workshop, excluding banned (`Member.not_banned`). No invitation creation.
+- Pagination via the standard `pagy(scope, items: 20)` helper and `shared/pagination` partial, matching `Admin::GroupsController#show`.
+- RuboCop clean, max line length 120. TDD: write failing spec, verify red, implement, verify green, commit.
+- Work in the existing worktree/branch for this feature; never commit to `master`.
+
+---
+
+## File Structure
+
+- Modify: `config/routes.rb` — add `get 'rsvp'` member route in the admin `resources :workshops` block (next to `get 'changes'`).
+- Modify: `app/controllers/admin/workshops_controller.rb` — add `rsvp` action, `paginate_matching_invitations` helper, and `rsvp` to the `set_workshop_by_id` before_action.
+- Create: `app/views/admin/workshops/rsvp.html.haml` — search form, eligible count, results table with toggle forms, pagination.
+- Modify: `app/views/admin/workshops/_invitation_management.html.haml` — replace the `<select>` form with an "RSVP a member" link.
+- Modify: `spec/controllers/admin/workshops_controller_spec.rb` — specs for `GET #rsvp`, toggle redirect, and show-page assertions.
+- Test: `spec/queriers` — none (no query object needed).
+
+---
+
+### Task 1: `rsvp` route and controller action
+
+**Files:**
+- Modify: `config/routes.rb` (admin `resources :workshops` block, ~line 145-157)
+- Modify: `app/controllers/admin/workshops_controller.rb`
+- Test: `spec/controllers/admin/workshops_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: the admin member-route param `params[:workshop_id]` (sets `@workshop`); `Member.not_banned` scope; `Member.find_members_by_name(name)` (public class method, ILIKE on `CONCAT(name,' ',surname)`); `pagy(scope, items:)` helper.
+- Produces: `Admin::WorkshopsController#rsvp` — assigns `@workshop`, `@eligible_count` (Integer, always), and `@pagy`/`@invitations` (only when `params[:q]` present; `@invitations` is a Pagy-page of `WorkshopInvitation` with `member` eager-loaded).
+
+- [ ] **Step 1: Write the failing controller specs**
+
+Add to `spec/controllers/admin/workshops_controller_spec.rb`, inside the existing `describe` blocks (the file already has `workshop`, `admin`, and `login_as_organiser(admin, workshop.chapter)` in `before`):
+
+```ruby
+describe 'GET #rsvp' do
+  let(:member) { Fabricate(:member, name: 'Zoe', surname: 'Searchable') }
+  let!(:matching) { Fabricate(:workshop_invitation, workshop: workshop, member: member, attending: nil) }
+  let!(:other_member) { Fabricate(:member, name: 'Aaron', surname: 'Other') }
+  let!(:other) { Fabricate(:workshop_invitation, workshop: workshop, member: other_member, attending: true) }
+  let!(:banned_member) { Fabricate(:member, name: 'Bob', surname: 'Banned') }
+  let!(:banned_invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: banned_member, attending: nil) }
+
+  before do
+    Fabricate(:ban, member: banned_member)
+    Fabricate(:workshop_invitation, member: matching) # an invite for a DIFFERENT workshop
+  end
+
+  it 'is not accessible without organiser rights' do
+    allow(controller).to receive(:manager?).and_return(false)
+    get :rsvp, params: { workshop_id: workshop.id }
+
+    expect(response).to redirect_to(root_path)
+  end
+
+  it 'assigns the eligible count and no invitations when no search term is given' do
+    get :rsvp, params: { workshop_id: workshop.id }
+
+    expect(assigns(:eligible_count)).to eq(2) # matching + other; banned is excluded from the count
+    expect(assigns(:invitations)).to be_nil
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'returns only matching invited members for the workshop, excluding banned members' do
+    get :rsvp, params: { workshop_id: workshop.id, q: 'Zoe' }
+
+    expect(assigns(:invitations).map(&:id)).to eq([matching.id])
+  end
+
+  it 'excludes banned members from search results' do
+    get :rsvp, params: { workshop_id: workshop.id, q: 'Banned' }
+
+    expect(assigns(:invitations)).to be_empty
+  end
+
+  it 'filters by member name case-insensitively across first and surname' do
+    get :rsvp, params: { workshop_id: workshop.id, q: 'SEARCHA' }
+
+    expect(assigns(:invitations).map(&:id)).to eq([matching.id])
+  end
+
+  it 'eager loads member so rendering does not query per row' do
+    query_count = count_queries { get :rsvp, params: { workshop_id: workshop.id, q: 'Zoe' } }
+
+    expect(query_count).to be < 8
+  end
+end
+```
+
+Note: `manager?` (login + admin/organiser) is the existing guard in `ApplicationController#authenticate_admin_or_organiser!`, so stubbing it to false reproduces the unauthorised redirect the admin layer already uses. `count_queries` is already defined in this spec file on the `fix/admin-workshop-nplus1` branch (added in PR #2797) — do not re-add it.
+
+- [ ] **Step 2: Run the specs to verify they fail**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb -e "GET #rsvp"`
+Expected: FAIL — `ActionController::UrlGenerationError` (no route) and `The action 'rsvp' could not be found`.
+
+- [ ] **Step 3: Add the route**
+
+In `config/routes.rb`, inside the admin block `resources :workshops, except: [:index] do ... end` (next to `get 'changes'`):
+
+```ruby
+      get 'rsvp'
+```
+
+Verify: `bundle exec rails routes | grep admin_workshop_rsvp` → `admin_workshop_rsvp GET /admin/workshops/:workshop_id/rsvp`.
+
+Note: like the other member routes in this block (`changes`, `attendees_checklist`), the admin `resources :workshops` block binds the workshop segment as `:workshop_id` — NOT `:id`. So the action must read `params[:workshop_id]`.
+
+- [ ] **Step 4: Implement the controller action**
+
+In `app/controllers/admin/workshops_controller.rb`, add the action and private helper (place the action near the other public actions; the helper in the private section):
+
+```ruby
+  def rsvp
+    @workshop = Workshop.find(params[:workshop_id])
+    authorize @workshop, :update?
+
+    @eligible_count = @workshop.invitations
+                               .joins(:member)
+                               .merge(Member.not_banned)
+                               .count
+
+    return unless params[:q].present?
+
+    @pagy, @invitations = paginate_matching_invitations(params[:q])
+  end
+```
+
+```ruby
+  def paginate_matching_invitations(query)
+    eligible = @workshop.invitations
+                        .joins(:member)
+                        .merge(Member.not_banned)
+    invitations = eligible.merge(Member.find_members_by_name(query))
+                          .includes(:member)
+                          .order('members.name, members.surname')
+    pagy(invitations, items: 20)
+  end
+```
+
+Note: do **not** use the `set_workshop_by_id` before_action (it reads `params[:id]`, which the member route does not provide). Load `@workshop` from `params[:workshop_id]` inside the action, keeping it undecorated so Pundit still resolves `WorkshopPolicy`. `authorize @workshop, :update?` uses the existing `WorkshopPolicy#update?` (`admin_or_chapter_organiser?`); no new policy method needed.
+
+- [ ] **Step 5: Create a minimal placeholder view**
+
+Create `app/views/admin/workshops/rsvp.html.haml` with just:
+
+```haml
+%p RSVP members
+```
+
+(The full view is Task 2.) This makes the controller-rendered response succeed.
+
+- [ ] **Step 6: Run the specs to verify they pass**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb -e "GET #rsvp"`
+Expected: all `GET #rsvp` examples pass.
+
+- [ ] **Step 7: Run the full file + lint**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb`
+Expected: all pass (existing examples plus new ones).
+Run: `bundle exec rubocop app/controllers/admin/workshops_controller.rb spec/controllers/admin/workshops_controller_spec.rb`
+Expected: no offenses.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add config/routes.rb app/controllers/admin/workshops_controller.rb app/views/admin/workshops/rsvp.html.haml spec/controllers/admin/workshops_controller_spec.rb
+git commit -m "feat: add admin workshop RSVP page route and action"
+```
+
+---
+
+### Task 2: `rsvp` view with search, count, toggle, pagination
+
+**Files:**
+- Modify: `app/views/admin/workshops/rsvp.html.haml`
+- Modify: `spec/controllers/admin/workshops_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: `@workshop` (Workshop), `@eligible_count` (Integer), `@pagy` (Pagy), `@invitations` (Pagy page of WorkshopInvitation with `member` loaded, may be nil); route helpers `admin_workshop_rsvp_path(@workshop)`, `admin_workshop_path(@workshop)`, `admin_member_path(member)`, `admin_workshop_invitation_path(@workshop, invitation)`; `shared/pagination` partial; existing `Admin::InvitationsController#update` (PUT with `attending` param).
+- Produces: rendered HTML — the complete page.
+
+- [ ] **Step 1: Write a failing view-level controller spec**
+
+Add to the rsvp describe block in `spec/controllers/admin/workshops_controller_spec.rb`:
+
+```ruby
+  it 'renders the eligible count, search box, back link and toggle forms' do
+    get :rsvp, params: { workshop_id: workshop.id, q: 'Zoe' }
+
+    expect(response.body).to include('invited members')
+    expect(response.body).to include('Search')
+    expect(response.body).to include('Back to')
+    # q: 'Zoe' only returns `matching` (attending: nil) -> its button says 'RSVP'
+    expect(response.body).to include('RSVP')
+    expect(response.body).not_to include('Mark as not attending')
+  end
+
+  it 'renders the not-attending toggle for an already-attending result' do
+    get :rsvp, params: { workshop_id: workshop.id, q: 'Aaron' }
+
+    expect(response.body).to include('Mark as not attending')
+  end
+```
+
+Add the toggle mutation example to **`spec/controllers/admin/invitations_controller_spec.rb`** (create the file if it does not exist), NOT the workshops controller — `put :update` must dispatch to `Admin::InvitationsController#update`, which is where the toggle routes live:
+
+```ruby
+RSpec.describe Admin::InvitationsController, type: :controller do
+  let!(:workshop) { Fabricate(:workshop) }
+  let(:admin) { Fabricate(:member) }
+  let(:member) { Fabricate(:member, name: 'Zoe', surname: 'Searchable') }
+  let!(:invitation) { Fabricate(:workshop_invitation, workshop: workshop, member: member, attending: nil) }
+
+  before { login_as_organiser(admin, workshop.chapter) }
+
+  describe 'PUT #update (RSVP toggle from the rsvp page)' do
+    it 'marks an invitation attending and redirects back to the rsvp page' do
+      request.env['HTTP_REFERER'] = admin_workshop_rsvp_url(workshop)
+      put :update, params: { workshop_id: workshop.id, id: invitation.token, attending: 'true' }
+
+      expect(invitation.reload.attending).to be(true)
+      expect(response).to redirect_to(admin_workshop_rsvp_url(workshop))
+    end
+
+    it 'marks an attending invitation as not attending' do
+      invitation.update!(attending: true)
+      request.env['HTTP_REFERER'] = admin_workshop_rsvp_url(workshop)
+      put :update, params: { workshop_id: workshop.id, id: invitation.token, attending: 'false' }
+
+      expect(invitation.reload.attending).to be(false)
+      expect(response).to redirect_to(admin_workshop_rsvp_url(workshop))
+    end
+  end
+end
+```
+
+Note: `admin_workshop_invitation_path(@workshop, invitation)` (two args) resolves to the plural `resources :invitations, only: [:update]` route, so `params[:id]` is the invitation token (via `Invitation#to_param`) and `set_invitation` finds it with `@workshop.invitations.find_by!(token: invitation_id)`; `invitation_id` reads `params[:id]` when there is no `:workshop` key (there isn't — the toggle posts `attending` only). `update`'s non-XHR branch `redirect_back`s to the Referer (the rsvp page), preserving search + page.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb -e "rsvp" `
+Expected: FAIL — view only renders "RSVP members" placeholder; strings like `invited members` not present.
+
+- [ ] **Step 3: Implement the full view**
+
+Replace the placeholder `app/views/admin/workshops/rsvp.html.haml` with:
+
+```haml
+.container.py-4.py-lg-5
+  .row.mb-3
+    .col
+      = link_to 'Back to workshop', admin_workshop_path(@workshop), class: 'text-muted'
+      %h2.mt-2 RSVP members
+      %p.text-muted
+        #{number_with_delimiter(@eligible_count)} invited members (total)
+
+  .row.mb-4
+    .col.col-md-10.col-lg-8
+      = form_tag admin_workshop_rsvp_path(@workshop), method: :get, class: 'row g-3 align-items-end' do
+        .col-auto.col-md-6
+          = label_tag :q, 'Member name', class: 'form-label'
+          = text_field_tag :q, params[:q], placeholder: 'Enter member name', class: 'form-control'
+        .col-auto
+          = submit_tag 'Search', class: 'btn btn-primary'
+
+  - if params[:q].present?
+    .row
+      .col.col-md-10.col-lg-8
+        - if @invitations.empty?
+          %p.text-muted No members found for "#{params[:q]}".
+        - else
+          %table.table.table-hover
+            %thead
+              %tr
+                %th Member
+                %th Role
+                %th Status
+                %th
+            %tbody
+              - @invitations.each do |invitation|
+                %tr
+                  %td
+                    = link_to invitation.member.full_name, admin_member_path(invitation.member)
+                    %br
+                    %small.text-muted= invitation.member.email
+                  %td= invitation.role
+                  %td
+                    - if invitation.attending?
+                      %span.badge.bg-success Attending
+                    - elsif invitation.attending == false
+                      %span.badge.bg-secondary Not attending
+                    - else
+                      %span.badge.bg-warning No response
+                  %td
+                    = form_tag admin_workshop_invitation_path(@workshop, invitation), method: :put, class: 'd-inline' do
+                      = hidden_field_tag :attending, invitation.attending? ? 'false' : 'true'
+                      = submit_tag(invitation.attending? ? 'Mark as not attending' : 'RSVP', class: 'btn btn-sm btn-outline-primary', aria: { label: "#{invitation.member.full_name} \u2014 #{invitation.attending? ? 'mark as not attending' : 'RSVP'}" })
+          = render partial: 'shared/pagination', locals: { pagy: @pagy, model: 'invitation' } if @pagy&.pages&.positive?
+  - else
+    %p.text-muted Search for a member to manage their RSVP.
+```
+
+Notes:
+- `@invitations` is only assigned when `params[:q]` is present (Task 1), so the `if params[:q].present?` guard matches. Use `@invitations.empty?` for the no-match message (Pagy returns an array).
+- The toggle form posts `attending` as the string `'true'`/`'false'` (hidden field) — `update_to_attending` compares `attending.eql?('true')`.
+- `admin_workshop_invitation_path(@workshop, invitation)` renders `/admin/workshops/:workshop_id/invitations/:token` (the plural `resources :invitations, only: [:update]` route; `:id` = token via `to_param`). `update`'s non-XHR branch `redirect_back`s, returning to the rsvp page with search + page preserved.
+
+- [ ] **Step 4: Run the specs to verify they pass**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb -e "rsvp" -e "GET #rsvp"`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/views/admin/workshops/rsvp.html.haml spec/controllers/admin/workshops_controller_spec.rb
+git commit -m "feat: render RSVP members page with search, count and toggle"
+```
+
+---
+
+### Task 3: Replace the dropdown on the show page with a link
+
+**Files:**
+- Modify: `app/views/admin/workshops/_invitation_management.html.haml`
+- Modify: `spec/controllers/admin/workshops_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: `@workshop`, `admin_workshop_rsvp_path(@workshop)` (from Task 1).
+- Produces: show page with the "RSVP a member" link and no invitation `<select>`.
+
+- [ ] **Step 1: Write a failing spec asserting the dropdown is gone**
+
+Add to the `GET #show` describe block in `spec/controllers/admin/workshops_controller_spec.rb`:
+
+```ruby
+  it 'links to the RSVP members page instead of rendering an invitations select' do
+    Fabricate(:workshop_invitation, workshop: workshop, attending: nil)
+    get :show, params: { id: workshop.id }
+
+    expect(response.body).to include(admin_workshop_rsvp_path(workshop))
+    expect(response.body).not_to include('chosen-select')
+    expect(response.body).not_to include('outstanding invitations')
+  end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb -e "GET #show"`
+Expected: FAIL — the current page includes `chosen-select` and no link to the rsvp page.
+
+- [ ] **Step 3: Replace the select block**
+
+In `app/views/admin/workshops/_invitation_management.html.haml`, **delete** the entire `= simple_form_for :workshop, url: admin_workshop_invitations_path(@workshop, attending: true) ... do |f| ... end` block (the one containing `f.select :invitations`, `recent_invites`, and the "outstanding invitations" caption added in PR #2797). Replace it with:
+
+```haml
+.link-to-rsvp.mb-4
+  = link_to 'RSVP a member', admin_workshop_rsvp_path(@workshop), class: 'btn btn-sm btn-outline-primary'
+```
+
+Keep the surrounding structure (the counts paragraph and the `See all invitations' statuses` link) unchanged.
+
+- [ ] **Step 4: Run the specs to verify they pass**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb`
+Expected: all pass (including the new rsvp specs from Tasks 1-2 and the dropdown-removal assertion).
+
+- [ ] **Step 5: Lint and full suite**
+
+Run:
+- `bundle exec rubocop app/controllers/admin/workshops_controller.rb spec/controllers/admin/workshops_controller_spec.rb`
+- `bundle exec rspec spec/controllers/ spec/requests/`
+Expected: no offenses; all controller/request specs green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/views/admin/workshops/_invitation_management.html.haml spec/controllers/admin/workshops_controller_spec.rb
+git commit -m "feat: replace admin workshop RSVP dropdown with link to RSVP page"
+```
+
+---
+
+### Task 4: End-to-end verification against production data
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run any remaining full suites**
+
+Run: `bundle exec rspec spec/`
+Expected: green.
+
+- [ ] **Step 2: Manual check against the production dump**
+
+With the server running against `codebar_production_dump`:
+1. `GET /admin/workshops/3824` — confirm the "RSVP a member" link renders and the page body contains no `chosen-select`.
+2. `GET /admin/workshops/3824/rsvp` — confirm it loads fast (one COUNT query), shows the eligible count, and shows no member rows until a name is searched.
+3. Search "Morgan" — confirm one result, paged at 20, with an RSVP/toggle button; toggling redirects back and flips attendance (check in the DB).

--- a/docs/superpowers/plans/2026-09-07-organiser-activity-strip.md
+++ b/docs/superpowers/plans/2026-09-07-organiser-activity-strip.md
@@ -1,0 +1,1577 @@
+# Organiser Activity Weekly Strip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record every member, organiser, and relevant admin action in the existing `activities` table, then render a 52-week GitHub-status-style activity strip on the admin member profile.
+
+**Architecture:** Two PRs. PR 1 adds `MemberActivityRecorder` (single funnel writing `PublicActivity::Activity` rows with the acting member as `owner`) and instruments all write sites. PR 2 adds `Admin::Members::ActivityStrip` (one indexed query, ISO-week bucketing, three states) and `Admin::Members::ActivityStripComponent` (SVG bars), rendered on `/admin/members/:id` behind an organiser check.
+
+**Tech Stack:** Rails 8.1, public_activity (already installed — zero schema changes except one `created_by_id` migration), ViewComponent, RSpec + Fabrication, HAML.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-organiser-activity-strip-design.md`
+
+## Global Constraints
+
+- Never work directly on `master`; each PR from its own feature branch. PR 1 from `spec/organiser-activity-strip` is fine to rebranch, or cut fresh.
+- Run tests with `bundle exec rspec <path>`; full suite via `bundle exec parallel_rspec spec/ -n 3` before pushing.
+- RuboCop clean on touched files: `bundle exec rubocop app spec`.
+- Activity recording must never break user flows: recorder rescues persistence errors internally.
+- Recorder keys come from the shared `KEYS` vocabulary — new sites add their key to the list and to the spec's assertions.
+- All prose/comments American English (documentation), 120-char max line length.
+- Fabrication (not FactoryBot), Faker for data.
+
+---
+
+# PR 1 — Instrumentation
+
+### Task 1: MemberActivityRecorder service
+
+**Files:**
+- Create: `app/services/member_activity_recorder.rb`
+- Test: `spec/services/member_activity_recorder_spec.rb`
+
+**Interfaces:**
+- Produces: `MemberActivityRecorder.record(actor:, key:, trackable: nil, recipient: nil)` — creates one `PublicActivity::Activity` row with `owner: actor`; rescues and logs all persistence errors.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+# spec/services/member_activity_recorder_spec.rb
+require 'rails_helper'
+
+RSpec.describe MemberActivityRecorder do
+  let(:member) { Fabricate(:member) }
+
+  it 'creates an activity row owned by the actor' do
+    described_class.record(actor: member, key: 'member.login')
+
+    activity = PublicActivity::Activity.find_by(owner: member)
+    expect(activity.key).to eq('member.login')
+  end
+
+  it 'stores trackable and recipient' do
+    other = Fabricate(:member)
+
+    described_class.record(actor: member, key: 'member.banned', recipient: other)
+
+    activity = PublicActivity::Activity.order(:created_at).last
+    expect(activity.recipient).to eq(other)
+    expect(activity.trackable).to be_nil
+  end
+
+  it 'never raises on persistence failure' do
+    allow(PublicActivity::Activity).to receive(:create!)
+      .and_raise(ActiveRecord::RecordInvalid)
+    allow(Rails.logger).to receive(:warn)
+
+    expect { described_class.record(actor: member, key: 'member.login') }.not_to raise_error
+    expect(Rails.logger).to have_received(:warn).with(/MemberActivityRecorder failed/)
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/services/member_activity_recorder_spec.rb`
+Expected: FAIL with `NameError: uninitialized constant MemberActivityRecorder`
+
+- [ ] **Step 3: Write the service**
+
+```ruby
+# app/services/member_activity_recorder.rb
+# frozen_string_literal: true
+
+# Single funnel for member-activity rows on the public_activity `activities` table.
+# Explicit call sites only — no model callbacks — so nothing is double-logged.
+# Recording is observability: persistence failures are logged, never raised.
+class MemberActivityRecorder
+  # Key vocabulary in use; extend when adding sites. New keys classify as :active in the strip.
+  KEYS = %w[
+    member.login
+    member.logout
+    member.checked_in
+    member_note.created
+    member.banned
+    profile.updated
+    toc.accepted
+    auth_service.removed
+    subscription.created
+    subscription.removed
+    subscription.admin_updated
+    mailing_list.subscribe
+    mailing_list.unsubscribe
+    event_invitation.rsvp
+    event_invitation.rejected
+    meeting_invitation.rsvp
+    meeting_invitation.cancelled
+    workshop_invitation.rsvp
+    workshop_invitation.rejected
+    waiting_list.joined
+    waiting_list.left
+    organiser_role.granted
+    organiser_role.revoked
+    invitation.send_batch
+    invitation.rsvp_override
+    invitation.verified
+    workshop.created
+    meeting_invitation.created
+    meeting_invitation.updated
+  ].freeze
+
+  def self.record(actor:, key:, trackable: nil, recipient: nil)
+    PublicActivity::Activity.create!(owner: actor, key: key, trackable: trackable, recipient: recipient)
+  rescue StandardError => e
+    Rails.logger.warn("MemberActivityRecorder failed (#{key}): #{e.class}: #{e.message}")
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/services/member_activity_recorder_spec.rb`
+Expected: 3 examples, 0 failures
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/member_activity_recorder.rb spec/services/member_activity_recorder_spec.rb
+git commit -m 'Add MemberActivityRecorder service'
+```
+
+### Task 2: Login capture via `sign_in!` funnel
+
+**Files:**
+- Modify: `app/controllers/auth_services_controller.rb`
+- Test: `spec/requests/member_login_activity_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+- Produces: private `AuthServicesController#sign_in!(member, auth_service)` — sets all four session values and records `member.login`. Both `create` branches call it.
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/member_login_activity_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Member login activity' do
+  it 'records member.login on the existing auth service path' do
+    member = Fabricate(:member, email: 'existing-login@example.com')
+    Fabricate(:auth_service, member: member, provider: 'github', uid: 'login-uid-1')
+
+    mock_auth_hash(provider: 'github', uid: 'login-uid-1', email: member.email)
+    post '/auth/github/callback'
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'member.login')).to be(true)
+  end
+
+  it 'records member.login when the callback creates a new member' do
+    mock_auth_hash(provider: 'github', uid: 'brand-new-uid', email: 'fresh-login@example.com')
+
+    expect { post '/auth/github/callback' }
+      .to change { PublicActivity::Activity.where(key: 'member.login').count }.by(1)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/member_login_activity_spec.rb`
+Expected: FAIL — no `member.login` rows exist.
+
+- [ ] **Step 3: Refactor both branches through `sign_in!`**
+
+In `app/controllers/auth_services_controller.rb`, replace the existing-service branch:
+
+```ruby
+    elsif current_service
+      sign_in!(current_service.member, current_service)
+
+      finish_registration || redirect_to(referer_or_dashboard_path)
+```
+
+Replace the new-member branch's four `session[...] =` lines (after the `begin/rescue` block) with:
+
+```ruby
+        sign_in!(member, member_service)
+```
+
+Add the private method next to `member_from_github_id`:
+
+```ruby
+  def sign_in!(member, auth_service)
+    session[:member_id]          = member.id
+    session[:service_id]         = auth_service.id
+    session[:oauth_token]        = omnihash[:credentials][:token]
+    session[:oauth_token_secret] = omnihash[:credentials][:secret]
+
+    MemberActivityRecorder.record(actor: member, key: 'member.login')
+  end
+```
+
+- [ ] **Step 4: Run the new spec and the existing OAuth specs**
+
+Run: `bundle exec rspec spec/requests/member_login_activity_spec.rb spec/requests/auth_services_callback_spec.rb`
+Expected: all pass — session behavior unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/auth_services_controller.rb spec/requests/member_login_activity_spec.rb
+git commit -m 'Record member.login through a shared sign_in! funnel'
+```
+
+### Task 3: Logout capture
+
+**Files:**
+- Modify: `app/controllers/application_controller.rb:105` (`logout!`)
+- Test: `spec/requests/member_logout_activity_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/member_logout_activity_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Member logout activity' do
+  it 'records member.logout before clearing the session' do
+    member = Fabricate(:member, email: 'logout@example.com')
+    Fabricate(:auth_service, member: member, provider: 'github', uid: 'logout-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'logout-uid-1', email: member.email)
+    post '/auth/github/callback'
+
+    expect { delete '/logout' }
+      .to change { PublicActivity::Activity.exists?(owner: member, key: 'member.logout') }
+      .from(false).to(true)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/member_logout_activity_spec.rb`
+Expected: FAIL — no `member.logout` row.
+
+- [ ] **Step 3: Instrument `logout!`**
+
+In `app/controllers/application_controller.rb`, replace:
+
+```ruby
+  def logout!
+    @current_member = nil
+    reset_session
+  end
+```
+
+with:
+
+```ruby
+  def logout!
+    member = current_user
+    MemberActivityRecorder.record(actor: member, key: 'member.logout') if member
+    @current_member = nil
+    reset_session
+  end
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/requests/member_logout_activity_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/application_controller.rb spec/requests/member_logout_activity_spec.rb
+git commit -m 'Record member.logout'
+```
+
+### Task 4: Group subscriptions and mailing list
+
+**Files:**
+- Modify: `app/controllers/subscriptions_controller.rb` (`create`, `destroy`)
+- Modify: `app/controllers/mailing_lists_controller.rb` (`create`, `destroy`)
+- Test: `spec/requests/member_activity_subscriptions_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/member_activity_subscriptions_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Subscription and mailing list activity' do
+  let(:member) { Fabricate(:member) }
+  let(:group) { Fabricate(:group) }
+
+  before { LoginHelpers::LoginStub.current_user = member }
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  it 'records subscription.created and subscription.removed' do
+    post subscriptions_path, params: { subscription: { group_id: group.id } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'subscription.created')).to be(true)
+
+    delete unsubscribe_group_subscription_path(group, member.subscriptions.last)
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'subscription.removed')).to be(true)
+  end
+
+  it 'records mailing_list.subscribe and unsubscribe' do
+    post mailing_lists_path
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'mailing_list.subscribe')).to be(true)
+
+    delete mailing_lists_path
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'mailing_list.unsubscribe')).to be(true)
+  end
+end
+```
+
+Note: run `bundle exec rails routes | grep -i "subscription\|mailing"` first and substitute the real helper names/paths — the ones above are the expected names but verify against `rails routes` before relying on them.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/member_activity_subscriptions_spec.rb`
+Expected: FAIL — no activity rows. (If route names differ, fix the spec to the real routes; the assertions stay.)
+
+- [ ] **Step 3: Instrument the four actions**
+
+In `app/controllers/subscriptions_controller.rb`, add to `create` immediately after `SubscriptionMailingListService.subscribe(subscription)`:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'subscription.created',
+                                    trackable: group)
+```
+
+Add to `destroy` immediately after `subscription&.destroy`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'subscription.removed',
+                                  trackable: group) if subscription
+```
+
+In `app/controllers/mailing_lists_controller.rb`, record as the first line of each action. In `create`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'mailing_list.subscribe')
+```
+
+In `destroy`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'mailing_list.unsubscribe')
+```
+
+Each action records its own key directly — no request-method inspection.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/requests/member_activity_subscriptions_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/subscriptions_controller.rb app/controllers/mailing_lists_controller.rb spec/requests/member_activity_subscriptions_spec.rb
+git commit -m 'Record subscription and mailing list activity'
+```
+
+### Task 5: Profile edits, TOC acceptance, provider unlink
+
+**Files:**
+- Modify: `app/controllers/members_controller.rb:25` (`update`)
+- Modify: `app/controllers/member/details_controller.rb:17` (`update`)
+- Modify: `app/controllers/terms_and_conditions_controller.rb:12` (`update`)
+- Modify: `app/controllers/auth_services_controller.rb:76` (`destroy`)
+- Test: `spec/requests/member_activity_profile_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/member_activity_profile_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Profile activity' do
+  let(:member) { Fabricate(:member) }
+
+  before { LoginHelpers::LoginStub.current_user = member }
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  it 'records profile.updated on MembersController#update' do
+    put member_path(member), params: { member: { about_you: 'updated bio' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'profile.updated')).to be(true)
+  end
+
+  it 'records profile.updated on Member::DetailsController#update' do
+    put member_details_path(member), params: { member: { about_you: 'details bio' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'profile.updated')).to be(true)
+  end
+
+  it 'records toc.accepted' do
+    put terms_and_conditions_path, params: { terms_and_conditions_form: { terms: '1' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'toc.accepted')).to be(true)
+  end
+
+  it 'records auth_service.removed on provider unlink' do
+    service = Fabricate(:auth_service, member: member, provider: 'github', uid: 'unlink-uid-1')
+
+    delete auth_services_path, params: { id: service.id }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'auth_service.removed')).to be(true)
+  end
+end
+```
+
+Note: verify exact route helper names with `bundle exec rails routes | grep -i "member\|terms\|auth_service"` and substitute before running. `Member::DetailsController#update` requires a logged-in member via `require_login` (edit only) — `LoginStub` covers it.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/member_activity_profile_spec.rb`
+Expected: FAIL on the activity assertions (and fix any route-name mismatches first).
+
+- [ ] **Step 3: Instrument the four sites**
+
+In `app/controllers/members_controller.rb#update`, inside the `if @member.update(member_params)` branch, before the `redirect_to`:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'profile.updated')
+```
+
+In `app/controllers/member/details_controller.rb#update`, after the `@member.update(attrs)` guard passes (after the newsletter line, before `redirect_to step2_member_path`):
+
+```ruby
+    MemberActivityRecorder.record(actor: @member, key: 'profile.updated')
+```
+
+In `app/controllers/terms_and_conditions_controller.rb#update`, inside the `valid?` branch after `member.save(validate: false)`:
+
+```ruby
+      MemberActivityRecorder.record(actor: member, key: 'toc.accepted')
+```
+
+In `app/controllers/auth_services_controller.rb#destroy`, inside the successful-destroy branch before `redirect_to`:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'auth_service.removed',
+                                    trackable: service)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/requests/member_activity_profile_spec.rb`
+Expected: PASS (4 examples)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/members_controller.rb app/controllers/member/details_controller.rb app/controllers/terms_and_conditions_controller.rb app/controllers/auth_services_controller.rb spec/requests/member_activity_profile_spec.rb
+git commit -m 'Record profile update, TOC acceptance, and provider unlink activity'
+```
+
+### Task 6: Event and meeting RSVPs (session-authenticated)
+
+**Files:**
+- Modify: `app/controllers/invitations_controller.rb` (`attend`, `reject`, `rsvp_meeting`, `cancel_meeting`)
+- Test: `spec/requests/member_activity_rsvps_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/member_activity_rsvps_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Event and meeting RSVP activity' do
+  let(:member) { Fabricate(:member) }
+
+  before { LoginHelpers::LoginStub.current_user = member }
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  describe 'event RSVPs' do
+    let(:invitation) { Fabricate(:event_invitation, member: member) }
+
+    it 'records event_invitation.rsvp on attend' do
+      post attend_event_invitation_path(invitation.token)
+
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'event_invitation.rsvp')).to be(true)
+    end
+
+    it 'records event_invitation.rejected on reject' do
+      invitation.update!(attending: true)
+      post reject_event_invitation_path(invitation.token)
+
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'event_invitation.rejected')).to be(true)
+    end
+  end
+
+  describe 'meeting RSVPs' do
+    let(:invitation) { Fabricate(:meeting_invitation, member: member) }
+
+    it 'records meeting_invitation.rsvp and meeting_invitation.cancelled' do
+      post rsvp_meeting_invitation_path(invitation.token)
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'meeting_invitation.rsvp')).to be(true)
+
+      post cancel_meeting_invitation_path(invitation.token)
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'meeting_invitation.cancelled')).to be(true)
+    end
+  end
+end
+```
+
+Note: check fabricator names (`spec/fabricators/`) for event/meeting invitation fabricators and the route helpers via `bundle exec rails routes | grep invitation`; substitute the real ones.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/member_activity_rsvps_spec.rb`
+Expected: FAIL on activity assertions after fixing any fabricator/route names.
+
+- [ ] **Step 3: Instrument the four actions**
+
+In `app/controllers/invitations_controller.rb`:
+
+`#attend`, immediately after `@invitation.update!(attending: true)`:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'event_invitation.rsvp',
+                                    trackable: @invitation)
+```
+
+`#reject`, immediately after `@invitation.update!(attending: false)`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'event_invitation.rejected',
+                                  trackable: @invitation)
+```
+
+`#rsvp_meeting`, inside `if invitation.update(attending: true)` before the mailer:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'meeting_invitation.rsvp',
+                                    trackable: invitation)
+```
+
+`#cancel_meeting`, immediately after `@invitation.update!(attending: false)`:
+
+```ruby
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'meeting_invitation.cancelled',
+                                  trackable: @invitation)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/requests/member_activity_rsvps_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/invitations_controller.rb spec/requests/member_activity_rsvps_spec.rb
+git commit -m 'Record event and meeting RSVP activity'
+```
+
+### Task 7: Workshop RSVP and waiting list (token-authenticated)
+
+**Files:**
+- Modify: `app/controllers/workshop_invitation_controller.rb` (`accept`, `reject`)
+- Modify: `app/controllers/waiting_lists_controller.rb` (`create`, `destroy`)
+- Test: `spec/requests/member_activity_token_rsvps_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+- Constraint: these paths have no `current_user` — the actor is `@invitation.member`, passed explicitly.
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/member_activity_token_rsvps_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Token-based workshop RSVP activity' do
+  let(:invitation) { Fabricate(:workshop_invitation) }
+  let(:member) { invitation.member }
+
+  it 'records workshop_invitation.rsvp on accept' do
+    put workshop_invitation_path(invitation.token), params: { invitation: { attending: 'true' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'workshop_invitation.rsvp')).to be(true)
+  end
+
+  it 'records workshop_invitation.rejected on reject' do
+    invitation.update!(attending: true)
+    put reject_workshop_invitation_path(invitation.token)
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'workshop_invitation.rejected')).to be(true)
+  end
+
+  it 'records waiting_list.joined and waiting_list.left' do
+    post invitation_waiting_lists_path(invitation.token)
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'waiting_list.joined')).to be(true)
+
+    delete invitation_waiting_lists_path(invitation.token)
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'waiting_list.left')).to be(true)
+  end
+end
+```
+
+Note: verify fabricator (`workshop_invitation`) and token route helpers with `bundle exec rails routes | grep -i "invitation\|waiting"`; substitute the real names. `accept` requires `workshop.rsvp_available?` — fabricate the workshop with a future `date_and_time` and `rsvp_closes_at` so RSVP is open.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/member_activity_token_rsvps_spec.rb`
+Expected: FAIL on activity assertions after fixing names/fabrication.
+
+- [ ] **Step 3: Instrument the four actions**
+
+In `app/controllers/workshop_invitation_controller.rb`, in `accept`, inside the `if @invitation.update(invitation_params.merge!(attending: true, rsvp_time: Time.zone.now))` branch before the email:
+
+```ruby
+      MemberActivityRecorder.record(actor: @invitation.member, key: 'workshop_invitation.rsvp',
+                                    trackable: @invitation)
+```
+
+In `reject`, immediately after `@invitation.update!(attending: false)`:
+
+```ruby
+        MemberActivityRecorder.record(actor: @invitation.member, key: 'workshop_invitation.rejected',
+                                      trackable: @invitation)
+```
+
+In `app/controllers/waiting_lists_controller.rb`, in `create` after `@invitation.save && WaitingList.add(@invitation, auto_rsvp)` (record unconditionally — the attempt is signal):
+
+```ruby
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'waiting_list.joined',
+                                  trackable: @invitation)
+```
+
+In `destroy` after the `.destroy` call:
+
+```ruby
+    MemberActivityRecorder.record(actor: @invitation.member, key: 'waiting_list.left',
+                                  trackable: @invitation)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/requests/member_activity_token_rsvps_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/workshop_invitation_controller.rb app/controllers/waiting_lists_controller.rb spec/requests/member_activity_token_rsvps_spec.rb
+git commit -m 'Record token-based workshop RSVP and waiting list activity'
+```
+
+### Task 8: Organiser role grant/revoke and bans (admin)
+
+**Files:**
+- Modify: `app/controllers/admin/chapters/organisers_controller.rb` (`create`, `destroy`)
+- Modify: `app/controllers/admin/bans_controller.rb` (`create`)
+- Test: `spec/controllers/admin/activity_admin_actions_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing controller spec**
+
+```ruby
+# spec/controllers/admin/activity_admin_actions_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Admin action activity' do
+  let(:admin) { Fabricate(:member) }
+  let(:chapter) { Fabricate(:chapter) }
+
+  before do
+    admin.add_role(:admin)
+    LoginHelpers::LoginStub.current_user = admin
+  end
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  describe 'organiser role changes' do
+    let(:member) { Fabricate(:member) }
+
+    it 'records organiser_role.granted on create' do
+      post :create, params: {
+        chapter_id: chapter.id, organiser: { organiser: member.id }
+      }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'organiser_role.granted',
+                                              recipient: member)).to be(true)
+    end
+
+    it 'records organiser_role.revoked on destroy' do
+      member.add_role(:organiser, chapter)
+
+      delete :destroy, params: { chapter_id: chapter.id, id: member.id }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'organiser_role.revoked',
+                                              recipient: member)).to be(true)
+    end
+  end
+
+  describe 'bans' do
+    let(:member) { Fabricate(:member) }
+
+    it 'records member.banned' do
+      expect do
+        post :create, params: {
+          member_id: member.id, ban: { reason: 'spam', explanation: 'test', permanent: '1' }
+        }
+      end.to change { PublicActivity::Activity.exists?(owner: admin, key: 'member.banned',
+                                                       recipient: member) }.from(false).to(true)
+    end
+  end
+end
+```
+
+Note: `describe` blocks need `type: :controller` routing — add `controller(Admin::Chapters::OrganisersController) { }` style or split into two files mirroring repo conventions (`spec/controllers/admin/` has per-controller specs; follow `spec/controllers/admin/bans_controller_spec.rb` for the ban params shape). Check the existing specs and reuse their param shapes.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/activity_admin_actions_spec.rb`
+Expected: FAIL on activity assertions.
+
+- [ ] **Step 3: Instrument the three actions**
+
+In `app/controllers/admin/chapters/organisers_controller.rb#create`, after `member.add_role(:organiser, @chapter)`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'organiser_role.granted',
+                                  recipient: member, trackable: @chapter)
+```
+
+In `#destroy`, after `member.remove_role(:organiser, @chapter)`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'organiser_role.revoked',
+                                  recipient: member, trackable: @chapter)
+```
+
+In `app/controllers/admin/bans_controller.rb#create`, inside `if @ban.save` before the mailer:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'member.banned',
+                                    recipient: @ban.member, trackable: @ban)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/controllers/admin/activity_admin_actions_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/admin/chapters/organisers_controller.rb app/controllers/admin/bans_controller.rb spec/controllers/admin/activity_admin_actions_spec.rb
+git commit -m 'Record organiser role changes and bans'
+```
+
+### Task 9: Admin invitation overrides and event verification
+
+**Files:**
+- Modify: `app/controllers/admin/invitations_controller.rb` (`update_to_attended`, `update_to_attending`, `update_to_not_attending`)
+- Modify: `app/controllers/admin/invitation_controller.rb` (`update`, `verify`)
+- Test: extend `spec/controllers/admin/invitations_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `spec/controllers/admin/invitations_controller_spec.rb` (follow the existing describe/setup scaffolding in that file — reuse its workshop/invitation/admin fixtures and `login` usage):
+
+```ruby
+  context 'activity recording' do
+    it 'records invitation.rsvp_override when admin forces attendance' do
+      # arrange: admin logged in, decorated workshop + invitation as in existing specs
+      patch :update, params: { workshop_id: workshop.id, invitation: { id: invitation.token },
+                               attending: 'true' }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'invitation.rsvp_override',
+                                              recipient: invitation.member)).to be(true)
+    end
+  end
+```
+
+Add to the `Admin::InvitationController` spec (create `spec/controllers/admin/invitation_controller_spec.rb` if none exists):
+
+```ruby
+  it 'records invitation.verified on verify' do
+    invitation = Fabricate(:event_invitation)
+    admin = Fabricate(:member)
+    admin.add_role(:admin)
+    LoginHelpers::LoginStub.current_user = admin
+
+    post :verify, params: { invitation_id: invitation.token }
+
+    expect(PublicActivity::Activity.exists?(owner: admin, key: 'invitation.verified',
+                                            recipient: invitation.member)).to be(true)
+  end
+```
+
+Note: these specs need the exact existing fixture idioms from the two files (`set_and_decorate_workshop` runs as before_action). Read both spec files first and mirror their setup; substitute variable names accordingly.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/invitations_controller_spec.rb spec/controllers/admin/invitation_controller_spec.rb`
+Expected: FAIL on activity assertions.
+
+- [ ] **Step 3: Instrument**
+
+In `app/controllers/admin/invitations_controller.rb`, add one line at the top of each of `update_to_attended`, `update_to_attending`, and `update_to_not_attending` (after the method body's update completes — safest is immediately after its `@invitation.update(...)` line in each method):
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'invitation.rsvp_override',
+                                  trackable: @invitation, recipient: @invitation.member)
+```
+
+In `app/controllers/admin/invitation_controller.rb`, in `update` after `invitation.update(attending: true, ...)`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'invitation.verified',
+                                  trackable: invitation, recipient: invitation.member)
+```
+
+and identically in `verify` after its `invitation.update(...)`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/controllers/admin/invitations_controller_spec.rb spec/controllers/admin/invitation_controller_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/admin/invitations_controller.rb app/controllers/admin/invitation_controller.rb spec/controllers/admin/
+git commit -m 'Record admin RSVP overrides and event verification'
+```
+
+### Task 10: Member notes and check-ins
+
+**Files:**
+- Modify: `app/controllers/admin/member_notes_controller.rb:5` (`create`)
+- Modify: `app/controllers/check_ins_controller.rb:111` (`mark_attended`)
+- Test: extend `spec/controllers/admin/member_notes_controller_spec.rb`; create `spec/requests/member_activity_check_in_spec.rb`
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `spec/controllers/admin/member_notes_controller_spec.rb` (mirror its existing setup):
+
+```ruby
+  it 'records member_note.created' do
+    member = Fabricate(:member)
+    LoginHelpers::LoginStub.current_user = admin # reuse the file's admin fixture name
+
+    post :create, params: { member_note: { member_id: member.id, note: 'context' } }
+
+    expect(PublicActivity::Activity.exists?(key: 'member_note.created', recipient: member)).to be(true)
+  end
+```
+
+Create `spec/requests/member_activity_check_in_spec.rb`:
+
+```ruby
+# spec/requests/member_activity_check_in_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Check-in activity' do
+  let(:invitation) { Fabricate(:workshop_invitation) }
+  let(:member) { invitation.member }
+  let(:workshop) { invitation.workshop }
+
+  before do
+    LoginHelpers::LoginStub.current_user = member
+    workshop.update!(date_and_time: 1.hour.ago, check_in_code: '1234')
+    allow_any_instance_of(Workshop).to receive(:check_in_open?).and_return(true)
+  end
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  it 'records member.checked_in' do
+    post check_ins_path, params: { check_in: { workshop_id: workshop.id, code: '1234', role: 'Student' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'member.checked_in')).to be(true)
+  end
+end
+```
+
+Note: read `app/controllers/check_ins_controller.rb` first for the exact param contract (`load_check_in_target` consumes the params) and mirror an existing check-in spec if one exists (`rg -l "check_ins_path" spec/`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/member_notes_controller_spec.rb spec/requests/member_activity_check_in_spec.rb`
+Expected: FAIL on activity assertions.
+
+- [ ] **Step 3: Instrument**
+
+In `app/controllers/admin/member_notes_controller.rb#create`, after `@note.author = current_user`:
+
+```ruby
+    if @note.save
+      MemberActivityRecorder.record(actor: current_user, key: 'member_note.created',
+                                    trackable: @note, recipient: @note.member)
+    else
+      flash[:error] = @note.errors.full_messages
+    end
+    redirect_back fallback_location: root_path
+```
+
+(replacing the existing `flash[:error] = @note.errors.full_messages unless @note.save` line).
+
+In `app/controllers/check_ins_controller.rb#mark_attended`, at the end of the method after `invitation.update!(attrs)`:
+
+```ruby
+    MemberActivityRecorder.record(actor: invitation.member, key: 'member.checked_in',
+                                  trackable: invitation)
+```
+
+Note: `mark_attended` is called both by self-service check-in and by admin flows; recording the invitation member (not `current_user`) is correct in both paths per the spec.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/controllers/admin/member_notes_controller_spec.rb spec/requests/member_activity_check_in_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/admin/member_notes_controller.rb app/controllers/check_ins_controller.rb spec/controllers/admin/member_notes_controller_spec.rb spec/requests/member_activity_check_in_spec.rb
+git commit -m 'Record member notes and check-in activity'
+```
+
+### Task 11: Workshop creation + `created_by_id`
+
+**Files:**
+- Create: `db/migrate/XXXXXXXX_add_created_by_id_to_workshops.rb`
+- Modify: `app/models/workshop.rb` (`belongs_to :created_by, optional: true, class_name: 'Member'`)
+- Modify: `app/controllers/admin/workshops_controller.rb:27` (`create`)
+- Test: extend `spec/controllers/admin/workshops_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+- Produces: `Workshop#created_by` → `Member` (nullable; NULL = unknown/pre-migration).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/controllers/admin/workshops_controller_spec.rb` (mirror its existing `create` setup):
+
+```ruby
+  it 'stamps created_by and records workshop.created' do
+    # arrange as in the file's existing create example
+
+    expect(Workshop.last.created_by).to eq(admin) # reuse the file's admin fixture name
+    expect(PublicActivity::Activity.exists?(owner: admin, key: 'workshop.created',
+                                            trackable: Workshop.last)).to be(true)
+  end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb`
+Expected: FAIL — `created_by` undefined / no activity.
+
+- [ ] **Step 3: Migration, association, instrumentation**
+
+```bash
+bin/rails generate migration AddCreatedByIdToWorkshops created_by_id:integer
+```
+
+Edit the generated migration to match the repo's foreign-key conventions:
+
+```ruby
+class AddCreatedByIdToWorkshops < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workshops, :created_by_id, :integer
+    add_index :workshops, :created_by_id
+    add_foreign_key :workshops, :members, column: :created_by_id, on_delete: :nullify
+  end
+end
+```
+
+Run `bin/rails db:migrate`. In `app/models/workshop.rb` add:
+
+```ruby
+  belongs_to :created_by, class_name: 'Member', optional: true, foreign_key: :created_by_id
+```
+
+In `app/controllers/admin/workshops_controller.rb#create`, inside `if workshop_type_valid? && @workshop.save` before the redirect:
+
+```ruby
+      @workshop.update_column(:created_by_id, current_user.id)
+      MemberActivityRecorder.record(actor: current_user, key: 'workshop.created',
+                                    trackable: @workshop)
+```
+
+(`update_column` matches the stashed design's plumbing decision: a stamp, not a user-facing attribute.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/controllers/admin/workshops_controller_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/migrate/ app/models/workshop.rb app/controllers/admin/workshops_controller.rb spec/controllers/admin/workshops_controller_spec.rb db/schema.rb
+git commit -m 'Stamp workshop creator and record workshop.created'
+```
+
+### Task 12: Admin subscription changes and meeting invitations
+
+**Files:**
+- Modify: `app/controllers/admin/members_controller.rb:40` (`update_subscriptions`)
+- Modify: `app/controllers/admin/meeting_invitations_controller.rb` (`create`, `update`)
+- Test: create `spec/requests/admin_activity_member_admin_spec.rb`
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing request spec**
+
+```ruby
+# spec/requests/admin_activity_member_admin_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Admin member management activity' do
+  let(:admin) { Fabricate(:member) }
+  let(:member) { Fabricate(:member) }
+  let(:group) { Fabricate(:group) }
+
+  before do
+    admin.add_role(:admin)
+    LoginHelpers::LoginStub.current_user = admin
+  end
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  it 'records subscription.admin_updated' do
+    member.subscriptions.create!(group: group)
+
+    patch admin_member_update_subscriptions_path(member), params: { group: group.id }
+
+    expect(PublicActivity::Activity.exists?(owner: admin, key: 'subscription.admin_updated',
+                                            recipient: member)).to be(true)
+  end
+
+  it 'records meeting_invitation.created on admin invite' do
+    meeting = Fabricate(:meeting)
+
+    post admin_meeting_meeting_invitations_path(meeting),
+         params: { meeting_invitations: { member: member.id, meeting_id: meeting.id } }
+
+    expect(PublicActivity::Activity.exists?(owner: admin, key: 'meeting_invitation.created',
+                                            recipient: member)).to be(true)
+  end
+
+  it 'records meeting_invitation.updated on admin update' do
+    meeting = Fabricate(:meeting)
+    invitation = Fabricate(:meeting_invitation, member: member, meeting: meeting)
+
+    patch admin_meeting_meeting_invitation_path(meeting, invitation),
+          params: { meeting_invitation: { attending: 'false' } }
+
+    expect(PublicActivity::Activity.exists?(owner: admin, key: 'meeting_invitation.updated',
+                                            recipient: member)).to be(true)
+  end
+end
+```
+
+Note: read `app/controllers/admin/members_controller.rb` for the real route names (`update_subscriptions` route member scope), `app/controllers/admin/meeting_invitations_controller.rb#update` for its actual params contract, and the meeting/meeting_invitation fabricator names; substitute before running.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/requests/admin_activity_member_admin_spec.rb`
+Expected: FAIL on activity assertions after fixing routes/fabricators.
+
+- [ ] **Step 3: Instrument**
+
+In `app/controllers/admin/members_controller.rb#update_subscriptions`, after `subscription.destroy`:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'subscription.admin_updated',
+                                  trackable: group, recipient: @member)
+```
+
+In `app/controllers/admin/meeting_invitations_controller.rb#create`, inside `if invitation.save` after the mailer line:
+
+```ruby
+      MemberActivityRecorder.record(actor: current_user, key: 'meeting_invitation.created',
+                                    trackable: invitation, recipient: member)
+```
+
+In `#update` (read the method first), immediately after its `invitation.update(...)` success path:
+
+```ruby
+    MemberActivityRecorder.record(actor: current_user, key: 'meeting_invitation.updated',
+                                  trackable: invitation, recipient: invitation.member)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/requests/admin_activity_member_admin_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/admin/members_controller.rb app/controllers/admin/meeting_invitations_controller.rb spec/requests/admin_activity_member_admin_spec.rb
+git commit -m 'Record admin subscription changes and meeting invitations'
+```
+
+### Task 13: InvitationLogger batch sends
+
+**Files:**
+- Modify: `app/services/invitation_logger.rb` (`start_batch`)
+- Test: extend `spec/services/invitation_logger_spec.rb`
+
+**Interfaces:**
+- Consumes: `MemberActivityRecorder.record` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/services/invitation_logger_spec.rb` (mirror its existing fabricator usage):
+
+```ruby
+  it 'records invitation.send_batch for the initiator' do
+    initiator = Fabricate(:member)
+
+    described_class.new(workshop, initiator, 'all', 'invite').start_batch
+
+    expect(PublicActivity::Activity.exists?(owner: initiator, key: 'invitation.send_batch',
+                                            trackable: workshop)).to be(true)
+  end
+```
+
+(substitute the file's actual loggable fixture — workshop or event — and arguments).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/services/invitation_logger_spec.rb`
+Expected: FAIL.
+
+- [ ] **Step 3: Instrument**
+
+In `app/services/invitation_logger.rb#start_batch`, after the `@log = InvitationLog.create!(...)` block:
+
+```ruby
+    MemberActivityRecorder.record(actor: @initiator, key: 'invitation.send_batch', trackable: @loggable)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/services/invitation_logger_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/invitation_logger.rb spec/services/invitation_logger_spec.rb
+git commit -m 'Record invitation batch sends as initiator activity'
+```
+
+### Task 14: PR 1 wrap-up
+
+- [ ] **Step 1: Full suite + lint**
+
+Run: `bundle exec parallel_rspec spec/ -n 3 && bundle exec rubocop app spec`
+Expected: green.
+
+- [ ] **Step 2: Push and open draft PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --draft --title 'Record member activity in the activities log' --body-file /tmp/pr1-body.md
+```
+
+PR body (write to `/tmp/pr1-body.md` first, no backticks in CLI args): summary = one funnel, closed key list, all write sites from the spec's Instrumentation section; test evidence = new specs listed; link the spec path.
+
+---
+
+# PR 2 — Visualisation
+
+### Task 15: ActivityStrip service
+
+**Files:**
+- Create: `app/services/admin/members/activity_strip.rb`
+- Test: `spec/services/admin/members/activity_strip_spec.rb` (create dirs)
+
+**Interfaces:**
+- Consumes: `PublicActivity::Activity` rows with `owner` = member (PR 1).
+- Produces: `Admin::Members::ActivityStrip.new(member, now: Time.zone.now).rows` → array of 52 `Row` structs (`week_start: Date/Time`, `state: :empty|:login_only|:active`, `counts: Hash{String=>Integer}`), oldest week first, ending at the current ISO week.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+# spec/services/admin/members/activity_strip_spec.rb
+require 'rails_helper'
+
+RSpec.describe Admin::Members::ActivityStrip do
+  let(:member) { Fabricate(:member) }
+  let(:now) { Time.zone.local(2026, 9, 2, 12, 0, 0) } # Wednesday, current week starts Mon 31 Aug
+  let(:strip) { described_class.new(member, now: now) }
+
+  def activity_at(time, key: 'member.login')
+    PublicActivity::Activity.create!(owner: member, key: key, created_at: time, updated_at: time)
+  end
+
+  it 'returns 52 rows oldest first' do
+    rows = strip.rows
+
+    expect(rows.size).to eq(52)
+    expect(rows.first.week_start).to eq(Time.zone.local(2026, 8, 31))
+    expect(rows.last.week_start).to eq(Time.zone.local(2026, 8, 31) + 51.weeks)
+  end
+
+  it 'marks weeks with no rows as empty' do
+    expect(strip.rows.map(&:state)).to all(eq(:empty))
+  end
+
+  it 'marks login-only weeks as login_only' do
+    activity_at(now - 2.weeks, key: 'member.login')
+
+    expect(strip.rows[-3].state).to eq(:login_only)
+  end
+
+  it 'marks weeks with any non-login key as active' do
+    activity_at(now - 2.weeks, key: 'event_invitation.rsvp')
+
+    expect(strip.rows[-3].state).to eq(:active)
+  end
+
+  it 'counts keys for tooltips' do
+    activity_at(now - 1.week, key: 'member.login')
+    activity_at(now - 1.week, key: 'event_invitation.rsvp')
+
+    expect(strip.rows[-2].counts).to eq('member.login' => 1, 'event_invitation.rsvp' => 1)
+  end
+
+  it 'buckets by ISO week with the boundary at window start' do
+    activity_at(strip.rows.first.week_start) # exactly at the window edge
+    activity_at(strip.rows.first.week_start - 1.second) # one second before: outside
+
+    expect(strip.rows.first.state).to eq(:login_only)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/services/admin/members/activity_strip_spec.rb`
+Expected: FAIL — constant undefined.
+
+- [ ] **Step 3: Write the service**
+
+```ruby
+# app/services/admin/members/activity_strip.rb
+# frozen_string_literal: true
+
+module Admin
+  module Members
+    # Buckets a member's activity log into the 52 ISO weeks ending the current week.
+    # Sole owner of strip state classification; the component renders, never classifies.
+    class ActivityStrip
+      WEEK_COUNT = 52
+      LOGIN_ONLY_KEYS = %w[member.login member.logout].freeze
+
+      Row = Struct.new(:week_start, :state, :counts, keyword_init: true)
+
+      def initialize(member, now: Time.zone.now)
+        @member = member
+        @now = now
+      end
+
+      def rows
+        activities = PublicActivity::Activity
+                     .where(owner: @member)
+                     .where(created_at: window_start..@now)
+                     .order(:created_at)
+
+        grouped = activities.group_by { |a| a.created_at.to_date.beginning_of_week.beginning_of_day }
+
+        weeks.map do |week_start|
+          week_activities = grouped[week_start] || []
+          counts = week_activities.map(&:key).tally
+          state = classify(counts)
+
+          Row.new(week_start: week_start, state: state, counts: counts)
+        end
+      end
+
+      private
+
+      def classify(counts)
+        return :empty if counts.empty?
+        return :login_only if counts.keys.all? { |key| LOGIN_ONLY_KEYS.include?(key) }
+
+        :active
+      end
+
+      def weeks
+        @weeks ||= Array.new(WEEK_COUNT) { |i| current_week_start - (WEEK_COUNT - 1 - i).weeks }
+      end
+
+      def window_start
+        @window_start ||= current_week_start - (WEEK_COUNT - 1).weeks
+      end
+
+      def current_week_start
+        @current_week_start ||= @now.to_date.beginning_of_week.beginning_of_day
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/services/admin/members/activity_strip_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/admin/members/activity_strip.rb spec/services/admin/members/activity_strip_spec.rb
+git commit -m 'Add admin member activity strip service'
+```
+
+### Task 16: ActivityStripComponent
+
+**Files:**
+- Create: `app/components/admin/members/activity_strip_component.rb`
+- Create: `app/components/admin/members/activity_strip_component.html.erb`
+- Create: `app/assets/stylesheets/partials/_activity_strip.scss`
+- Modify: `app/assets/stylesheets/application.scss` (add `@import "partials/activity_strip";` next to the other partial imports)
+- Test: `spec/components/admin/members/activity_strip_component_spec.rb`
+
+**Interfaces:**
+- Consumes: `Admin::Members::ActivityStrip#rows` (Task 15) — `Row(week_start:, state:, counts:)`.
+- Produces: `Admin::Members::ActivityStripComponent.new(weeks: rows)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# spec/components/admin/members/activity_strip_component_spec.rb
+require 'rails_helper'
+
+RSpec.describe Admin::Members::ActivityStripComponent, type: :component do
+  let(:member) { Fabricate(:member) }
+  let(:now) { Time.zone.local(2026, 9, 2, 12, 0, 0) }
+  let(:rows) do
+    Admin::Members::ActivityStrip.new(member, now: now).tap do |strip|
+      PublicActivity::Activity.create!(owner: member, key: 'member.login',
+                                       created_at: now - 1.week, updated_at: now - 1.week)
+      PublicActivity::Activity.create!(owner: member, key: 'event_invitation.rsvp',
+                                       created_at: now - 2.weeks, updated_at: now - 2.weeks)
+    end.rows
+  end
+
+  before { render_inline(described_class.new(weeks: rows)) }
+
+  it 'renders 52 cells' do
+    expect(page).to have_css('rect', count: 52)
+  end
+
+  it 'renders all three state classes' do
+    expect(page).to have_css('.activity-cell-empty')
+    expect(page).to have_css('.activity-cell-login_only')
+    expect(page).to have_css('.activity-cell-active')
+  end
+
+  it 'renders a tooltip with the week and counts' do
+    expect(page).to have_css('rect[title*="event_invitation rsvp"]')
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/components/admin/members/activity_strip_component_spec.rb`
+Expected: FAIL — constant undefined.
+
+- [ ] **Step 3: Write the component**
+
+```ruby
+# app/components/admin/members/activity_strip_component.rb
+# frozen_string_literal: true
+
+module Admin
+  module Members
+    class ActivityStripComponent < ViewComponent::Base
+      CELL_WIDTH = 8
+      CELL_GAP = 4
+
+      def initialize(weeks:)
+        @weeks = weeks
+      end
+
+      private
+
+      attr_reader :weeks
+
+      def title_for(week)
+        summary = week.counts.map { |key, count| "#{count} #{key.tr('.', ' ')}" }.join(', ')
+        "Week of #{week.week_start.strftime('%-d %b %Y')}: #{summary.presence || 'no activity'}"
+      end
+
+      def svg_width
+        weeks.size * (CELL_WIDTH + CELL_GAP)
+      end
+    end
+  end
+end
+```
+
+```erb
+<%# app/components/admin/members/activity_strip_component.html.erb %>
+<div class="activity-strip">
+  <h5>Activity — last 12 months</h5>
+  <svg viewBox="0 0 <%= svg_width %> 32" width="100%" height="32"
+       role="img" aria-label="Weekly activity, last 12 months">
+    <% weeks.each_with_index do |week, i| %>
+      <rect x="<%= i * (CELL_WIDTH + CELL_GAP) %>" y="0"
+            width="<%= CELL_WIDTH %>" height="32" rx="2"
+            class="activity-cell activity-cell-<%= week.state %>"
+            title="<%= title_for(week) %>" />
+    <% end %>
+  </svg>
+</div>
+```
+
+```scss
+// app/assets/stylesheets/partials/_activity_strip.scss
+.activity-strip {
+  .activity-cell {
+    &-empty { fill: $gray-200; }
+    &-login_only { fill: $gray-400; }
+    &-active { fill: $codebar-purple; } // substitute the repo's brand colour variable
+  }
+}
+```
+
+Note: check `app/assets/stylesheets/partials/_colors.sass` for the real brand/ink variable names and use them; if none exist, use literal hex values matching the site's accent colour.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/components/admin/members/activity_strip_component_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/admin/members/ app/assets/stylesheets/partials/_activity_strip.scss app/assets/stylesheets/application.scss spec/components/admin/members/activity_strip_component_spec.rb
+git commit -m 'Add activity strip view component'
+```
+
+### Task 17: Profile integration
+
+**Files:**
+- Modify: `app/controllers/admin/members_controller.rb:26` (`show`)
+- Modify: `app/views/admin/members/_profile.html.haml`
+- Test: extend `spec/controllers/admin/members_controller_spec.rb`
+
+**Interfaces:**
+- Consumes: Tasks 15–16. `MemberPresenter` is a `SimpleDelegator`, so `@member.organiser?` resolves to the underlying member's method.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `spec/controllers/admin/members_controller_spec.rb`, add (inside the existing `show` describe, mirroring its admin-login setup):
+
+```ruby
+    describe 'activity strip' do
+      render_views
+
+      let(:organiser) { Fabricate(:member) }
+      let(:chapter) { Fabricate(:chapter) }
+
+      before { organiser.add_role(:organiser, chapter) }
+
+  it 'renders the strip for organisers' do
+    get :show, params: { id: organiser.id }
+
+    expect(response.body).to include('activity-strip')
+  end
+
+      it 'does not render the strip for non-organisers' do
+        plain = Fabricate(:member)
+
+        get :show, params: { id: plain.id }
+
+        expect(response.body).not_to include('activity-strip')
+      end
+    end
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bundle exec rspec spec/controllers/admin/members_controller_spec.rb`
+Expected: FAIL — `activity_weeks` unassigned, strip absent.
+
+- [ ] **Step 3: Controller and view**
+
+In `app/controllers/admin/members_controller.rb`, replace `show` with (fetch the undecorated member first so both the presenter and the service use the same record):
+
+```ruby
+  def show
+    member = Member.find(params[:id])
+    @member = MemberPresenter.new(member)
+    load_attendance_data(@member)
+    @activity_weeks = Admin::Members::ActivityStrip.new(member).rows
+    @actions = admin_actions(@member).sort_by(&:created_at).reverse
+  end
+```
+
+In `app/views/admin/members/_profile.html.haml`, directly after the avatar/full-name block (top of the profile content):
+
+```haml
+  - if @member.organiser?
+    = render Admin::Members::ActivityStripComponent.new(weeks: @activity_weeks)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bundle exec rspec spec/controllers/admin/members_controller_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/admin/members_controller.rb app/views/admin/members/_profile.html.haml spec/controllers/admin/members_controller_spec.rb
+git commit -m 'Render organiser activity strip on admin member profile'
+```
+
+### Task 18: PR 2 wrap-up
+
+- [ ] **Step 1: Full suite + lint**
+
+Run: `bundle exec parallel_rspec spec/ -n 3 && bundle exec rubocop app spec`
+Expected: green.
+
+- [ ] **Step 2: Push and open draft PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --draft --title 'Organiser activity strip on admin member profile' --body-file /tmp/pr2-body.md
+```
+
+PR body (write to `/tmp/pr2-body.md` first): summary = service + component + profile placement behind organiser check; screenshots from local run (`bundle exec rails server`, visit `/admin/members/:id` as an admin, organiser with seeded activity); test evidence; link the spec path.

--- a/docs/superpowers/specs/2025-03-31-self-check-in-design.md
+++ b/docs/superpowers/specs/2025-03-31-self-check-in-design.md
@@ -1,0 +1,207 @@
+# Self Check-In Design
+
+## Summary
+
+Allow attendees at events and workshops to mark themselves as attended via a QR code. Organisers download a landscape PDF containing the QR code, event info, venue, and sponsors. The PDF can be printed, displayed on screens/projectors, or sent to venue hosts ahead of time — no internet connection required. Each event/workshop gets a unique 3-word code that shortens the QR URL. After scanning, the attendee authenticates, confirms their role, and is checked in.
+
+## Routes
+
+```
+# Admin — instructions page (HTML) + PDF download (same URL, .pdf format)
+GET  /admin/events/:slug/check-in     → admin/check_ins#show
+GET  /admin/workshops/:id/check-in    → admin/check_ins#show
+
+# Public — check-in flow (what the QR encodes)
+GET  /check-in/e/:code  → check_ins#new  (event)
+POST /check-in/e/:code  → check_ins#create
+GET  /check-in/w/:code  → check_ins#new  (workshop)
+POST /check-in/w/:code  → check_ins#create
+```
+
+No public display pages. The PDF is the display.
+
+## Data Model
+
+Add a `check_in_code` column to both `events` and `workshops`:
+
+- Type: string, unique per table, indexed
+- Generated on `before_create` from the EFF word list (3 random words)
+- Retry on collision
+- Existing records: generate the code on first PDF download (or via a one-time rake task)
+
+Add a `source` column to `workshop_invitations` and `invitations`:
+
+- Type: string, nullable (no default)
+- Valid values: `"email"`, `"check_in"`, `"admin"`
+- `NULL` = legacy records, no backfill needed
+- Every new code path sets it explicitly
+
+No new tables.
+
+## Word List
+
+Bundle the [EFF large word list](https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt) as `lib/words/check_in_words.txt`.
+
+- 7,776 common English words, curated to exclude offensive terms
+- Diceware-derived, work-safe
+- Stripped of diceware numbers on import — just the word column
+
+Three random words from 7,776 gives ~470 billion combinations. Collision probability for any realistic number of events/workshops is negligible. Generate and validate uniqueness in a loop (typically 1 attempt).
+
+## QR Code Generation & PDF
+
+### Gems to add
+
+- `rqrcode` — QR code matrix calculation + PNG rendering
+- `prawn` — PDF generation (pure Ruby, no native deps)
+
+### QR Code
+
+Generate the QR as PNG, embed in the PDF:
+
+```ruby
+qrcode = RQRCode::QRCode.new(check_in_url)
+png = qrcode.as_png(module_size: 4, resize_gte_to: false)
+```
+
+The QR encodes the full public check-in URL, e.g. `https://codebar.io/check-in/e/sunny-ocean-breeze`.
+
+### PDF Layout (Landscape A4)
+
+Generated on-the-fly when the admin downloads it. No storage, no background job needed.
+
+Content:
+- **Header**: codebar logo (optional v1, text is fine)
+- **Event info**: name, date, time — large, bold, readable at a distance
+- **Venue**: name and address
+- **Sponsors**: listed below venue (names, logos deferred to v2)
+- **QR code**: large, centred, ~200×200px
+- **URL**: below QR in monospace: `codebar.io/check-in/e/sunny-ocean-breeze`
+- **Label**: "Scan to check in" above the QR
+- Background: white, black text, minimal ink usage
+
+Embedded in the PDF via `Prawn::Document#image` with the PNG blob.
+
+### Note on `check_in_code` generation
+
+Generated on `before_create` for new records. For existing records, generated lazily on first PDF download — the admin action checks for nil and creates one before rendering the PDF. This is a deliberate side effect on a download action (not a pure read).
+
+## Check-In Flow (Public)
+
+1. Member scans QR or types the URL → hits `CheckInsController#new`
+2. If already logged in: skip to step 5.
+3. If not logged in: set `session[:referer_path] = request.path`, call `authenticate_member!` → redirects to `/auth/github`. After GitHub auth, `AuthServicesController#create` uses `referer_or_dashboard_path` → sends them back to the check-in page. No changes needed to `AuthServicesController`.
+4. If logged in but profile incomplete: redirect through existing `edit_member_details` flow. After completion, `session[:referer_path]` returns them to the check-in page.
+5. `CheckInsController#new` renders the role-selection page:
+   - Member's name
+   - Event/workshop title and date
+   - Two large buttons: **[I'm a Student]** **[I'm a Coach]**
+   - Button highlighting logic:
+     - Existing invitation with known role → that button highlighted
+     - No invitation but one group subscription → that button highlighted
+     - Both groups or no groups → both shown equally, no highlight
+   - If already checked in: show "You're already checked in as [role] ✓"
+6. Member clicks role → `POST CheckInsController#create` with `role`
+7. Controller finds or creates the invitation. Sets `source="check_in"` plus:
+
+   | Table | Fields set |
+   |-------|-----------|
+   | `workshop_invitations` | `attending=true`, `attended=true`, `source="check_in"` |
+   | `invitations` (events) | `attending=true`, `verified=true`, `source="check_in"` |
+
+   Events have no `attended` column — check-in maps to `verified` (physical presence substitutes for admin verification).
+
+8. Redirects to confirmation: "You're checked in as a Student at Summer Workshop 2026"
+9. Confirmation has a "Back to Dashboard" link
+
+### Edge Cases
+
+- **Already attended:** Already `attended`/`verified` → re-show success, no duplicate
+- **Existing invitation (not yet attended):** `attending=true` but `attended=nil`/`verified=false` → update
+- **New member (no groups):** Both buttons, no highlight. Invitation created, no subscription inferred.
+- **Event with `confirmation_required`:** Physical presence = verified, so `verified=true`
+- **Workshop at capacity:** `attended` is independent of spot counting — always set
+- **Past event:** No time restriction — venue presence is the only gate
+
+## Admin Integration
+
+In the admin event/workshop show page toolbar, a button labelled "Check-in" that opens the instructions page at `/admin/events/:slug/check-in` (or `/admin/workshops/:id/check-in`) in the same tab. The instructions page then has a "Download PDF" button.
+
+The existing `admin/workshop/attendance_row` partial already has admin checkboxes for marking `attended` on workshop invitations. These remain the admin interface for manual attendance verification. Self check-in is a parallel path.
+
+### Admin Controller — `show` action
+
+Uses `respond_to` to serve HTML (default) or PDF:
+
+```ruby
+def show
+  @parent = find_parent  # event or workshop, polymorphic
+  authorize @parent
+  generate_check_in_code_if_missing
+
+  respond_to do |format|
+    format.html  # instructions page (default)
+    format.pdf do
+      pdf = CheckInPdf.new(@parent).render
+      send_data pdf,
+                filename: "check-in-#{@parent.to_param}.pdf",
+                type: "application/pdf",
+                disposition: "attachment"
+    end
+  end
+end
+```
+
+### Instructions page content
+
+The HTML page guides the organiser through the feature:
+
+- **Title**: "Check-in for [Event/Workshop Name]"
+- **What this is**: "Let attendees mark themselves as attended by scanning a QR code."
+- **Check-in code** and **URL**: displayed prominently (so the organiser can share the URL verbally if someone can't scan)
+- **How to use**:
+  1. Download the PDF
+  2. Print it or display it on a screen at the venue entrance
+  3. Attendees scan the QR code with their phone
+  4. They sign in with GitHub and select their role (Student/Coach)
+  5. They're checked in — you can see attendance in the event/workshop admin page
+- **Download PDF button**: links to the same URL with `.pdf` format (e.g. `/admin/events/summer-2026/check-in.pdf`)
+- Uses the standard admin layout, consistent with the rest of the admin section
+
+## Existing Code Changes
+
+The `source` column must be set in all invitation-creation paths:
+
+| Location | Set `source` to |
+|----------|----------------|
+| `InvitationManager#invite_students_to_event` and friends | `"email"` |
+| `InvitationManager#create_invitation` (workshop email path) | `"email"` |
+| `Admin::InvitationsController#update_to_attending` (admin adds attendee) | `"admin"` |
+| `Admin::InvitationController##verify` (admin verifies event attendee) | `"admin"` |
+| `CheckInsController#create` (self check-in) | `"check_in"` |
+| `EventsController#rsvp` (Tito webhook) | `"email"` |
+| `EventsController#student` / `#coach` (public event RSVP) | `"email"` |
+| `WorkshopsController#rsvp` (public workshop RSVP) | `"email"` |
+
+## Implementation Order
+
+1. Migration: add `check_in_code` to events + workshops (unique, indexed), add `source` to workshop_invitations + invitations (nullable)
+2. Model changes: `before_create` generates `check_in_code` from EFF word list. Existing records get one lazily on first PDF download.
+3. Bundle EFF word list as `lib/words/check_in_words.txt`
+4. Add `rqrcode` and `prawn` gems
+5. Build `CheckInPdf` service object — takes an event or workshop, renders a landscape PDF
+6. Build `Admin::CheckInsController` — `show` action with `respond_to` (HTML instructions + PDF download)
+7. Build admin instructions page view for check-in
+8. Update existing code paths to set `source` (InvitationManager, admin controllers, public RSVP controllers)
+9. Build `CheckInsController` (public): `new` (auth gate + role selection), `create`, confirmation
+10. Build views: role-selection page, confirmation page
+11. Admin toolbar: "Check-in" button on event/workshop show pages linking to instructions page
+12. Routes (admin + public, as above)
+
+## Controller Design
+
+**`Admin::CheckInsController`:** Single action (`show`) with `respond_to` for HTML and PDF. Polymorphic parent loading by slug (events) or id (workshops). Requires admin/organiser auth. Generates `check_in_code` if missing on first visit. HTML page provides instructions and download link. PDF response streams the generated document.
+
+**`CheckInsController` (public):** Two check-in actions (`new`, `create`, plus `confirm`). Detects parent type from URL prefix (`/check-in/e/` vs `/check-in/w/`). Loads by `check_in_code`. `create` branches on parent type for field mapping.
+
+**`CheckInPdf` service object:** Takes a parent (event or workshop), builds a `Prawn::Document` with landscape layout. Handles QR generation via `rqrcode`, text layout via `prawn`.

--- a/docs/superpowers/specs/2026-07-07-rsvp-close-time-design.md
+++ b/docs/superpowers/specs/2026-07-07-rsvp-close-time-design.md
@@ -1,0 +1,136 @@
+# RSVP Close Time for Workshops
+
+## Problem
+
+Workshop RSVPs don't close automatically. Students and coaches can RSVP after
+3pm on the day of the workshop if capacity hasn't been reached, causing
+last-minute pairing and venue security issues.
+
+## Current State
+
+- The `workshops` table already has an `rsvp_closes_at` datetime column
+- `Workshop#rsvp_available?` checks it but is **never called** — it's dead code
+- The active RSVP gating is `available_for_rsvp?` which only checks
+  `invitable_yet? && date_and_time.future?`
+- There's already a pattern for local-date/local-time virtual attributes
+  (`rsvp_open_local_date`, `rsvp_open_local_time`) that convert to UTC via
+  `DateTimeConcerns#datetime_from_fields`
+- The admin workshop form has fields for "Open RSVPs at" but no close counterpart
+
+## Design
+
+### Model (`app/models/workshop.rb`)
+
+**Virtual attributes** — added to `attr_accessor`:
+- `rsvp_close_local_date` (String, DD/MM/YYYY)
+- `rsvp_close_local_time` (String, HH:MM)
+
+**Callback** — added to the existing `before_validation` list:
+```ruby
+before_validation :set_closes_at
+```
+
+**Private method** (same pattern as `set_opens_at`):
+```ruby
+def set_closes_at
+  new_closes_at = datetime_from_fields(rsvp_close_local_date, rsvp_close_local_time)
+  self.rsvp_closes_at = new_closes_at if new_closes_at
+end
+```
+
+**Timezone-aware getter** (same pattern as `rsvp_opens_at`):
+```ruby
+def rsvp_closes_at
+  return nil unless super
+  super.in_time_zone(time_zone)
+end
+```
+
+**Validation:**
+Close time must be before workshop start time (when both are present).
+
+```ruby
+validate :rsvp_close_before_workshop_start
+
+def rsvp_close_before_workshop_start
+  return unless rsvp_closes_at && date_and_time
+  return if rsvp_closes_at < date_and_time
+  errors.add(:rsvp_close_local_date, "must be before the workshop start time")
+end
+```
+
+**Gating change** — wire the existing `rsvp_available?` into the RSVP flow:
+```ruby
+def available_for_rsvp?
+  invitable_yet? && rsvp_available?
+end
+```
+
+`rsvp_available?` already handles the nil case (returns `future?`, i.e. workshop
+date/time is still in the future) so existing workshops without a close time are
+unaffected.
+
+### Controller (`app/controllers/admin/workshops_controller.rb`)
+
+Add params to `workshop_params`:
+```ruby
+:rsvp_close_local_date, :rsvp_close_local_time
+```
+
+### Controller (`app/controllers/workshop_invitation_controller.rb`)
+
+Guard in `accept` action, after the `already_rsvped` check, before anything else:
+```ruby
+return back_with_message(t('messages.invitations.closed')) unless workshop.rsvp_available?
+```
+
+Reject/update actions remain ungated — people who RSVP'd before close can still
+change their status or cancel.
+
+### View (`app/views/admin/workshops/_shared_form.html.haml`)
+
+In the RSVP details card, after the existing open-RSVP fields:
+```haml
+= f.input :rsvp_close_local_date, as: :string, input_html: { data: { value: @workshop.rsvp_closes_at.try(:strftime, '%d/%m/%Y') } }
+= f.input :rsvp_close_local_time, as: :string, input_html: { data: { value: @workshop.rsvp_closes_at.try(:time).try(:strftime, '%H:%M') } }
+```
+
+Labels: "Close RSVPs at" (for both fields, date then time).
+
+### I18n (`config/locales/en.yml`)
+
+Add message key:
+```yaml
+messages:
+  invitations:
+    closed: "RSVPs for this workshop are now closed."
+```
+
+### Admin bypass
+
+The `Admin::InvitationsController#update` path is authorised via Pundit and
+already allows organisers/admins to add or remove attendees regardless of
+RSVP state. No changes needed.
+
+## Tests
+
+- **Workshop model (timezone context)**: add `rsvp_closes_at` getter/setter
+  tests mirroring the existing `rsvp_opens_at` tests
+- **Workshop model (validation)**: test close time must be before workshop start
+- **Workshop model (`rsvp_available?`)**: existing tests already cover the
+  `rsvp_closes_at` logic; confirm they hold after wiring
+- **Controller (`workshop_invitation`)**: test that `accept` is blocked when
+  `rsvp_available?` returns false
+- **Feature/admin**: test that the new form fields render in the create and
+  edit workshop pages
+
+## Files Changed
+
+1. `app/models/workshop.rb` — virtual attrs, callback, getter, validations, gating
+2. `app/controllers/admin/workshops_controller.rb` — permitted params
+3. `app/controllers/workshop_invitation_controller.rb` — accept guard
+4. `app/views/admin/workshops/_shared_form.html.haml` — form fields
+5. `config/locales/en.yml` — message key
+6. `spec/models/workshop_spec.rb` — model tests
+7. `spec/controllers/workshop_invitation_controller_spec.rb` — controller guard test
+8. `spec/features/admin/manage_workshop_spec.rb` — form field test

--- a/docs/superpowers/specs/2026-07-19-switch-navigation-to-codebar-auth-design.md
+++ b/docs/superpowers/specs/2026-07-19-switch-navigation-to-codebar-auth-design.md
@@ -1,0 +1,41 @@
+# Switch navigation and auth redirects to `/auth/codebar`
+
+## Context
+
+The new authentication provider at `/auth/codebar` is now proven and working. The application currently sends users to `/auth/github` in several places, including the navigation sign-in link and other auth entry points.
+
+## Goal
+
+Route all user-facing sign-in flows to `/auth/codebar` instead of `/auth/github`.
+
+## Changes
+
+1. **`ApplicationController#redirect_path`**
+   - Return `'/auth/codebar'` instead of `'/auth/github'`.
+   - This covers `authenticate_member!` (protected routes) and `AuthSessionsController#create` (`/register`).
+
+2. **`app/views/layouts/_navigation.html.haml`**
+   - Replace the hardcoded `/auth/github` sign-in link with the `redirect_path` helper.
+
+3. **`app/views/terms_and_conditions/show.html.haml`**
+   - Replace the hardcoded `/auth/github` login link with the `redirect_path` helper.
+
+4. **`AuthServicesController#new`**
+   - Change `redirect_to '/auth/github'` to `redirect_to '/auth/codebar'`.
+
+5. **`TermsAndConditionsController#update`**
+   - Change `redirect_to '/auth/github'` to `redirect_to '/auth/codebar'`.
+
+6. **`spec/controllers/auth_services_controller_spec.rb`**
+   - Update expectations from `/auth/github` to `/auth/codebar`.
+
+## Non-changes
+
+- `AuthServicesController#destroy` calls `redirect_to redirect_path`, but it overrides the helper to return `:services`, so it is unaffected.
+- No new constants, helpers, or routes are introduced.
+
+## Verification
+
+- Run the affected controller specs.
+- Run RuboCop and HAML lint.
+- Smoke-test the navigation sign-in link and `/login` path in development.

--- a/docs/superpowers/specs/2026-08-08-workshop-rsvp-page-design.md
+++ b/docs/superpowers/specs/2026-08-08-workshop-rsvp-page-design.md
@@ -1,0 +1,183 @@
+# Design: Workshop "RSVP members" page (replace the 4k-item dropdown)
+
+Date: 2026-08-08
+Status: Draft for review
+Issue: #2796 (follow-up improvement)
+
+## Problem
+
+The admin workshop show page carries an RSVP `<select>` listing every
+**outstanding invitation** (`workshop.invitations.not_accepted`) for the
+workshop — up to 4,337 options on large workshops. Even after the N+1 fix
+(PR #2797), generating that list and feeding it to Chosen costs ~2.5 s of view
+time and ~8M allocations for data the control is rarely used for. The control
+is only meaningful on the rare occasion an organiser wants to RSVP a specific
+member by hand; loading the whole list every time an organiser views a
+workshop is wasteful.
+
+## Goal
+
+Move that functionality to a dedicated **RSVP members** page for the workshop:
+
+- The workshop show page no longer loads the invitation list at all; it links
+  to the new page instead.
+- The new page is **search-driven**: no members are loaded on page load. The
+  organiser searches by member name; matching invited members come back
+  **paginated** (Pagy).
+- Each result row has a **toggle button** that flips that member's RSVP state
+  (attending <-> not attending).
+
+## Scope
+
+Search pool is members who already have an **invitation row for this
+workshop** (any attending state, so already-attending members can be toggled
+off), **excluding banned members**. No invitation-creation logic — RSVPing is
+only ever applied to an existing invitation.
+
+## Design
+
+### Route
+
+Add to the admin workshops resource:
+
+```ruby
+resources :workshops do
+  member do
+    get 'rsvp'   # admin_workshop_rsvp_path(@workshop)
+  end
+end
+```
+
+### Controller
+
+New action on `Admin::WorkshopsController`:
+
+```ruby
+def rsvp
+  set_workshop
+  authorize @workshop, :update?
+
+  @eligible_count = @workshop.invitations
+                             .joins(:member)
+                             .merge(Member.not_banned)
+                             .count
+
+  return unless params[:q].present?
+
+  @pagy, @invitations = paginate_matching_invitations(params[:q])
+end
+
+def paginate_matching_invitations(query)
+  eligible = @workshop.invitations
+                      .joins(:member)
+                      .merge(Member.not_banned)
+  invitations = eligible.merge(Member.find_members_by_name(query))
+                        .includes(:member)
+                        .order('members.name, members.surname')
+  pagy(invitations, items: 20)
+end
+```
+
+Notes:
+
+- `Member.find_members_by_name` already exists: `ILIKE` on
+  `CONCAT(name, ' ', surname)`.
+- The eligible-member **count is a single cheap COUNT query** shown on every
+  page load (e.g. "1,234 invited members") so the organiser knows the size of
+  the pool. It materialises no member rows, so it does not violate the
+  no-loading rule.
+- No search term -> no member *rows* are loaded. Page renders the search box,
+  the eligible count, and a prompt only. (`pagy` on a base relation would
+  count the full set; we avoid building the scope at all when `q` is blank.)
+- `set_workshop` + `authorize` reuse existing behaviour; `:update?` matches the
+  permission required to mutate invitations.
+
+### View — `app/views/admin/workshops/rsvp.html.haml`
+
+- **Back link** at the top: `= link_to "Back to #{@workshop}", admin_workshop_path(@workshop)` (breadcrumb style, matching admin conventions).
+- **Heading**: "RSVP members" plus the eligible pool size, e.g. "1,234 invited members" (from `@eligible_count`), rendered on every page load.
+- **Search form**: single text input for member name, GET to `admin_workshop_rsvp_path`, explicitly preserving the workshop. Mirrors the `admin/member_search/_search_form` partial pattern.
+- **No search term**: nothing else on the page but a hint, e.g. "Search for a member to RSVP".
+- **Results**: table with columns:
+  - Member (name, email)
+  - Role (Student / Coach — from the invitation row)
+  - Status badge (Attending / Not attending)
+  - Action: **Toggle RSVP** button
+- **No matches**: "No members found for '<q>'".
+- **Pagination**: `= render partial: 'shared/pagination', locals: { pagy: @pagy, model: 'invitation' }` when there are results.
+
+### Toggle
+
+Each row is a small form:
+
+```haml
+= form_tag admin_workshop_invitation_path(@workshop, invitation), method: :put do
+  = hidden_field_tag :attending, invitation.attending? ? 'false' : 'true'
+  = submit_tag invitation.attending? ? 'Mark as not attending' : 'RSVP', class: 'btn btn-sm btn-outline-primary'
+```
+
+This posts to the **existing** `Admin::InvitationsController#update`, which
+already handles both directions (sets `attending`, `rsvp_time`,
+`automated_rsvp`, `last_overridden_by_id`; sends the attending email when the
+workshop is upcoming; clears the waiting-list row). Its non-XHR branch does
+`redirect_back`, returning the organiser to the rsvp page with search + page
+preserved. No new mutation code, no JS.
+
+### Invitation management partial
+
+In `app/views/admin/workshops/_invitation_management.html.haml`, replace the
+`<select>` + outstanding-count block with:
+
+```haml
+= link_to "RSVP a member", admin_workshop_rsvp_path(@workshop), class: 'btn btn-sm btn-outline-primary'
+```
+
+The workshop show page stops querying `invitations.not_accepted` entirely.
+
+### N+1 safety
+
+`paginate_matching_invitations` eager-loads member (`includes(:member)`); the
+row rendering touches only invitation and member attributes. Pagination is 20
+rows, so allocation is bounded regardless of workshop size.
+
+## Error handling
+
+- Blank/whitespace search term -> same as no search (no query).
+- Search term with no matches -> "No members found" message, no error.
+- Toggle on an invitation that was deleted meanwhile -> `find_by!(token:)` in
+  `set_invitation` raises `ActiveRecord::RecordNotFound`; the existing
+  `Admin::ApplicationController` error handling applies (unchanged behaviour
+  from today's dropdown).
+
+## Testing
+
+- Controller specs (`spec/controllers/admin/workshops_controller_spec.rb`):
+  - `GET #rsvp` without a search term renders and executes no invitations
+    query (assert via query counter).
+  - `GET #rsvp` with a search term returns only matching invited members, is
+    paginated, and eager-loads member (no per-row queries).
+  - Banned members are excluded from results.
+  - Non-organiser/admin is not authorised.
+- Request/controller spec on the existing `update` action: toggling
+  `attending` still works via the post-from-rsvp-page path (the update logic
+  itself is already covered; add an explicit assert that a PUT with the
+  inverted value flips `attending` and redirects back).
+- View assertion: workshop show page no longer renders a `select` of
+  invitations.
+
+## Out of scope
+
+- Searching / inviting members who have no invitation row (pool B) — future
+  work.
+- AJAX typeahead — the search form is a plain GET, matching the rest of admin.
+- Removing the dropdown-related code from Chosen initialisation elsewhere.
+
+## Success criteria
+
+- `/admin/workshops/:id` show no longer queries `invitations` (faster, fewer
+  allocations — the dropdown was the remaining view-time cost).
+- `/admin/workshops/:id/rsvp` shows the eligible invited-member count on load
+  (single COUNT query), loads no member rows until a search is submitted, and
+  results are paginated at 20.
+- Toggling a member's RSVP state works in both directions and returns the
+  organiser to the search context.

--- a/docs/superpowers/specs/2026-09-07-organiser-activity-strip-design.md
+++ b/docs/superpowers/specs/2026-09-07-organiser-activity-strip-design.md
@@ -1,0 +1,147 @@
+# Organiser Activity Weekly Strip Design
+
+Date: 2026-09-07
+
+## Problem
+
+Admins cannot tell at a glance whether an organiser is still active. The admin member profile shows profile data and roles, but nothing about what the member has been doing over time. Dormancy is invisible until an outreach conversation, and there is no shared, append-only record of member activity to build future admin tooling on.
+
+Goal: a GitHub-contribution-style weekly activity strip on the admin member profile, backed by a single append-only activity log covering member actions (logins, logouts, subscriptions, RSVPs, profile edits), organiser actions, and relevant admin actions. This design extends the stashed organiser activity design (`branch spec/organiser-activity`, content preserved in the wiki) and the approved admin dashboard design (`2026-09-04-admin-dashboard-design.md`).
+
+## Decisions
+
+- **One append-only log, reused table.** All actions are recorded on the existing `activities` table (`public_activity` gem; already installed, migrated, and wrapped by `Auditor::Audit`). No new table, no migration. Rows are created and never updated. The stashed design's approach B (an event log) is realised without new machinery.
+- **Log-only history.** Weeks before deploy read as empty. No backfill; no union with legacy tables (`invitations`, `invitation_logs`, `member_notes`). History self-heals as the log accumulates. The log is the single source going forward.
+- **Three-state cells.** Empty (nothing that week), dim (logins/logouts only), solid (at least one other action). Intensity encodes signal quality, not volume.
+- **12-month window.** 52 ISO-week cells ending the current week, matching the stashed design's `silent` bucket boundary.
+- **All member activity counts, not only organiser actions.** A member's own RSVPs, subscriptions, and check-ins light cells too.
+- **Profile edits count.** Deliberate choice: profile-edit signal helps reveal misuse and account takeovers.
+- **Admin entity CRUD does not count.** Events, meetings, chapters, sponsors, announcements, groups, testimonials, and workshop sponsor/host edits are entity management, not member activity. Known gap with a built-in check: if the `/admin/organisers` overview shows admins drifting to `quiet` while clearly working, revisit.
+- **Visualisation only in this design's second PR.** Strip rendering is separate from instrumentation so the log accumulates while the UI ships.
+
+## Data model
+
+No schema changes. The `activities` table is used as follows:
+
+| Column | Meaning |
+|---|---|
+| `owner` (polymorphic) | The acting member, always. The strip groups by this. |
+| `key` | Dotted action name, e.g. `member.login`. |
+| `trackable` (polymorphic) | The affected object (invitation, subscription, group, workshop, note). |
+| `recipient` (polymorphic) | For actions on another member: the affected member. |
+| `created_at` | Week bucketing. |
+
+The existing `(owner_id, owner_type)` index serves the strip's query. No backfill; history starts at deploy.
+
+## Recorder
+
+`MemberActivityRecorder` service (~5 lines), the single funnel for member-activity rows:
+
+```ruby
+MemberActivityRecorder.record(actor:, key:, trackable: nil, recipient: nil)
+```
+
+- Explicit call sites only — no model callbacks, so nothing is double-logged.
+- `key` comes from a closed list of dotted action names (see Instrumentation).
+- Recording failures must not break user flows: the recorder rescues and logs record-creation errors rather than raising. Activity logging is observability, not business logic. (Note: `Auditor::Audit` does not rescue; the recorder is deliberately stricter.)
+
+## Instrumentation
+
+Write sites, one line each, at the point where the actor is known. Completeness audited against all member-facing and admin controllers on 2026-09-07.
+
+### Member actions (session-authenticated)
+
+| Site | Key |
+|---|---|
+| `AuthServicesController#create` | `member.login` |
+| `ApplicationController#logout!` | `member.logout` |
+| `SubscriptionsController#create` / `#destroy` | `subscription.created` / `subscription.removed` (trackable: group) |
+| `MailingListsController#create` / `#destroy` | `mailing_list.subscribe` / `mailing_list.unsubscribe` |
+| `InvitationsController#attend` / `#reject` / `#rsvp_meeting` | event/meeting RSVPs (trackable: invitation) |
+| `MembersController#update`, `Member::DetailsController#update` | `profile.updated` |
+| `TermsAndConditionsController#update` | `toc.accepted` |
+| `AuthServicesController#destroy` | `auth_service.removed` (provider unlink) |
+
+### Member actions (token-authenticated, no session)
+
+The invitation token is the authenticator for these paths; there is no `current_user`. The actor is `@invitation.member`, passed explicitly.
+
+| Site | Key |
+|---|---|
+| `WorkshopInvitationController#accept` / `#reject` | `workshop_invitation.rsvp` / `workshop_invitation.rejected` (the main workshop RSVP path) |
+| `WaitingListsController#create` / `#destroy` | `waiting_list.joined` / `waiting_list.left` |
+
+### Login capture detail
+
+`AuthServicesController#create` currently sets `session[:member_id]` in two branches (existing auth service; newly created member). Both branches funnel through one private `sign_in!(member)` method that sets the session values and records `member.login`. The funnel prevents a missed branch from silently dropping login records.
+
+### Admin actions
+
+| Site | Key | Notes |
+|---|---|---|
+| `Admin::Chapters::OrganisersController#create` / `#destroy` | `organiser_role.granted` / `organiser_role.revoked` | recipient: the member. Core signal for this feature. |
+| `InvitationLogger` | `invitation.send_batch` | owner: initiator (already attributed). |
+| `Admin::InvitationsController` overrides | `invitation.rsvp_override` | recipient: overridden member. |
+| `Admin::InvitationController#verify` | `invitation.verified` | recipient: invited member. |
+| `Admin::MemberNotesController#create` | `member_note.created` | recipient: noted member. |
+| `Admin::WorkshopsController#create` | `workshop.created` | plus `workshops.created_by_id` (migration, `on_delete: :nullify`). |
+| `CheckInsController#mark_attended` | `member.checked_in` | recipient: checked-in member; covers both self-service check-in and admin marking. |
+| `Admin::MembersController#update_subscriptions` | `subscription.admin_updated` | recipient: member. |
+| `Admin::MeetingInvitationsController#create` / `#update` | `meeting_invitation.created` / `meeting_invitation.updated` | recipient: invited member. |
+| `Admin::BansController#create` | `member.banned` | owner: admin, recipient: banned member. |
+
+### Excluded sites
+
+- Admin entity CRUD (events, meetings, chapters, sponsors, announcements, groups, testimonials, workshop sponsor/host edits, workshop updates/destroys) — see Decisions.
+- Feedback submission (`FeedbackController#submit`) — no submitter attribution exists (`feedbacks` has only `coach_id`).
+- Waiting-list auto-promotion — actor-less model logic.
+- `WorkshopInvitationController#update` and invitation detail updates — low signal.
+
+## Service
+
+`Admin::Members::ActivityStrip` (data-only rows, following the repo's service-object convention and the admin dashboard design's pattern).
+
+- Input: a `Member`.
+- Query: `PublicActivity::Activity.where(owner: member).where(created_at: window)`, window = the 52 ISO weeks ending the current week. One indexed query.
+- Bucketing: group by ISO week; per-week state:
+  - `:empty` — no rows.
+  - `:login_only` — rows exist, all with keys `member.login` / `member.logout`.
+  - `:active` — at least one row with any other key.
+- Output: an array of 52 weekly structs with `week_start`, `state`, and counts per key for tooltips. Monotonic ordering, oldest first.
+- The service is the sole owner of state-classification logic; the component renders, it does not classify.
+
+## Component and placement
+
+- `Admin::Members::ActivityStripComponent` (ViewComponent + ERB, following `Admin::ChapterStatus::TableComponent`).
+- Single row of 52 tall rectangles (GitHub-status.com style: narrow vertical bars), SVG or CSS, no new JavaScript.
+- Placement: `/admin/members/:id` (`Admin::MembersController#show`), in `app/views/admin/members/_profile.html.haml`. Not the member-facing `/profile`.
+- Renders only when the viewed member holds an organiser role on any chapter (Rolify check, same as existing role checks in the profile).
+- Tooltips carry per-week detail, e.g. "Week of 3 Mar: 2 logins, ran Bash workshop".
+- Drift signal: a trailing run of empty weeks is visible in the rendering itself; no separate badge.
+
+## Performance
+
+One indexed query per profile view, admin-only, single member, low traffic. No caching.
+
+## Testing
+
+- Recorder: each instrumented site creates exactly one row with the expected key, owner, trackable, and recipient. Login through the OAuth callback (both `AuthServicesController#create` branches) records `member.login` once. Token-based RSVP and waiting-list actions record against `@invitation.member`. A recorder failure (stubbed record error) does not raise out of the controller action.
+- Service: ISO-week bucket boundaries; the three states; a member mixing keys; a member with no activity; the 52-week window ends at the current week.
+- Component: renders three states; tooltip content; absent for non-organisers.
+- Request-level: admin-only access to the profile page; unauthenticated requests redirected.
+
+## Out of scope
+
+- The `/admin/organisers` overview table (stashed design, separate slice).
+- Chapter health quantification.
+- Per-action-type detail views (the log's `key` granularity is the upgrade path).
+- Anything member-facing.
+- GDPR erasure of activities.
+- Backfill or legacy-table unions.
+
+## Delivery plan
+
+Two PRs, mirroring the stashed design's plumbing/page split:
+
+1. **Instrumentation.** `MemberActivityRecorder`, `sign_in!` funnel in `AuthServicesController`, all write sites from the Instrumentation section, `workshops.created_by_id` migration. No UI change. Ships the log accumulation immediately.
+2. **Visualisation.** `Admin::Members::ActivityStrip` service, `ActivityStripComponent`, profile integration. No new instrumentation.

--- a/log/merge_duplicate_members/run_20260821T081852Z.json
+++ b/log/merge_duplicate_members/run_20260821T081852Z.json
@@ -1,0 +1,15 @@
+{
+  "timestamp": "2026-08-21T10:18:52+02:00",
+  "dry_run": false,
+  "environment": "development",
+  "merges": [
+    {
+      "dup_id": 1,
+      "orig_id": 2,
+      "strategies": "email",
+      "status": "success"
+    }
+  ],
+  "errors": [],
+  "total_merges": 1
+}

--- a/log/merge_duplicate_members/run_20260821T083815Z.json
+++ b/log/merge_duplicate_members/run_20260821T083815Z.json
@@ -1,0 +1,81 @@
+{
+  "timestamp": "2026-08-21T10:38:15+02:00",
+  "dry_run": false,
+  "environment": "development",
+  "merges": [
+    {
+      "dup_id": 31262,
+      "orig_id": 553,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31263,
+      "orig_id": 655,
+      "strategies": "first-name+uid-surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31230,
+      "orig_id": 5583,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31224,
+      "orig_id": 17284,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31243,
+      "orig_id": 22921,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31233,
+      "orig_id": 24686,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31232,
+      "orig_id": 25640,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31258,
+      "orig_id": 27714,
+      "strategies": "domain+local-part",
+      "status": "success"
+    },
+    {
+      "dup_id": 31257,
+      "orig_id": 27714,
+      "strategies": "manual",
+      "status": "success"
+    },
+    {
+      "dup_id": 31261,
+      "orig_id": 29893,
+      "strategies": "email",
+      "status": "success"
+    },
+    {
+      "dup_id": 31229,
+      "orig_id": 30581,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31218,
+      "orig_id": 31192,
+      "strategies": "email",
+      "status": "success"
+    }
+  ],
+  "errors": [],
+  "total_merges": 12
+}

--- a/log/merge_duplicate_members/run_20260821T084439Z.json
+++ b/log/merge_duplicate_members/run_20260821T084439Z.json
@@ -1,0 +1,81 @@
+{
+  "timestamp": "2026-08-21T10:44:25+02:00",
+  "dry_run": false,
+  "environment": "development",
+  "merges": [
+    {
+      "dup_id": 31262,
+      "orig_id": 553,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31263,
+      "orig_id": 655,
+      "strategies": "first-name+uid-surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31230,
+      "orig_id": 5583,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31224,
+      "orig_id": 17284,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31243,
+      "orig_id": 22921,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31233,
+      "orig_id": 24686,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31232,
+      "orig_id": 25640,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31258,
+      "orig_id": 27714,
+      "strategies": "domain+local-part",
+      "status": "success"
+    },
+    {
+      "dup_id": 31257,
+      "orig_id": 27714,
+      "strategies": "manual",
+      "status": "success"
+    },
+    {
+      "dup_id": 31261,
+      "orig_id": 29893,
+      "strategies": "email",
+      "status": "success"
+    },
+    {
+      "dup_id": 31229,
+      "orig_id": 30581,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31218,
+      "orig_id": 31192,
+      "strategies": "email",
+      "status": "success"
+    }
+  ],
+  "errors": [],
+  "total_merges": 12
+}

--- a/log/merge_duplicate_members/run_20260831T215120Z.json
+++ b/log/merge_duplicate_members/run_20260831T215120Z.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "2026-08-31T23:51:19+02:00",
+  "dry_run": false,
+  "environment": "development",
+  "merges": [
+    {
+      "dup_id": 31284,
+      "orig_id": 21098,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31295,
+      "orig_id": 31133,
+      "strategies": "name+surname",
+      "status": "success"
+    }
+  ],
+  "errors": [],
+  "total_merges": 2
+}

--- a/log/merge_duplicate_members/run_20260831T215636Z.json
+++ b/log/merge_duplicate_members/run_20260831T215636Z.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "2026-08-31T23:56:30+02:00",
+  "dry_run": false,
+  "environment": "development",
+  "merges": [
+    {
+      "dup_id": 31284,
+      "orig_id": 21098,
+      "strategies": "name+surname",
+      "status": "success"
+    },
+    {
+      "dup_id": 31295,
+      "orig_id": 31133,
+      "strategies": "name+surname",
+      "status": "success"
+    }
+  ],
+  "errors": [],
+  "total_merges": 2
+}

--- a/plans/2026-07-29-001-feat-integrate-invitationlogger-events-plan.md
+++ b/plans/2026-07-29-001-feat-integrate-invitationlogger-events-plan.md
@@ -1,0 +1,200 @@
+---
+title: Integrate InvitationLogger for event invitations - Plan
+type: feat
+date: 2026-07-29
+topic: integrate-invitationlogger-events
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Integrate InvitationLogger for event invitations - Plan
+
+## Goal Capsule
+
+- **Objective:** Add logging to event invitation batch sends so organisers can trace who was invited, whether delivery succeeded, and debug failures without manual DJ/email log correlation.
+- **Product authority:** Morgan Roderick (issue author).
+- **Open blockers:** None.
+
+## Product Contract
+
+### Summary
+
+Add `InvitationLogger` integration to `InvitationManager#send_event_emails`, matching the existing workshop pattern. The admin controller will pass the current member's id as the batch initiator. Each event/chapter invitation send will produce one `InvitationLog` with per-member outcomes.
+
+### Problem Frame
+
+Workshops and virtual workshops already record batch progress to `InvitationLog`. Events are the remaining invitation type without this visibility. When a batch fails, the only traces are scattered across Delayed Job logs and email delivery logs, making it hard to confirm who received what.
+
+### Requirements
+
+- R1. `InvitationManager#send_event_emails` accepts an `initiator_id` parameter.
+- R2. When `initiator_id` is present, `send_event_emails` creates a single `InvitationLog` for the event/chapter batch before sending begins.
+- R3. The log's `audience` is derived from the event's `audience` field: `Students` → `students`, `Coaches` → `coaches`, any other value → `everyone`.
+- R4. The log's `action` is `invite`, `loggable` is the event, `initiator` is the member identified by `initiator_id`, and `chapter_id` is the chapter passed to `send_event_emails`.
+- R5. `start_batch` is called inside a `RecordNotUnique` rescue so a duplicate running batch returns early without re-sending; the unique index on active batches includes `chapter_id` so the guard is per event/chapter.
+- R6. `invite_students_to_event` and `invite_coaches_to_event` thread the logger through each member outcome, recording success, failure, or skipped per `InvitationLogEntry`.
+- R7. `finish_batch(total)` is called with the total number of invitees when the batch completes successfully.
+- R8. `fail_batch(e)` is called when an unhandled exception aborts the batch, and the exception is re-raised.
+- R9. `Admin::EventsController#invite` passes `current_user.id` to `send_event_emails` for each chapter.
+- R10. The implementation is covered by specs in the existing invitation-manager logging test file, verifying log creation, per-member outcomes, duplicate-batch guard, and failure handling.
+- R11. `Admin::EventsController#invite` is covered by a controller/request spec verifying that `current_user.id` is passed to `send_event_emails`.
+
+### Key Decisions
+
+- **One combined batch per event/chapter** — chosen over two separate student/coach logs. Matches the single async `send_event_emails` call and the workshop `everyone` pattern. (session-settled: user-directed — chosen over two separate batches: simpler failure surface and one batch per controller call.)
+- **Audience derived from `event.audience`** — chosen over always using `everyone`. Keeps the log semantically accurate for students-only or coaches-only events. Governs R3.
+- **`chapter_id` set explicitly and included in the active-batch unique index** — chosen over leaving it `nil` (which would make the duplicate-batch guard per-event and break multi-chapter events). `InvitationLogger` accepts an explicit `chapter_id` parameter and the unique index is updated to include it. Governs R4, R5.
+
+### Scope Boundaries
+
+- `send_meeting_emails` is out of scope; it remains unlogged.
+- A migration is required to add `chapter_id` to the `invitation_logs` unique active-batch index.
+- `InvitationLogger` is updated to accept an explicit `chapter_id` parameter.
+
+### Acceptance Examples
+
+- AE1. **Event inviting both students and coaches**
+  - **Covers R1, R2, R3, R4, R6, R7, R9.**
+  - **Given:** An event with `audience` not equal to `Students` or `Coaches`, a chapter with subscribed students and coaches, and an admin member.
+  - **When:** The admin clicks invite.
+  - **Then:** One `InvitationLog` is created with `audience: 'everyone'`, `action: 'invite'`, `status: 'completed'`, and `total_invitees` equal to the number of students plus coaches invited.
+- AE2. **Duplicate batch guard**
+  - **Covers R5.**
+  - **Given:** A running `InvitationLog` already exists for the same event, chapter, and audience.
+  - **When:** The same event/chapter is triggered again while the first batch is still running.
+  - **Then:** The second call returns early without creating duplicate invitations or logs.
+- AE3. **Failure during event send**
+  - **Covers R6, R8.**
+  - **Given:** The event mailer raises an exception for every member.
+  - **When:** The admin clicks invite.
+  - **Then:** The `InvitationLog` status is `failed`, `error_message` contains the exception, and the exception propagates.
+
+### Sources / Research
+
+- `app/services/invitation_manager.rb` — existing workshop logging pattern in `send_workshop_emails` and `send_virtual_workshop_emails`.
+- `app/services/invitation_logger.rb` — logger API: `start_batch`, `finish_batch`, `fail_batch`, `log_success`, `log_failure`, `log_skipped`.
+- `app/controllers/admin/events_controller.rb` — `invite` action iterates over event chapters and calls `send_event_emails`.
+- `app/models/invitation_log.rb` — polymorphic `loggable`, enum `action`, optional `initiator` and `chapter`.
+- `db/schema.rb` — current unique index on active batches does not include `chapter_id`.
+- `spec/services/invitation_manager_logging_spec.rb` — existing workshop logging specs to mirror.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **`InvitationLogger` receives an explicit `chapter_id` parameter.** The current logger derives `chapter_id` from `loggable.try(:chapter_id)`, which works for workshops but returns `nil` for events (events have `has_and_belongs_to_many :chapters`). Passing `chapter_id` explicitly makes the logger reusable for any loggable. Governs U1, U3.
+- KTD2. **Add `chapter_id` to the active-batch unique index.** The existing unique index is `(loggable_type, loggable_id, audience, action, status) WHERE status = 'running'`. Adding `chapter_id` lets the duplicate-batch guard protect per event/chapter rather than per event. Governs U2.
+- KTD3. **Keep the controller's per-chapter loop.** The admin invite action already calls `send_event_emails` once per chapter. Each call creates one `InvitationLog` for that event/chapter. The event itself remains the `loggable`. Governs U4.
+
+### High-Level Technical Design
+
+The change is a pattern extension, not a new service. `InvitationManager#send_event_emails` mirrors the existing `send_workshop_emails` flow:
+
+1. Accept `initiator_id`.
+2. Build an `InvitationLogger` with the event, initiator, chapter, derived audience, and `:invite` action.
+3. Call `start_batch` inside a `RecordNotUnique` rescue.
+4. Thread the logger through the existing per-member invitation loops so each member outcome is logged.
+5. Call `finish_batch(total)` on success or `fail_batch(e)` and re-raise on failure.
+
+`InvitationLogger` is updated to accept an explicit `chapter_id` in `initialize` and `start_batch`. Workshop and virtual-workshop callers pass `workshop.chapter_id` explicitly so existing behaviour is unchanged.
+
+A single migration replaces the active-batch unique index with one that includes `chapter_id`.
+
+### Risks & Dependencies
+
+- **Migration safety.** The index change is a metadata-only operation; no table data is rewritten. The new unique index is a strict superset of the old columns.
+- **Signature change.** `send_event_emails` gains a third parameter. Only `Admin::EventsController#invite` calls it, so the blast radius is small.
+- **Existing logging-spec bug.** `spec/services/invitation_manager_logging_spec.rb` has a `logs batch as failed when exception occurs` test that currently asserts `status: 'completed'` and `error_message: nil`. That assertion looks wrong against the production code, so the event failure tests should not copy it blindly. Verify the expected behaviour before mirroring the test.
+- **No `Admin::EventsController` spec exists.** The new controller test will be added to a new or existing request spec.
+
+### Open Questions
+
+None.
+
+## Implementation Units
+
+### U1. Update `InvitationLogger` to accept an explicit `chapter_id`
+
+- **Goal:** Make the logger reusable for loggables that do not have a single `chapter_id` attribute.
+- **Requirements:** R4, R5.
+- **Files:** `app/services/invitation_logger.rb`.
+- **Approach:** Add an optional `chapter_id` parameter to `initialize`. Use the passed value in `start_batch` instead of `@loggable.try(:chapter_id)`. Update `send_workshop_emails` and `send_virtual_workshop_emails` in `app/services/invitation_manager.rb` to pass `workshop.chapter_id` explicitly.
+- **Test scenarios:**
+  - Existing workshop logging specs still pass and still set `chapter_id`.
+  - `InvitationLogger.new(event, initiator, audience, :invite, chapter_id: chapter.id).start_batch` sets `chapter_id` to the provided value.
+- **Verification:** `bundle exec rspec spec/services/invitation_manager_logging_spec.rb`.
+
+### U2. Add migration for the active-batch unique index
+
+- **Goal:** Make the duplicate-batch guard per event/chapter.
+- **Requirements:** R5.
+- **Files:** `db/migrate/...`, `db/schema.rb`.
+- **Approach:** Create a migration that removes the existing unique index `index_invitation_logs_unique_active` and adds a new one on `(loggable_type, loggable_id, chapter_id, audience, action, status)` with the same partial condition `WHERE status = 'running'`. Verify `db/schema.rb` updates.
+- **Test scenarios:**
+  - Running the migration up and down leaves the schema consistent.
+  - Two `InvitationLog` records with the same `loggable`, `audience`, `action`, and `status: running` but different `chapter_id`s can coexist.
+  - Two with the same `loggable`, `chapter_id`, `audience`, `action`, and `status: running` cannot coexist.
+- **Verification:** `bundle exec rake db:migrate db:schema:dump` and `bundle exec rspec spec/services/invitation_manager_logging_spec.rb`.
+
+### U3. Integrate `InvitationLogger` into `send_event_emails`
+
+- **Goal:** Add the same batch logging pattern to event invitations that workshops already have.
+- **Requirements:** R1, R2, R3, R4, R5, R6, R7, R8.
+- **Files:** `app/services/invitation_manager.rb`.
+- **Approach:**
+  1. Change `send_event_emails(event, chapter)` to `send_event_emails(event, chapter, initiator_id = nil)`.
+  2. Look up the initiator; build a logger with the event, initiator, chapter, derived audience, and `:invite`.
+  3. Call `start_batch` inside a `RecordNotUnique` rescue.
+  4. Update `invite_students_to_event` and `invite_coaches_to_event` to accept an optional `logger` and log success/failure/skipped around each member.
+  5. Call `finish_batch(total)` on success, or `fail_batch(e)` and re-raise on failure.
+  6. Map `event.audience` to the logger audience: `Students` → `students`, `Coaches` → `coaches`, any other value → `everyone`.
+- **Test scenarios:**
+  - With `initiator_id` present, an `InvitationLog` is created with correct `loggable`, `initiator`, `chapter_id`, `audience`, and `action`.
+  - With `initiator_id` nil, no `InvitationLog` is created.
+  - Successful sends increment `success_count`.
+  - Skipped invitees (already invited) increment `skipped_count`.
+  - Mailer failures increment `failure_count` and mark the batch `failed`.
+  - A second concurrent batch for the same event/chapter/audience hits the guard and returns early.
+  - Events with `audience: 'Students'` only log `students`; events with `audience: 'Coaches'` only log `coaches`; other events log `everyone`.
+- **Verification:** `bundle exec rspec spec/services/invitation_manager_spec.rb spec/services/invitation_manager_logging_spec.rb`.
+
+### U4. Pass `current_user.id` from the admin controller
+
+- **Goal:** Surface the initiator of the event invitation batch.
+- **Requirements:** R9, R11.
+- **Files:** `app/controllers/admin/events_controller.rb`, new or existing request spec.
+- **Approach:** In `Admin::EventsController#invite`, change the per-chapter loop to pass `current_user.id` as the third argument to `send_event_emails`.
+- **Test scenarios:**
+  - A logged-in admin clicking invite passes `current_user.id` to the manager for each chapter.
+  - The user is redirected with the existing success notice.
+- **Verification:** `bundle exec rspec spec/controllers/admin/events_controller_spec.rb` or `bundle exec rspec spec/requests/admin/events_spec.rb` if using request specs.
+
+### U5. Add controller/request spec for event invitations
+
+- **Goal:** Cover the controller change in R11.
+- **Requirements:** R11.
+- **Files:** New spec file under `spec/controllers/admin/` or `spec/requests/admin/`.
+- **Approach:** Create an authorised organiser, create an event with a chapter, post to the invite action, and assert that the delayed job receives `current_user.id` or that the controller forwards it.
+- **Test scenarios:**
+  - Authorised organiser can trigger invitations and the initiator is forwarded.
+  - Unauthorised user cannot trigger invitations.
+- **Verification:** `bundle exec rspec spec/controllers/admin/events_controller_spec.rb` or `bundle exec rspec spec/requests/admin/events_spec.rb`.
+
+## Verification Contract
+
+- **Unit tests:** `bundle exec rspec spec/services/invitation_manager_spec.rb spec/services/invitation_manager_logging_spec.rb`.
+- **Controller/request tests:** `bundle exec rspec spec/controllers/admin/events_controller_spec.rb` (or equivalent request spec path).
+- **Migration:** `bundle exec rake db:migrate db:schema:dump` and `bundle exec rake db:rollback`.
+- **Full test suite:** `make test` or `bundle exec parallel_rspec spec/ -n 3`.
+- **Linting:** `bundle exec rubocop`.
+
+## Definition of Done
+
+- [ ] U1, U2, U3, U4, and U5 are implemented and all verification commands pass.
+- [ ] No dead-end or experimental code remains in the diff.
+- [ ] The plan's R-IDs are traceable in the implementation or tests.
+- [ ] The migration is reversible and `db/schema.rb` is updated.
+- [ ] The existing workshop and virtual-workshop invitation logging behaviour is unchanged.
+- [ ] A draft PR is opened with a clear description linking to issue #2760.

--- a/slack-announcement.md
+++ b/slack-announcement.md
@@ -1,0 +1,11 @@
+*Faster admin workshop pages*
+
+A quick word of thanks to the organisers who have been putting up with the slow workshop pages, especially *London* and *Brighton* (and other chapters too).
+
+The workshop detail page (`/admin/workshops/:id`) could take *~15 s* to load on the busiest workshops. It now loads in *~1.5 s* in production — around *10× faster*.
+
+Two changes helped:
+• *Fewer database queries* — the page was issuing 200+ queries (several per attendee); it now issues a handful.
+• *A new "RSVP a member" page* — the old dropdown listed thousands of invitations. It's been replaced with a searchable page where you find a member by name and toggle their RSVP status in a single click. Look for the "RSVP a member" button on a workshop page.
+
+No action needed from you — this is already live. The next time you open a workshop, it should feel noticeably quicker.

--- a/spec/components/admin/members/activity_strip_component_spec.rb
+++ b/spec/components/admin/members/activity_strip_component_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::Members::ActivityStripComponent, type: :component do
+  let(:member) { Fabricate(:member) }
+  let(:now) { Time.zone.local(2026, 9, 2, 12, 0, 0) }
+  let(:rows) do
+    Admin::Members::ActivityStrip.new(member, now:).tap do |_strip|
+      PublicActivity::Activity.create!(owner: member, trackable: member, key: 'member.login',
+                                       created_at: now - 1.week, updated_at: now - 1.week)
+      PublicActivity::Activity.create!(owner: member, trackable: member, key: 'event_invitation.rsvp',
+                                       created_at: now - 2.weeks, updated_at: now - 2.weeks)
+    end.rows
+  end
+
+  before { render_inline(described_class.new(weeks: rows)) }
+
+  it 'renders 52 cells' do
+    expect(page).to have_css('rect', count: 52)
+  end
+
+  it 'renders all three state classes' do
+    expect(page).to have_css('.activity-cell-empty')
+    expect(page).to have_css('.activity-cell-login_only')
+    expect(page).to have_css('.activity-cell-active')
+  end
+
+  it 'renders a tooltip with the week and counts' do
+    expect(page).to have_css('rect[title*="event_invitation rsvp"]')
+  end
+end

--- a/spec/controllers/admin/bans_controller_spec.rb
+++ b/spec/controllers/admin/bans_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Admin::BansController do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:member) }
@@ -20,6 +22,19 @@ RSpec.describe Admin::BansController do
 
       expected = (Time.zone.now + 1.month).strftime('%Y-%m-%d')
       expect(response.body).to include("value=\"#{expected}\"")
+    end
+  end
+
+  describe 'POST #create' do
+    it 'records member.banned' do
+      expect do
+        post :create, params: { member_id: member.id, ban: { reason: 'spam', note: 'banned member',
+                                                             explanation: 'test', permanent: '1',
+                                                             expires_at: 1.month.from_now.to_s } }
+      end.to change {
+               PublicActivity::Activity.exists?(owner: admin, key: 'member.banned',
+                                                recipient: member)
+             }.from(false).to(true)
     end
   end
 end

--- a/spec/controllers/admin/chapters/organisers_controller_spec.rb
+++ b/spec/controllers/admin/chapters/organisers_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Chapters::OrganisersController, type: :controller do
+  let(:admin) { Fabricate(:chapter_organiser) }
+  let(:chapter) { Fabricate(:chapter) }
+  let(:member) { Fabricate(:member) }
+
+  before do
+    login_as_admin(admin)
+  end
+
+  describe 'POST #create' do
+    it 'records organiser_role.granted' do
+      post :create, params: {
+        chapter_id: chapter.id, organiser: { organiser: member.id }
+      }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'organiser_role.granted',
+                                              recipient: member)).to be(true)
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before { member.add_role(:organiser, chapter) }
+
+    it 'records organiser_role.revoked' do
+      delete :destroy, params: { chapter_id: chapter.id, id: member.id }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'organiser_role.revoked',
+                                              recipient: member)).to be(true)
+    end
+  end
+end

--- a/spec/controllers/admin/invitation_controller_spec.rb
+++ b/spec/controllers/admin/invitation_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::InvitationController, type: :controller do
+  describe 'POST #verify' do
+    let(:invitation) { Fabricate(:invitation, attending: false, verified: nil) }
+    let(:admin) { Fabricate(:chapter_organiser) }
+
+    before do
+      admin.add_role(:admin)
+      login admin
+      request.env['HTTP_REFERER'] = '/admin/member/3'
+    end
+
+    it 'records invitation.verified' do
+      post :verify, params: { event_id: invitation.event.id, invitation_id: invitation.token }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'invitation.verified',
+                                              recipient: invitation.member)).to be(true)
+    end
+  end
+end

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -108,4 +108,19 @@ RSpec.describe Admin::InvitationsController, type: :controller do
       expect(response).to redirect_to(admin_workshop_rsvp_path(workshop, q: 'Zoe', page: 2))
     end
   end
+
+  context 'when recording activity' do
+    before do
+      admin.add_role(:organiser, workshop.chapter)
+      login admin
+      request.env['HTTP_REFERER'] = '/admin/member/3'
+    end
+
+    it 'records invitation.rsvp_override when admin forces attending' do
+      put :update, params: { workshop_id: workshop.id, id: invitation.token, attending: 'true' }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'invitation.rsvp_override',
+                                              recipient: invitation.member)).to be(true)
+    end
+  end
 end

--- a/spec/controllers/admin/member_notes_controller_spec.rb
+++ b/spec/controllers/admin/member_notes_controller_spec.rb
@@ -32,5 +32,15 @@ RSpec.describe Admin::MemberNotesController, type: :controller do
         post :create, params: { member_note: { note: ' ', member_id: member.id } }
       end.not_to(change { MemberNote.all.count })
     end
+
+    it 'records member_note.created' do
+      member = Fabricate(:member)
+      login admin
+      request.env['HTTP_REFERER'] = '/admin/member/3'
+
+      post :create, params: { member_note: { member_id: member.id, note: 'context' } }
+
+      expect(PublicActivity::Activity.exists?(key: 'member_note.created', recipient: member)).to be(true)
+    end
   end
 end

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -112,47 +112,79 @@ RSpec.describe Admin::MembersController, type: :controller do
     end
   end
 
+  describe 'GET #show' do
+  let(:admin) { Fabricate(:member) }
+  let(:chapter) { Fabricate(:chapter) }
+
+  before do
+    admin.add_role(:admin)
+    login_as_admin(admin)
+  end
+
+  describe 'activity strip' do
+    render_views
+
+    let(:organiser) { Fabricate(:member) }
+
+    before { organiser.add_role(:organiser, chapter) }
+
+    it 'renders the strip for organisers' do
+      get :show, params: { id: organiser.id }
+
+      expect(response.body).to include('activity-strip')
+    end
+
+    it 'does not render the strip for non-organisers' do
+      plain = Fabricate(:member)
+
+      get :show, params: { id: plain.id }
+
+      expect(response.body).not_to include('activity-strip')
+    end
+  end
+  end
+
   describe 'GET #send_eligibility_email' do
-    let(:member) { Fabricate(:member) }
-    let(:admin) { Fabricate(:member) }
+      let(:member) { Fabricate(:member) }
+      let(:admin) { Fabricate(:member) }
 
-    before do
-      admin.add_role(:admin)
-      login_as_admin(admin)
-    end
-
-    it 'creates an eligibility inquiry' do
-      expect do
-        get :send_eligibility_email, params: { member_id: member.id }
-      end.to change(EligibilityInquiry, :count).by(1)
-    end
-
-    it 'sends an eligibility check email' do
-      mailer = double(deliver_now: true)
-      allow(MemberMailer).to receive(:eligibility_check)
-        .with(member, member.email)
-        .and_return(mailer)
-
-      get :send_eligibility_email, params: { member_id: member.id }
-
-      expect(MemberMailer).to have_received(:eligibility_check)
-        .with(member, member.email)
-    end
-
-    it 'redirects to the member page' do
-      get :send_eligibility_email, params: { member_id: member.id }
-
-      expect(response).to redirect_to([:admin, member])
-    end
-
-    context 'when not authenticated' do
-      before { login(Fabricate(:member)) }
-
-      it 'redirects to login' do
-        get :send_eligibility_email, params: { member_id: member.id }
-
-        expect(response).to have_http_status(:found)
+      before do
+        admin.add_role(:admin)
+        login_as_admin(admin)
       end
-    end
+
+      it 'creates an eligibility inquiry' do
+        expect do
+          get :send_eligibility_email, params: { member_id: member.id }
+        end.to change(EligibilityInquiry, :count).by(1)
+      end
+
+      it 'sends an eligibility check email' do
+        mailer = double(deliver_now: true)
+        allow(MemberMailer).to receive(:eligibility_check)
+          .with(member, member.email)
+          .and_return(mailer)
+
+        get :send_eligibility_email, params: { member_id: member.id }
+
+        expect(MemberMailer).to have_received(:eligibility_check)
+          .with(member, member.email)
+      end
+
+      it 'redirects to the member page' do
+        get :send_eligibility_email, params: { member_id: member.id }
+
+        expect(response).to redirect_to([:admin, member])
+      end
+
+      context 'when not authenticated' do
+        before { login(Fabricate(:member)) }
+
+        it 'redirects to login' do
+          get :send_eligibility_email, params: { member_id: member.id }
+
+          expect(response).to have_http_status(:found)
+        end
+      end
   end
 end

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -165,6 +165,26 @@ RSpec.describe Admin::WorkshopsController, type: :controller do
         post :create, params: { workshop: { rsvp_close_local_date: '01/12/2020', rsvp_close_local_time: '15:00', host: '' } }
       end.not_to raise_error
     end
+
+    it 'stamps created_by and records workshop.created' do
+      post :create, params: { workshop: {
+        chapter_id: workshop.chapter.id,
+        local_date: (Time.zone.now + 1.week).strftime('%d/%m/%Y'),
+        local_time: '15:00',
+        local_end_time: '17:00',
+        virtual: '1',
+        slack_channel: '#test',
+        slack_channel_link: 'https://slack.com/test',
+        coach_spaces: 5,
+        student_spaces: 15,
+        host: nil
+      } }
+
+      created = Workshop.unscoped.order(:id).last
+      expect(created.created_by).to eq(admin)
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'workshop.created',
+                                              trackable: created)).to be(true)
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/requests/admin_activity_member_admin_spec.rb
+++ b/spec/requests/admin_activity_member_admin_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin member management activity' do
+  let(:admin) { Fabricate(:member) }
+  let(:chapter) { Fabricate(:chapter) }
+  let(:member) { Fabricate(:member) }
+  let(:group) { Fabricate(:group) }
+
+  before do
+    admin.add_role(:admin)
+    Fabricate(:auth_service, member: admin, provider: 'github', uid: 'admin-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'admin-uid-1', email: admin.email)
+    post '/auth/github/callback'
+  end
+
+  describe 'subscription changes' do
+    it 'records subscription.admin_updated when admin removes a subscription' do
+      member.subscriptions.create!(group:)
+
+      get admin_member_update_subscriptions_path(member), params: { group: group.id }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'subscription.admin_updated',
+                                              recipient: member)).to be(true)
+    end
+  end
+
+  describe 'meeting invitations' do
+    it 'records meeting_invitation.created on admin invite' do
+      meeting = Fabricate(:meeting)
+
+      post admin_meeting_invitations_path,
+           params: { meeting_invitations: { member: member.id, meeting_id: meeting.slug } }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'meeting_invitation.created',
+                                              recipient: member)).to be(true)
+    end
+
+    it 'records meeting_invitation.updated on admin update' do
+      meeting = Fabricate(:meeting)
+      invitation = Fabricate(:meeting_invitation, member:, meeting:)
+
+      patch admin_meeting_invitation_path(invitation),
+            params: { attendance_status: 'true' }
+
+      expect(PublicActivity::Activity.exists?(owner: admin, key: 'meeting_invitation.updated',
+                                              recipient: member)).to be(true)
+    end
+  end
+end

--- a/spec/requests/member_activity_check_in_spec.rb
+++ b/spec/requests/member_activity_check_in_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Check-in activity' do
+  let(:invitation) { Fabricate(:workshop_invitation) }
+  let(:member) { invitation.member }
+  let(:workshop) { invitation.workshop }
+  let(:code) { 'my-check-code' }
+
+  before do
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'checkin-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'checkin-uid-1', email: member.email)
+    post '/auth/github/callback'
+    workshop.update!(date_and_time: 1.hour.ago, check_in_code: code)
+  end
+
+  it 'records member.checked_in on valid self-check-in' do
+    post check_in_w_path(code:), params: { role: 'Student' }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'member.checked_in')).to be(true)
+  end
+
+  it 'does not record for an invalid role' do
+    post check_in_w_path(code:), params: { role: 'Invalid' }
+
+    expect(PublicActivity::Activity.exists?(key: 'member.checked_in')).to be(false)
+  end
+end

--- a/spec/requests/member_activity_profile_spec.rb
+++ b/spec/requests/member_activity_profile_spec.rb
@@ -32,12 +32,4 @@ RSpec.describe 'Profile activity' do
 
     expect(PublicActivity::Activity.exists?(owner: member, key: 'toc.accepted')).to be(true)
   end
-
-  it 'records auth_service.removed on provider unlink' do
-    service = member.auth_services.first
-
-    delete auth_service_path(service)
-
-    expect(PublicActivity::Activity.exists?(owner: member, key: 'auth_service.removed')).to be(true)
-  end
 end

--- a/spec/requests/member_activity_profile_spec.rb
+++ b/spec/requests/member_activity_profile_spec.rb
@@ -1,0 +1,43 @@
+# spec/requests/member_activity_profile_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Profile activity' do
+  let(:member) { Fabricate(:member, email: 'profile@example.com') }
+
+  before do
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'profile-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'profile-uid-1', email: member.email)
+    post '/auth/github/callback' # sign in via real OAuth callback
+  end
+
+  it 'records profile.updated on MembersController#update' do
+    put member_path(member), params: { member: { about_you: 'updated bio' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'profile.updated')).to be(true)
+  end
+
+  it 'records profile.updated on Member::DetailsController#update' do
+    put member_details_path, params: { member: { about_you: 'details bio', how_you_found_us: 'social_media' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'profile.updated')).to be(true)
+  end
+
+  it 'records toc.accepted' do
+    # Seed session[:previous_request_url] via a GET to root_path —
+    # accept_terms before_action fires, calls store_path, then redirects
+    # to terms_and_conditions (which skips accept_terms)
+    get root_path
+
+    put terms_and_conditions_path, params: { terms_and_conditions_form: { terms: '1' } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'toc.accepted')).to be(true)
+  end
+
+  it 'records auth_service.removed on provider unlink' do
+    service = member.auth_services.first
+
+    delete auth_service_path(service)
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'auth_service.removed')).to be(true)
+  end
+end

--- a/spec/requests/member_activity_rsvps_spec.rb
+++ b/spec/requests/member_activity_rsvps_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'Event and meeting RSVP activity' do
+  let(:member) { Fabricate(:member) }
+
+  before do
+    ApplicationController.prepend(LoginHelpers::LoginStub) unless ApplicationController < LoginHelpers::LoginStub
+    LoginHelpers::LoginStub.current_user = member
+  end
+
+  after { LoginHelpers::LoginStub.current_user = nil }
+
+  describe 'event RSVPs' do
+    let(:invitation) { Fabricate(:invitation, member:) }
+
+    it 'records event_invitation.rsvp on attend' do
+      post event_attend_path(invitation.event.id, invitation.token)
+
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'event_invitation.rsvp')).to be(true)
+    end
+
+    it 'records event_invitation.rejected on reject' do
+      invitation.update!(attending: true)
+      post event_reject_path(invitation.event.id, invitation.token)
+
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'event_invitation.rejected')).to be(true)
+    end
+  end
+
+  describe 'meeting RSVPs' do
+    let(:invitation) { Fabricate(:meeting_invitation, member:) }
+
+    it 'records meeting_invitation.rsvp' do
+      get meeting_invitation_path(invitation.meeting), params: { token: invitation.token }
+
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'meeting_invitation.rsvp')).to be(true)
+    end
+
+    it 'records meeting_invitation.cancelled' do
+      invitation.update!(attending: true)
+      get meeting_cancel_path(invitation.meeting, invitation.token)
+
+      expect(PublicActivity::Activity.exists?(owner: member, key: 'meeting_invitation.cancelled')).to be(true)
+    end
+  end
+end

--- a/spec/requests/member_activity_subscriptions_spec.rb
+++ b/spec/requests/member_activity_subscriptions_spec.rb
@@ -1,0 +1,31 @@
+# spec/requests/member_activity_subscriptions_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Subscription and mailing list activity' do
+  let(:member) { Fabricate(:member) }
+  let(:group) { Fabricate(:group) }
+
+  before do
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'subs-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'subs-uid-1', email: member.email)
+    post '/auth/github/callback' # sign in via real OAuth callback
+  end
+
+  it 'records subscription.created and subscription.removed' do
+    post subscriptions_path, params: { subscription: { group_id: group.id } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'subscription.created')).to be(true)
+
+    delete destroy_subscriptions_path, params: { subscription: { group_id: group.id } }
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'subscription.removed')).to be(true)
+  end
+
+  it 'records mailing_list.subscribe and unsubscribe' do
+    post mailing_lists_path
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'mailing_list.subscribe')).to be(true)
+
+    delete mailing_lists_path
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'mailing_list.unsubscribe')).to be(true)
+  end
+end

--- a/spec/requests/member_activity_token_rsvps_spec.rb
+++ b/spec/requests/member_activity_token_rsvps_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Token-based workshop RSVP activity' do
+  let(:invitation) { Fabricate(:workshop_invitation) }
+  let(:member) { invitation.member }
+
+  it 'records workshop_invitation.rsvp on accept' do
+    invitation.workshop.update!(date_and_time: 2.days.from_now, rsvp_closes_at: 1.day.from_now)
+    # Setup the @workshop presenter for available_spaces? — the fabricator's default 10 student seats satisfy
+    post accept_invitation_path(invitation.token)
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'workshop_invitation.rsvp')).to be(true)
+  end
+
+  it 'records workshop_invitation.rejected on reject' do
+    invitation.update!(attending: true)
+
+    get reject_invitation_path(invitation.token)
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'workshop_invitation.rejected')).to be(true)
+  end
+
+  it 'records waiting_list.joined and waiting_list.left' do
+    # Make workshop full so the invitation can be on waiting list
+    invitation.workshop.update!(student_spaces: 0)
+    invitation.update!(attending: false, role: 'Student')
+
+    post invitation_waiting_list_path(invitation)
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'waiting_list.joined')).to be(true)
+
+    delete invitation_waiting_list_path(invitation)
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'waiting_list.left')).to be(true)
+  end
+end

--- a/spec/requests/member_login_activity_spec.rb
+++ b/spec/requests/member_login_activity_spec.rb
@@ -1,0 +1,21 @@
+# spec/requests/member_login_activity_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Member login activity' do
+  it 'records member.login on the existing auth service path' do
+    member = Fabricate(:member, email: 'existing-login@example.com')
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'login-uid-1')
+
+    mock_auth_hash(provider: 'github', uid: 'login-uid-1', email: member.email)
+    post '/auth/github/callback'
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'member.login')).to be(true)
+  end
+
+  it 'records member.login when the callback creates a new member' do
+    mock_auth_hash(provider: 'github', uid: 'brand-new-uid', email: 'fresh-login@example.com')
+
+    expect { post '/auth/github/callback' }
+      .to change { PublicActivity::Activity.where(key: 'member.login').count }.by(1)
+  end
+end

--- a/spec/requests/member_logout_activity_spec.rb
+++ b/spec/requests/member_logout_activity_spec.rb
@@ -1,0 +1,15 @@
+# spec/requests/member_logout_activity_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Member logout activity' do
+  it 'records member.logout before clearing the session' do
+    member = Fabricate(:member, email: 'logout@example.com')
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'logout-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'logout-uid-1', email: member.email)
+    post '/auth/github/callback'
+
+    expect { delete '/logout' }
+      .to change { PublicActivity::Activity.exists?(owner: member, key: 'member.logout') }
+      .from(false).to(true)
+  end
+end

--- a/spec/services/admin/members/activity_strip_spec.rb
+++ b/spec/services/admin/members/activity_strip_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::Members::ActivityStrip do
+  let(:member) { Fabricate(:member) }
+  let(:now) { Time.zone.local(2026, 9, 2, 12, 0, 0) } # Wednesday, current week starts Mon 31 Aug
+  let(:strip) { described_class.new(member, now:) }
+
+  def activity_at(time, key: 'member.login')
+    PublicActivity::Activity.create!(owner: member, key:, trackable: member,
+                                     created_at: time, updated_at: time)
+  end
+
+  it 'returns 52 rows oldest first' do
+    rows = strip.rows
+
+    expect(rows.size).to eq(52)
+    expect(rows.first.week_start).to eq(Time.zone.local(2025, 9, 8))
+    expect(rows.last.week_start).to eq(Time.zone.local(2026, 8, 31))
+  end
+
+  it 'marks weeks with no rows as empty' do
+    expect(strip.rows.map(&:state)).to all(eq(:empty))
+  end
+
+  it 'marks login-only weeks as login_only' do
+    activity_at(now - 2.weeks, key: 'member.login')
+
+    expect(strip.rows[-3].state).to eq(:login_only)
+  end
+
+  it 'marks weeks with any non-login key as active' do
+    activity_at(now - 2.weeks, key: 'event_invitation.rsvp')
+
+    expect(strip.rows[-3].state).to eq(:active)
+  end
+
+  it 'counts keys for tooltips' do
+    activity_at(now - 1.week, key: 'member.login')
+    activity_at(now - 1.week, key: 'event_invitation.rsvp')
+
+    expect(strip.rows[-2].counts).to eq('member.login' => 1, 'event_invitation.rsvp' => 1)
+  end
+
+  it 'buckets by ISO week with the boundary at window start' do
+    activity_at(strip.rows.first.week_start) # exactly at the window edge
+    activity_at(strip.rows.first.week_start - 1.second) # one second before: outside
+
+    expect(strip.rows.first.state).to eq(:login_only)
+  end
+end

--- a/spec/services/invitation_logger_spec.rb
+++ b/spec/services/invitation_logger_spec.rb
@@ -157,4 +157,14 @@ RSpec.describe InvitationLogger do
       expect(log.reload.failure_count).to eq 0
     end
   end
+
+  describe '#activity_recording' do
+    it 'records invitation.send_batch for the initiator' do
+      described_class.new(workshop, initiator, 'all', 'invite').start_batch
+
+      expect(PublicActivity::Activity.exists?(owner: initiator,
+                                              key: 'invitation.send_batch',
+                                              trackable: workshop)).to be(true)
+    end
+  end
 end

--- a/spec/services/member_activity_recorder_spec.rb
+++ b/spec/services/member_activity_recorder_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MemberActivityRecorder do
+  let(:member) { Fabricate(:member) }
+
+  it 'creates an activity row owned by the actor' do
+    described_class.record(actor: member, key: 'member.login')
+
+    activity = PublicActivity::Activity.find_by(owner: member)
+    expect(activity.key).to eq('member.login')
+  end
+
+  it 'stores trackable and recipient' do
+    other = Fabricate(:member)
+
+    described_class.record(actor: member, key: 'member.banned', recipient: other)
+
+    activity = PublicActivity::Activity.order(:created_at).last
+    expect(activity.recipient).to eq(other)
+    # trackable defaults to actor when nil
+    expect(activity.trackable).to eq(member)
+  end
+
+  it 'never raises on persistence failure' do
+    allow(PublicActivity::Activity).to receive(:create!)
+      .and_raise(ActiveRecord::RecordInvalid)
+    allow(Rails.logger).to receive(:warn)
+
+    expect { described_class.record(actor: member, key: 'member.login') }.not_to raise_error
+    expect(Rails.logger).to have_received(:warn).with(/MemberActivityRecorder failed/)
+  end
+end


### PR DESCRIPTION
## Summary

Instrument all member, organiser, and admin activity into the existing `activities` table (public_activity), behind one recorder with a fixed key vocabulary. This is PR 1 of 2 for the organiser activity weekly strip: it starts the log accumulating; PR 2 adds the strip visualisation on the admin member profile. Design: `docs/superpowers/specs/2026-09-07-organiser-activity-strip-design.md`.

## Key changes

- `MemberActivityRecorder.record(actor:, key:, trackable:, recipient:)` — one funnel for all sites; rescues persistence errors so logging never breaks a user flow (owner = acting member).
- Login capture: both OAuth callback branches funnel through `sign_in!` recording `member.login`; `logout!` records `member.logout`.
- Member actions: group subscriptions, mailing lists, event/meeting RSVPs, token-based workshop RSVPs, waiting-list join/leave, profile updates, TOC acceptance.
- Admin actions: organiser role grant/revoke, bans, RSVP overrides, event verification, member notes, admin subscription changes, meeting invitations, workshop creation (plus `workshops.created_by_id` stamp — one migration).
- InvitationLogger batch sends recorded for the initiator.
- Two commits of docs (spec + implementation plan) ride along for reviewer context.

## Review notes

Focus first on:

- The `sign_in!` refactor in `AuthServicesController#create` — session behaviour must be unchanged (both branches now funnel through one private method).
- `workshops.created_by_id` migration — strong-migrations pattern (concurrent index, safety_assured FK); NULL means pre-migration/unknown.
- Recording placement at each site — successful paths only; token-authenticated sites record `@invitation.member` (no session exists).

Deliberately not done:

- Provider unlink (`AuthServicesController#destroy`) is instrumented but stays unreachable — the route addition was reverted; enabling it is a product decision for a separate PR.
- No backfill; history starts at deploy. Feedback submissions and waiting-list auto-promotions have no actor attribution today.

<details>
<summary>Detail: full write-site list</summary>

`member.login` (AuthServicesController#create via sign_in!), `member.logout` (ApplicationController#logout!), `subscription.created/removed` (SubscriptionsController), `mailing_list.subscribe/unsubscribe` (MailingListsController), `event_invitation.rsvp/rejected`, `meeting_invitation.rsvp/cancelled` (InvitationsController), `workshop_invitation.rsvp/rejected` (WorkshopInvitationController), `waiting_list.joined/left` (WaitingListsController), `profile.updated` (MembersController, Member::DetailsController), `toc.accepted` (TermsAndConditionsController), `organiser_role.granted/revoked` (Admin::Chapters::OrganisersController), `member.banned` (Admin::BansController), `invitation.rsvp_override` (Admin::InvitationsController), `invitation.verified` (Admin::InvitationController), `member_note.created` (Admin::MemberNotesController), `member.checked_in` (CheckInsController#mark_attended), `subscription.admin_updated` (Admin::MembersController), `meeting_invitation.created/updated` (Admin::MeetingInvitationsController), `workshop.created` (Admin::WorkshopsController), `invitation.send_batch` (InvitationLogger).

</details>
