### PR TITLE
Enable RSpecRails/InferredSpecType and drop redundant spec types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,14 @@ plugins:
   - rubocop-rspec
   - rubocop-rspec_rails
 
+# spec/components is registered as the :component type in rails_helper.rb, so
+# an explicit `type: :component` is redundant. Inferences covers the standard
+# rspec-rails directories; ViewComponent's directory is not one of them.
+RSpecRails/InferredSpecType:
+  Enabled: true
+  Inferences:
+    components: component
+
 Layout/LineLength:
   Max: 120
   Exclude:

--- a/spec/components/event_card_component_spec.rb
+++ b/spec/components/event_card_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe EventCardComponent, type: :component do
+RSpec.describe EventCardComponent do
   let(:chapter) { Fabricate(:chapter, active: true) }
 
   context 'with a workshop' do

--- a/spec/controllers/admin/chapters_controller_spec.rb
+++ b/spec/controllers/admin/chapters_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::ChaptersController, type: :controller do
+RSpec.describe Admin::ChaptersController do
   let(:admin) { Fabricate(:member) }
 
   before do

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::EventsController, type: :controller do
+RSpec.describe Admin::EventsController do
   let(:admin) { Fabricate(:member) }
   let(:event) { Fabricate(:event, chapters: [chapter]) }
   let(:chapter) { Fabricate(:chapter) }

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::InvitationsController, type: :controller do
+RSpec.describe Admin::InvitationsController do
   let(:invitation) { Fabricate(:student_workshop_invitation) }
   let(:workshop) { invitation.workshop }
   let(:admin) { Fabricate(:chapter_organiser) }

--- a/spec/controllers/admin/member_notes_controller_spec.rb
+++ b/spec/controllers/admin/member_notes_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::MemberNotesController, type: :controller do
+RSpec.describe Admin::MemberNotesController do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:chapter_organiser) }
   let!(:member_note) { Fabricate(:member_note) }

--- a/spec/controllers/admin/member_search_controller_spec.rb
+++ b/spec/controllers/admin/member_search_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::MemberSearchController, type: :controller do
+RSpec.describe Admin::MemberSearchController do
   let(:member) { Fabricate.build(:member) }
 
   describe 'GET #index' do

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Admin::MembersController, type: :controller do
+RSpec.describe Admin::MembersController do
   describe 'GET #search' do
     let(:admin) { Fabricate(:member) }
     let!(:member_jane) { Fabricate(:member, name: 'Jane', surname: 'Doe', email: 'jane@example.com', pronouns: nil) }

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::SponsorsController, type: :controller do
+RSpec.describe Admin::SponsorsController do
   let(:member) { Fabricate(:member) }
   let(:member1) { Fabricate(:member) }
   let(:address) { Fabricate(:address) }

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::WorkshopsController, type: :controller do
+RSpec.describe Admin::WorkshopsController do
   let!(:workshop) { Fabricate(:workshop) }
   let(:admin) { Fabricate(:member) }
 

--- a/spec/controllers/workshop_invitation_controller_spec.rb
+++ b/spec/controllers/workshop_invitation_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe WorkshopInvitationController, type: :controller do
+RSpec.describe WorkshopInvitationController do
   let(:member) { Fabricate(:member) }
   let(:tutorial) { Fabricate(:tutorial) }
   let(:workshop) { Fabricate(:workshop) }

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Accepting a workshop invitation', type: :feature do
+RSpec.feature 'Accepting a workshop invitation' do
   describe '#workshop' do
     let(:member) { Fabricate(:member) }
     let(:invitation) { Fabricate(:workshop_invitation, member:, tutorial: tutorial.title) }

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Accepting Terms and Conditions', type: :feature do
+RSpec.feature 'Accepting Terms and Conditions' do
   context 'when a user signs up to codebar' do
     before do
       mock_codebar_auth

--- a/spec/features/admin/accessing_portal_spec.rb
+++ b/spec/features/admin/accessing_portal_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'admin portal', type: :feature do
+RSpec.feature 'admin portal' do
   scenario 'non admin cannot access the admin portal' do
     member = Fabricate(:member)
     login(member)

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Add a user to an existing workshop', :js, type: :feature do
+RSpec.describe 'Add a user to an existing workshop', :js do
   let(:member) { Fabricate(:member) }
 
   let!(:juliet) { Fabricate(:member, name: 'Juliet', surname: 'Capulet') }

--- a/spec/features/admin/announcements_spec.rb
+++ b/spec/features/admin/announcements_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Announcements', type: :feature do
+RSpec.feature 'Announcements' do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_groups) }
 

--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Chapter workshop feedback', type: :feature do
+RSpec.feature 'Chapter workshop feedback' do
   it 'is only available to chapter organisers' do
     member = Fabricate(:member)
     chapter = Fabricate(:chapter)

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Chapters', type: :feature do
+RSpec.feature 'Chapters' do
   let(:member) { Fabricate(:member) }
 
   context 'with authorization smoke test' do

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Event creation', type: :feature do
+RSpec.feature 'Event creation' do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter) }
 

--- a/spec/features/admin/feedback_spec.rb
+++ b/spec/features/admin/feedback_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Viewing feedback', type: :feature do
+RSpec.feature 'Viewing feedback' do
   let(:member) { Fabricate(:member) }
 
   context 'when an admin' do

--- a/spec/features/admin/filtering_sponsors_list_spec.rb
+++ b/spec/features/admin/filtering_sponsors_list_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Admin filtering sponsors list', type: :feature do
+RSpec.feature 'Admin filtering sponsors list' do
   let(:manager) { Fabricate(:member) }
 
   before do

--- a/spec/features/admin/groups_spec.rb
+++ b/spec/features/admin/groups_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'admin groups', type: :feature do
+RSpec.feature 'admin groups' do
   describe '#show page' do
     let(:member) { Fabricate(:member) }
     let(:chapter) { Fabricate(:chapter, name: 'Brighton') }

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing events', type: :feature do
+RSpec.feature 'Managing events' do
   let(:member) { Fabricate(:member) }
   let!(:event) { Fabricate(:event, confirmation_required: true) }
 

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing sponsors', type: :feature do
+RSpec.feature 'Managing sponsors' do
   let(:member) { Fabricate(:member) }
 
   before do

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'managing workshop attendances', type: :feature do
+RSpec.feature 'managing workshop attendances' do
   context 'when an admin' do
     let(:member) { Fabricate(:member) }
     let(:chapter) { Fabricate(:chapter) }

--- a/spec/features/admin/managing_meeting_invitations_spec.rb
+++ b/spec/features/admin/managing_meeting_invitations_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing meeting invitations', type: :feature do
+RSpec.feature 'Managing meeting invitations' do
   let(:admin) { Fabricate(:member) }
   let(:meeting) { Fabricate(:meeting) }
 

--- a/spec/features/admin/managing_organisers_spec.rb
+++ b/spec/features/admin/managing_organisers_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing organisers', type: :feature do
+RSpec.feature 'Managing organisers' do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_organiser) }
 

--- a/spec/features/admin/managing_testimonials_spec.rb
+++ b/spec/features/admin/managing_testimonials_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing testimonials', type: :feature do
+RSpec.feature 'Managing testimonials' do
   let(:member) { Fabricate(:member) }
 
   scenario 'non admin cannot manage testimonials' do

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing meetings', type: :feature do
+RSpec.feature 'Managing meetings' do
   let(:member) { Fabricate(:member) }
   let!(:venue) { Fabricate(:sponsor) }
   let(:today) { Time.zone.now }

--- a/spec/features/admin/member_search_spec.rb
+++ b/spec/features/admin/member_search_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'admin member search', type: :feature do
+RSpec.feature 'admin member search' do
   scenario 'search returns single member to requesting service' do
     Fabricate(:member, name: 'Romeo', surname: 'Montague')
     Fabricate(:member, name: 'Juliet', surname: 'Capulet')

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Admin managing members', type: :feature do
+RSpec.describe 'Admin managing members' do
   let(:member) do
     Fabricate(:student, dietary_restrictions: %w[vegan other],
                         other_dietary_restrictions: 'peanut allergy')

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Admin::Sponsors', type: :feature do
+RSpec.feature 'Admin::Sponsors' do
   let(:manager) { Fabricate(:member) }
 
   before do

--- a/spec/features/admin/tom_select_member_lookup_spec.rb
+++ b/spec/features/admin/tom_select_member_lookup_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Admin TomSelect Member Lookup', :js, type: :feature do
+RSpec.describe 'Admin TomSelect Member Lookup', :js do
   let(:admin) { Fabricate(:member) }
   let!(:member_jane) { Fabricate(:member, name: 'Jane', surname: 'Doe', email: 'jane@example.com') }
 

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'An admin managing workshops', type: :feature do
+RSpec.feature 'An admin managing workshops' do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }
   let!(:sponsor) { Fabricate(:sponsor) }

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'viewing a Chapter', type: :feature do
+RSpec.feature 'viewing a Chapter' do
   context 'with non-active chapters' do
     let(:inactive_chapter) { Fabricate(:chapter, active: false) }
 

--- a/spec/features/coach_accepting_invitation_spec.rb
+++ b/spec/features/coach_accepting_invitation_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'a Coach can', type: :feature do
+RSpec.feature 'a Coach can' do
   describe '#workshop' do
     let(:member) { Fabricate(:member) }
     let(:invitation) { Fabricate(:coach_workshop_invitation, member:) }

--- a/spec/features/internationalization_spec.rb
+++ b/spec/features/internationalization_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Internationalization', type: :feature do
+RSpec.feature 'Internationalization' do
   after do
     I18n.locale = :en
   end

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'when visiting the coaches page', type: :feature do
+RSpec.feature 'when visiting the coaches page' do
   scenario 'I can see the most active coaches' do
     # Use a past workshop date in the current year to ensure the coach is counted
     workshop = Fabricate(:workshop, date_and_time: Time.zone.today.beginning_of_year + 1.month)

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'event listing', type: :feature do
+RSpec.feature 'event listing' do
   describe 'I can see upcoming events' do
     let!(:chapter) { Fabricate(:chapter, active: true) }
     let!(:event) { Fabricate(:event) }

--- a/spec/features/manage_contact_preferences_spec.rb
+++ b/spec/features/manage_contact_preferences_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing contact preferences', type: :feature do
+RSpec.feature 'Managing contact preferences' do
   context 'when a sponsor contact can manage their contact preferences' do
     let(:manager) { Fabricate(:member) }
 

--- a/spec/features/managing_workshop_attendance_spec.rb
+++ b/spec/features/managing_workshop_attendance_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing workshop attendance', type: :feature do
+RSpec.feature 'Managing workshop attendance' do
   let(:coach) { Fabricate(:coach) }
   let(:student) { Fabricate(:student) }
 

--- a/spec/features/member/login_spec.rb
+++ b/spec/features/member/login_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Member logging in', type: :feature do
+RSpec.feature 'Member logging in' do
   let(:member) { Fabricate(:member) }
 
   describe 'Sign up' do

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'member feedback', type: :feature do
+RSpec.feature 'member feedback' do
   let(:feedback_request) { Fabricate(:feedback_request) }
   let(:valid_token) { feedback_request.token }
   let(:submited_token) { Fabricate(:feedback_request, submited: true).token }

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'A new student signs up', type: :feature do
+RSpec.feature 'A new student signs up' do
   before do
     mock_codebar_auth
   end

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Member portal', type: :feature do
+RSpec.feature 'Member portal' do
   subject { page }
 
   let(:member) { Fabricate(:member) }

--- a/spec/features/member_updating_details_spec.rb
+++ b/spec/features/member_updating_details_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Update your details', type: :feature do
+RSpec.feature 'Update your details' do
   before do
     mock_codebar_auth
   end

--- a/spec/features/sponsors_spec.rb
+++ b/spec/features/sponsors_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Sponsors', type: :feature do
+RSpec.feature 'Sponsors' do
   context 'when viewing the listing' do
     scenario 'can see a listing of all non expired job posts' do
       gold_sponsor = Fabricate.create(:sponsor, level: :gold)

--- a/spec/features/subscribing_to_emails_spec.rb
+++ b/spec/features/subscribing_to_emails_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Managing subscriptions', type: :feature do
+RSpec.feature 'Managing subscriptions' do
   let(:member) { Fabricate(:member) }
   let!(:group) { Fabricate(:group) }
 

--- a/spec/features/subscribing_to_newsletter_spec.rb
+++ b/spec/features/subscribing_to_newsletter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Subscribing to the newsletter', type: :feature do
+RSpec.feature 'Subscribing to the newsletter' do
   before do
     OmniAuth.config.mock_auth[:codebar] = OmniAuth::AuthHash.new(
       provider: 'codebar',

--- a/spec/features/view_event_spec.rb
+++ b/spec/features/view_event_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'viewing an event', type: :feature do
+RSpec.feature 'viewing an event' do
   let(:closed_event) { Fabricate(:event, confirmation_required: true, surveys_required: true) }
   let(:open_event) { Fabricate(:event, confirmation_required: false, surveys_required: false) }
 

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'viewing a meeting', type: :feature do
+RSpec.feature 'viewing a meeting' do
   let!(:meeting) { Fabricate(:meeting) }
 
   context 'when a visitor' do

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Viewing a workshop invitation', :wip, type: :feature do
+RSpec.feature 'Viewing a workshop invitation', :wip do
   let(:invitation) { Fabricate(:workshop_invitation, workshop:) }
 
   before do

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Viewing a workshop page', type: :feature do
+RSpec.feature 'Viewing a workshop page' do
   context 'when a visitor' do
     before do
       visit workshop_path(workshop)

--- a/spec/features/viewing_pages_spec.rb
+++ b/spec/features/viewing_pages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'A visitor to the website', type: :feature do
+RSpec.feature 'A visitor to the website' do
   scenario 'can access and view the cookie policy' do
     visit root_path
 

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'when visiting the homepage', type: :feature do
+RSpec.feature 'when visiting the homepage' do
   let!(:next_workshop) { Fabricate(:workshop) }
   let!(:events) { Fabricate.times(3, :event) }
 

--- a/spec/helpers/email_header_helper_spec.rb
+++ b/spec/helpers/email_header_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe EmailHeaderHelper, type: :helper do
+RSpec.describe EmailHeaderHelper do
   before do
     EmailHeaderHelper.module_eval { public :mail_to_member }
   end

--- a/spec/views/dashboard/show.html.haml_spec.rb
+++ b/spec/views/dashboard/show.html.haml_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'dashboard/show.html.haml', type: :view do
+RSpec.describe 'dashboard/show.html.haml' do
   let(:chapters) { Fabricate.times(2, :chapter) }
   let(:upcoming_workshops) { {} }
   let(:testimonials) { [] }


### PR DESCRIPTION
Enables the RuboCop cop that flags spec type metadata RSpec already infers from the file path, so redundant `type: :model`-style tags never need manual review again.

- Enable RSpecRails/InferredSpecType (it ships pending) and register `components: component` in its Inferences, since ViewComponent specs are outside the rspec-rails defaults
- Autocorrect the 56 offenses it found across 56 spec files (removal of the redundant `type:` pair from `RSpec.describe`)

Details:

<details><summary>Why this is safe here</summary>

The cop assumes `config.infer_spec_type_from_file_location!` is enabled, which this repo does in `spec/rails_helper.rb` - including the custom `spec/components` mapping registered before inference runs, and `config.include ViewComponent::TestHelpers, type: :component`, which keys off the inferred type. Removing the explicit tag therefore changes nothing at runtime. The full suite passes (1308 examples, 0 failures) and RuboCop is clean with the cop enabled.
</details>

Motivation: reviewer feedback on #2844 pointed out redundant `type: :component` metadata; this makes the linter catch it permanently.