### PR TITLE
Fix intermittent login navigation race in feature specs

### DIFF
--- a/spec/support/helpers/login_helpers.rb
+++ b/spec/support/helpers/login_helpers.rb
@@ -15,6 +15,11 @@ module LoginHelpers
       mock_auth_hash(provider: member.auth_services.first.provider,
                      uid: member.auth_services.first.uid)
       visit '/auth/codebar'
+      # visit returns once the OAuth redirect chain has committed navigation, but
+      # a following request can still race the chain and resolve to its landing
+      # page instead. Wait for the member nav (only rendered when logged in) so
+      # the session is fully established before the caller navigates on.
+      expect(page).to have_css('#navbarDropdownMenuLinkMember')
     else
       ApplicationController.prepend(LoginStub) unless ApplicationController < LoginStub
       LoginStub.current_user = member


### PR DESCRIPTION
Fixes an intermittent feature-spec failure where a request issued straight after `login(member)` resolved to the OAuth chain's landing page instead of the requested path.

Observed in #2846's CI run (34213281043): `accepting_terms_and_conditions_spec.rb` expected `/dashboard` after `visit dashboard_path` but got `/` - the page the auth redirect chain lands on. The run was not deterministic: the same job passed on re-run and the full suite passed four times locally with CI's seed (8255).

Root cause: `LoginHelpers#login` returns once `visit '/auth/codebar'` has committed navigation, but the OAuth redirect chain can still be in flight. A `visit` issued immediately after can race it and land on the chain's destination instead of the requested path.

Fix: `login()` now waits for `#navbarDropdownMenuLinkMember` - the member nav toggle, rendered only once the session is established - before returning. The wait resolves as soon as the chain settles, so it adds no measurable time to passing runs.

Details:

<details><summary>Why this fix point</summary>

`login()` is the shared helper for all feature specs, so fixing it there covers the whole flake class rather than only the spec that happened to fail. Verified: the targeted spec passes 5/5 runs with CI's seed, and the full suite passes with the change (1308 examples, 0 failures). RuboCop clean.
</details>