### PR TITLE
Fix timeline tick labels and calendar-day health counts

### DIFF
--- a/app/components/admin/dashboard/workshop_timeline_component.html.erb
+++ b/app/components/admin/dashboard/workshop_timeline_component.html.erb
@@ -8,7 +8,7 @@
     <line x1="<%= tick_x %>" y1="14" x2="<%= tick_x %>" y2="70" stroke="#dee2e6" stroke-width="1" />
     <% if (ticks_ago % 2).zero? %>
       <text x="<%= tick_x %>" y="86" font-size="9" fill="#6c757d" text-anchor="middle">
-        <%= (range_start + (ticks_ago * 30).days).to_fs(:short) %>
+        <%= (Time.zone.today - (ticks_ago * 30).days).to_fs(:short) %>
       </text>
     <% end %>
   <% end %>

--- a/app/services/admin/dashboard/chapter_health.rb
+++ b/app/services/admin/dashboard/chapter_health.rb
@@ -40,11 +40,13 @@ module Admin
         private
 
         def recency_days(date)
-          date && ((Time.zone.now - date) / 1.day).floor
+          # calendar-day difference, so "yesterday 23:00" reads as 1 day ago
+          date && (Time.zone.today - date.to_date).to_i
         end
 
         def countdown_days(date)
-          date && ((date - Time.zone.now) / 1.day).ceil
+          # calendar-day difference, so "tomorrow 18:30" reads as 1 day away
+          date && (date.to_date - Time.zone.today).to_i
         end
 
         def median_cadence(dates) # rubocop:disable Metrics/AbcSize

--- a/spec/components/admin/dashboard/workshop_timeline_component_spec.rb
+++ b/spec/components/admin/dashboard/workshop_timeline_component_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Admin::Dashboard::WorkshopTimelineComponent do
     expect(page).to have_css("line[stroke-dasharray][x1='667']")
   end
 
+  it 'labels past ticks with dates counting back from today' do
+    render_inline(described_class.new(past: [], future: []))
+
+    # the tick under the today line is today; the leftmost labelled tick is
+    # 180 days back. Labels are dates only (no midnight times).
+    expect(page).to have_css('text', text: Time.zone.today.to_fs(:short))
+    expect(page).to have_css('text', text: (Time.zone.today - 180.days).to_fs(:short))
+    expect(page).to have_no_text('00:00')
+  end
+
   it 'places a filled marker for each held workshop with a date tooltip' do
     past = [5.months.ago, 2.months.ago]
 

--- a/spec/services/admin/dashboard/chapter_health_spec.rb
+++ b/spec/services/admin/dashboard/chapter_health_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe Admin::Dashboard::ChapterHealth do
       expect(row.days_until_next_workshop).to eq(10)
     end
 
+    it 'counts the next workshop in calendar days, not elapsed 24-hour blocks' do
+      chapter = Fabricate(:chapter)
+      Fabricate(:workshop, chapter:, date_and_time: 1.day.from_now.change(hour: 18, min: 30))
+
+      row = described_class.row(chapter:)
+
+      expect(row.days_until_next_workshop).to eq(1)
+    end
+
     it 'returns nil days_since_last_workshop with no past workshops' do
       chapter = Fabricate(:chapter)
 


### PR DESCRIPTION
Two Chapter Health card bugs against production data, both in the timeline/tile maths rather than the data:

- The tick under the today line was labelled 12 Mar 00:00 - the start of the 180-day window, not today. Past-side ticks were drawn counting back from today but labelled counting forward from the window start, so every label sat opposite its position (labels ran 10 Jul, 11 May, 12 Mar left to right). Each tick is now labelled with its own date (today minus its offset), which also removes the spurious 00:00 the Time-based short format appended. The axis now reads 12 Mar at the left edge, 08 Sep under the today line, 07 Dec at the right edge.
- "Previous workshop: 12 days ago" / "Next workshop: 2 days away" were floor/ceil of elapsed duration: a workshop tomorrow at 18:30 counted as 2 days away, and a workshop 11 calendar days back could read as 10. Both counters now use calendar-day differences, matching how humans count ("tomorrow 18:30" = 1 day away).

#### Before

<img width="923" height="488" alt="image" src="https://github.com/user-attachments/assets/e6902c01-2a37-404e-949d-309f6deda1d8" />

#### After
<img width="895" height="366" alt="image" src="https://github.com/user-attachments/assets/c2cdc98b-e303-492f-957e-1f363131a817" />


Details:

<details><summary>Verification</summary>

- Component/service/controller specs updated and green (121 examples), including new regressions: tick labels ascend from today, no 00:00 on labels, and a tomorrow-18:30 workshop counts as 1 day away.
- Rendered the component against the production dump: labels x=0 "12 Mar" ... x=667 "08 Sep" ... x=1000 "07 Dec"; chapter 1 reports 11 days ago / 5 days away.
- Full RuboCop clean.
</details>