### PR TITLE
fix: make blank-name members findable in admin search

### DIFF
--- a/app/assets/javascripts/admin/tom-select-init.js
+++ b/app/assets/javascripts/admin/tom-select-init.js
@@ -23,6 +23,9 @@
         render: {
           option: function(item, escape) {
             return '<div>' + escape(item.full_name) + ' <small class="text-muted">' + escape(item.email) + '</small></div>';
+          },
+          item: function(item, escape) {
+            return '<div>' + escape(item.full_name || item.email) + '</div>';
           }
         }
       });
@@ -54,6 +57,9 @@
           option: function(item, escape) {
             return '<div>' + escape(item.full_name) + ' <small class="text-muted">' + escape(item.email) + '</small></div>';
           },
+          item: function(item, escape) {
+            return '<div>' + escape(item.full_name || item.email) + '</div>';
+          },
           no_results: function() {
             return '<div class="no-results">No members found</div>';
           }
@@ -83,6 +89,9 @@
         render: {
           option: function(item, escape) {
             return '<div>' + escape(item.full_name) + ' <small class="text-muted">' + escape(item.email) + '</small></div>';
+          },
+          item: function(item, escape) {
+            return '<div>' + escape(item.full_name || item.email) + '</div>';
           },
           no_results: function() {
             return '<div class="no-results">No members found</div>';

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -104,7 +104,7 @@ class Member < ApplicationRecord
   end
 
   def name_and_surname
-    [name, surname].compact.join ' '
+    [name, surname].map(&:presence).compact.join(' ').presence || email
   end
 
   def full_name
@@ -207,7 +207,7 @@ class Member < ApplicationRecord
     # a bare '%' matches everything and a trailing backslash raises 'LIKE pattern must
     # not end with escape character'.
     escaped = name.gsub(/[%_\\]/) { |char| "\\#{char}" }
-    where("CONCAT(name, ' ', surname) ILIKE ?", "%#{escaped}%")
+    where("CONCAT(name, ' ', surname) ILIKE ? OR email ILIKE ?", "%#{escaped}%", "%#{escaped}%")
   end
 
   private

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -225,6 +225,12 @@ RSpec.describe Member do
       end
     end
 
+    describe 'search by email' do
+      it 'finds the member' do
+        expect(described_class.find_members_by_name(member.email).first).to eq(member)
+      end
+    end
+
     describe 'search bar is empty' do
       it 'returns no members' do
         Fabricate(:member)
@@ -244,6 +250,17 @@ RSpec.describe Member do
         result = described_class.find_members_by_name('back\\')
         expect(result.map(&:surname)).to include('Back\\')
       end
+    end
+  end
+
+  describe '#name_and_surname' do
+    it 'returns name and surname' do
+      expect(member.name_and_surname).to eq("#{member.name} #{member.surname}")
+    end
+
+    it 'falls back to email when name and surname are blank' do
+      member = Fabricate.build(:member, name: '', surname: '')
+      expect(member.name_and_surname).to eq(member.email)
     end
   end
 


### PR DESCRIPTION
Members who sign up via OAuth with no GitHub name (e.g. GitHub profiles without a public name) end up with blank name and surname. Their profiles were effectively unreachable from the admin area: the member search picker matched names only, search results rendered an invisible link (empty `name_and_surname` returned `' '`), and the TomSelect directory showed an empty value after picking one.

- `Member#name_and_surname` falls back to email when name and surname are blank
- `Member.find_members_by_name` matches email as well as name, matching what `/admin/members/search` (Members Directory) already does
- TomSelect lookups render the email for the selected item when `full_name` is blank

## Review notes

- The `name_and_surname` fallback is the riskiest change: the method is also used in admin workshop activity views, so a blank-name member now appears there as their email
- Email matching in `find_members_by_name` means pickers embedded in other admin pages return email hits where they previously showed none
- Deliberately not done: no change to `full_name` (member-facing, used in mailers and invitations), no name presence validation (root cause is `Member#active?` being false during OAuth signup, tracked as future work)

<details>
<summary>Background: how this was found</summary>

An organiser reported a member who signed up with no name and whose profile could not be opened from admin search. Investigation of the production dump found a member created that day via the codebar OAuth provider whose GitHub profile has no public name: blank name and surname, no chapter subscriptions. `AuthServicesController#create` falls back to `''` for the name, and `Member#active?` (presence-validation gate) is `auth_services.exists?`, which is false for the unsaved association at signup time — so the presence validations are skipped exactly when they would be needed. Prevention and remediation tooling (admin list of incomplete profiles, nudge emails) are noted as future work, out of scope here.

</details>
