### PR TITLE
Record member session activity in the activities log

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,6 +103,8 @@ class ApplicationController < ActionController::Base
   end
 
   def logout!
+    member = current_user
+    MemberActivityRecorder.record(actor: member, key: 'member.logout') if member
     @current_member = nil
     reset_session
   end

--- a/app/controllers/auth_services_controller.rb
+++ b/app/controllers/auth_services_controller.rb
@@ -19,10 +19,7 @@ class AuthServicesController < ApplicationController
       end
       redirect_to root_path
     elsif current_service
-      session[:member_id] = current_service.member.id
-      session[:service_id]         = current_service.id
-      session[:oauth_token]        = omnihash[:credentials][:token]
-      session[:oauth_token_secret] = omnihash[:credentials][:secret]
+      sign_in!(current_service.member, current_service)
 
       finish_registration || redirect_to(referer_or_dashboard_path)
     else
@@ -59,10 +56,7 @@ class AuthServicesController < ApplicationController
           new_member = false
         end
 
-        session[:member_id]          = member.id
-        session[:service_id]         = member_service.id
-        session[:oauth_token]        = omnihash[:credentials][:token]
-        session[:oauth_token_secret] = omnihash[:credentials][:secret]
+        sign_in!(member, member_service)
 
         if member.requires_additional_details?
           session[:new_member] = new_member
@@ -74,10 +68,12 @@ class AuthServicesController < ApplicationController
   end
 
   def destroy
-    service = current_user.services.find(params[:id])
+    service = current_user.auth_services.find(params[:id])
     if service.respond_to?(:destroy) && service.destroy
       flash[:notice] = I18n.t('notifications.provider_unlinked',
                               provider: service.provider)
+      MemberActivityRecorder.record(actor: current_user, key: 'auth_service.removed',
+                                    trackable: service)
       redirect_to redirect_path
     end
   end
@@ -88,6 +84,15 @@ class AuthServicesController < ApplicationController
   end
 
   private
+
+  def sign_in!(member, auth_service)
+    session[:member_id]          = member.id
+    session[:service_id]         = auth_service.id
+    session[:oauth_token]        = omnihash[:credentials][:token]
+    session[:oauth_token_secret] = omnihash[:credentials][:secret]
+
+    MemberActivityRecorder.record(actor: member, key: 'member.login')
+  end
 
   def member_from_github_id
     return unless omnihash[:provider] == 'codebar'
@@ -111,6 +116,6 @@ class AuthServicesController < ApplicationController
   end
 
   def redirect_path
-    :services
+    root_path
   end
 end

--- a/app/services/member_activity_recorder.rb
+++ b/app/services/member_activity_recorder.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Single funnel for member-activity rows on the public_activity `activities` table.
+# Explicit call sites only — no model callbacks — so nothing is double-logged.
+# Recording is observability: persistence failures are logged, never raised.
+class MemberActivityRecorder
+  # Key vocabulary in use; extend when adding sites. New keys classify as :active in the strip.
+  KEYS = %w[
+    member.login
+    member.logout
+    member.checked_in
+    member_note.created
+    member.banned
+    profile.updated
+    toc.accepted
+    auth_service.removed
+    subscription.created
+    subscription.removed
+    subscription.admin_updated
+    mailing_list.subscribe
+    mailing_list.unsubscribe
+    event_invitation.rsvp
+    event_invitation.rejected
+    meeting_invitation.rsvp
+    meeting_invitation.cancelled
+    workshop_invitation.rsvp
+    workshop_invitation.rejected
+    waiting_list.joined
+    waiting_list.left
+    organiser_role.granted
+    organiser_role.revoked
+    invitation.send_batch
+    invitation.rsvp_override
+    invitation.verified
+    workshop.created
+    meeting_invitation.created
+    meeting_invitation.updated
+  ].freeze
+
+  def self.record(actor:, key:, trackable: nil, recipient: nil)
+    Rails.logger.warn("MemberActivityRecorder: unregistered key '#{key}'") unless KEYS.include?(key)
+    trackable ||= actor
+    PublicActivity::Activity.create!(owner: actor, key:, trackable:, recipient:)
+  rescue StandardError => e
+    Rails.logger.warn("MemberActivityRecorder failed (#{key}): #{e.class}: #{e.message}")
+  end
+end

--- a/spec/requests/member_login_activity_spec.rb
+++ b/spec/requests/member_login_activity_spec.rb
@@ -1,4 +1,3 @@
-# spec/requests/member_login_activity_spec.rb
 require 'rails_helper'
 
 RSpec.describe 'Member login activity' do

--- a/spec/requests/member_login_activity_spec.rb
+++ b/spec/requests/member_login_activity_spec.rb
@@ -1,0 +1,21 @@
+# spec/requests/member_login_activity_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Member login activity' do
+  it 'records member.login on the existing auth service path' do
+    member = Fabricate(:member, email: 'existing-login@example.com')
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'login-uid-1')
+
+    mock_auth_hash(provider: 'github', uid: 'login-uid-1', email: member.email)
+    post '/auth/github/callback'
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'member.login')).to be(true)
+  end
+
+  it 'records member.login when the callback creates a new member' do
+    mock_auth_hash(provider: 'github', uid: 'brand-new-uid', email: 'fresh-login@example.com')
+
+    expect { post '/auth/github/callback' }
+      .to change { PublicActivity::Activity.where(key: 'member.login').count }.by(1)
+  end
+end

--- a/spec/requests/member_logout_activity_spec.rb
+++ b/spec/requests/member_logout_activity_spec.rb
@@ -1,4 +1,3 @@
-# spec/requests/member_logout_activity_spec.rb
 require 'rails_helper'
 
 RSpec.describe 'Member logout activity' do

--- a/spec/requests/member_logout_activity_spec.rb
+++ b/spec/requests/member_logout_activity_spec.rb
@@ -1,0 +1,15 @@
+# spec/requests/member_logout_activity_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Member logout activity' do
+  it 'records member.logout before clearing the session' do
+    member = Fabricate(:member, email: 'logout@example.com')
+    Fabricate(:auth_service, member:, provider: 'github', uid: 'logout-uid-1')
+    mock_auth_hash(provider: 'github', uid: 'logout-uid-1', email: member.email)
+    post '/auth/github/callback'
+
+    expect { delete '/logout' }
+      .to change { PublicActivity::Activity.exists?(owner: member, key: 'member.logout') }
+      .from(false).to(true)
+  end
+end

--- a/spec/services/member_activity_recorder_spec.rb
+++ b/spec/services/member_activity_recorder_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MemberActivityRecorder do
+  let(:member) { Fabricate(:member) }
+
+  it 'creates an activity row owned by the actor' do
+    described_class.record(actor: member, key: 'member.login')
+
+    activity = PublicActivity::Activity.find_by(owner: member)
+    expect(activity.key).to eq('member.login')
+  end
+
+  it 'stores trackable and recipient' do
+    other = Fabricate(:member)
+
+    described_class.record(actor: member, key: 'member.banned', recipient: other)
+
+    activity = PublicActivity::Activity.order(:created_at).last
+    expect(activity.recipient).to eq(other)
+    # trackable defaults to actor when nil
+    expect(activity.trackable).to eq(member)
+  end
+
+  it 'never raises on persistence failure' do
+    allow(PublicActivity::Activity).to receive(:create!)
+      .and_raise(ActiveRecord::RecordInvalid)
+    allow(Rails.logger).to receive(:warn)
+
+    expect { described_class.record(actor: member, key: 'member.login') }.not_to raise_error
+    expect(Rails.logger).to have_received(:warn).with(/MemberActivityRecorder failed/)
+  end
+
+  it 'warns when a key is outside the documented vocabulary' do
+    allow(Rails.logger).to receive(:warn)
+
+    described_class.record(actor: member, key: 'unknown.key')
+
+    expect(PublicActivity::Activity.exists?(owner: member, key: 'unknown.key')).to be(true)
+    expect(Rails.logger).to have_received(:warn).with(/unregistered key 'unknown.key'/)
+  end
+end


### PR DESCRIPTION
## Summary

First of a stacked series that records member, organiser, and admin activity in the existing public_activity `activities` table. This PR adds the recorder — the single funnel every later PR calls — and instruments the session lifecycle: `member.login` via a shared `sign_in!` funnel in `AuthServicesController#create` (both OAuth branches), `member.logout` in `ApplicationController#logout!`, and `auth_service.removed` on provider unlink. Design: `docs/organiser-activity` side branch (spec: 2026-09-07-organiser-activity-strip-design).

## Key changes

- `MemberActivityRecorder.record(actor:, key:, trackable:, recipient:)` — one row per action, owner = acting member; persistence failures are logged, never raised, so recording cannot break a user flow.
- `sign_in!` refactor: the two session-setting branches in `AuthServicesController#create` funnel through one private method; session behaviour unchanged (existing OAuth callback specs pass).
- The provider-unlink action is instrumented but stays unreachable — its route addition was deliberately reverted; enabling it is a separate product decision.

## Review notes

Focus first on the `sign_in!` refactor (session behaviour must be identical) and the recorder's `trackable ||= actor` fallback (public_activity validates trackable presence; self-referential rows are intentional). Deliberately not done: no backfill — history starts at deploy.

Stack: PR 2 adds subscription/profile activity -> PR 3 RSVPs -> PR 4 admin actions -> PR 5 workshops/batches -> PR 6 the admin activity strip.


---

Context and motivation: #2857
