### PR TITLE
Add missing require 'rails_helper' to spec files

### DIFF
--- a/spec/controllers/admin/announcements_controller_spec.rb
+++ b/spec/controllers/admin/announcements_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::AnnouncementsController do
   let(:member) { Fabricate(:member) }
   let(:announcement) { Fabricate(:announcement) }

--- a/spec/controllers/admin/bans_controller_spec.rb
+++ b/spec/controllers/admin/bans_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::BansController do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:member) }

--- a/spec/controllers/admin/chapters_controller_spec.rb
+++ b/spec/controllers/admin/chapters_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::ChaptersController, type: :controller do
   let(:admin) { Fabricate(:member) }
 

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::EventsController, type: :controller do
   let(:admin) { Fabricate(:member) }
   let(:event) { Fabricate(:event, chapters: [chapter]) }

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::InvitationsController, type: :controller do
   let(:invitation) { Fabricate(:student_workshop_invitation) }
   let(:workshop) { invitation.workshop }

--- a/spec/controllers/admin/meetings_controller_spec.rb
+++ b/spec/controllers/admin/meetings_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::MeetingsController do
   let(:member) { Fabricate(:member) }
   let(:meeting) { Fabricate(:meeting) }

--- a/spec/controllers/admin/member_notes_controller_spec.rb
+++ b/spec/controllers/admin/member_notes_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::MemberNotesController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:admin) { Fabricate(:chapter_organiser) }

--- a/spec/controllers/admin/member_search_controller_spec.rb
+++ b/spec/controllers/admin/member_search_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::MemberSearchController, type: :controller do
   let(:member) { Fabricate.build(:member) }
 

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::SponsorsController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:member1) { Fabricate(:member) }

--- a/spec/controllers/admin/workshop_invitation_logs_controller_spec.rb
+++ b/spec/controllers/admin/workshop_invitation_logs_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::WorkshopInvitationLogsController do
   let(:workshop) { Fabricate(:workshop) }
   let(:admin) { Fabricate(:member).tap { |m| m.add_role(:admin) } }

--- a/spec/controllers/admin/workshops_controller_spec.rb
+++ b/spec/controllers/admin/workshops_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Admin::WorkshopsController, type: :controller do
   let!(:workshop) { Fabricate(:workshop) }
   let(:admin) { Fabricate(:member) }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ApplicationController do
   describe '#render_not_found' do
     controller do

--- a/spec/controllers/auth_services_controller_spec.rb
+++ b/spec/controllers/auth_services_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe AuthServicesController do
   describe 'GET #new' do
     it 'redirects when referer is missing' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe EventsController do
   describe '#fetch_upcoming_events' do
     context 'when no events exist' do

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe FeedbackController do
   let(:feedback_request) { Fabricate(:feedback_request) }
   let(:coach) { Fabricate(:coach) }

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe InvitationsController do
   let(:event) { Fabricate(:event) }
 

--- a/spec/controllers/member/details_controller_spec.rb
+++ b/spec/controllers/member/details_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Member::DetailsController do
   render_views
   let(:member) { Fabricate(:member) }

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MembersController do
   describe 'GET unsubscribe/#token' do
     it 'redirects to the subscription path when token is valid' do

--- a/spec/controllers/waiting_lists_controller_spec.rb
+++ b/spec/controllers/waiting_lists_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WaitingListsController do
   let(:workshop) { Fabricate(:workshop) }
   let(:invitation) { Fabricate(:workshop_invitation, workshop:) }

--- a/spec/controllers/workshop_invitation_controller_spec.rb
+++ b/spec/controllers/workshop_invitation_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopInvitationController, type: :controller do
   let(:member) { Fabricate(:member) }
   let(:tutorial) { Fabricate(:tutorial) }

--- a/spec/controllers/workshops_controller_spec.rb
+++ b/spec/controllers/workshops_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopsController do
   let(:member) { Fabricate(:member) }
   let(:workshop) { Fabricate(:workshop) }

--- a/spec/features/accepting_invitation_spec.rb
+++ b/spec/features/accepting_invitation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Accepting a workshop invitation', type: :feature do
   describe '#workshop' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/accepting_terms_and_conditions_spec.rb
+++ b/spec/features/accepting_terms_and_conditions_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Accepting Terms and Conditions', type: :feature do
   context 'when a user signs up to codebar' do
     before do

--- a/spec/features/admin/accessing_portal_spec.rb
+++ b/spec/features/admin/accessing_portal_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'admin portal', type: :feature do
   scenario 'non admin cannot access the admin portal' do
     member = Fabricate(:member)

--- a/spec/features/admin/add_user_to_workshop_spec.rb
+++ b/spec/features/admin/add_user_to_workshop_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'Add a user to an existing workshop', :js, type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/announcements_spec.rb
+++ b/spec/features/admin/announcements_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Announcements', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_groups) }

--- a/spec/features/admin/chapter/feedback_spec.rb
+++ b/spec/features/admin/chapter/feedback_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Chapter workshop feedback', type: :feature do
   it 'is only available to chapter organisers' do
     member = Fabricate(:member)

--- a/spec/features/admin/chapters_spec.rb
+++ b/spec/features/admin/chapters_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Chapters', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Event creation', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter) }

--- a/spec/features/admin/feedback_spec.rb
+++ b/spec/features/admin/feedback_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Viewing feedback', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/filtering_sponsors_list_spec.rb
+++ b/spec/features/admin/filtering_sponsors_list_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Admin filtering sponsors list', type: :feature do
   let(:manager) { Fabricate(:member) }
 

--- a/spec/features/admin/groups_spec.rb
+++ b/spec/features/admin/groups_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'admin groups', type: :feature do
   describe '#show page' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing events', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:event) { Fabricate(:event, confirmation_required: true) }

--- a/spec/features/admin/manage_sponsor_spec.rb
+++ b/spec/features/admin/manage_sponsor_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing sponsors', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/manage_workshop_attendances_spec.rb
+++ b/spec/features/admin/manage_workshop_attendances_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'managing workshop attendances', type: :feature do
   context 'when an admin' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/admin/managing_meeting_invitations_spec.rb
+++ b/spec/features/admin/managing_meeting_invitations_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing meeting invitations', type: :feature do
   let(:admin) { Fabricate(:member) }
   let(:meeting) { Fabricate(:meeting) }

--- a/spec/features/admin/managing_organisers_spec.rb
+++ b/spec/features/admin/managing_organisers_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing organisers', type: :feature do
   let(:member) { Fabricate(:member) }
   let(:chapter) { Fabricate(:chapter_with_organiser) }

--- a/spec/features/admin/managing_testimonials_spec.rb
+++ b/spec/features/admin/managing_testimonials_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing testimonials', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/admin/meeting_spec.rb
+++ b/spec/features/admin/meeting_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing meetings', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:venue) { Fabricate(:sponsor) }

--- a/spec/features/admin/member_search_spec.rb
+++ b/spec/features/admin/member_search_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'admin member search', type: :feature do
   scenario 'search returns single member to requesting service' do
     Fabricate(:member, name: 'Romeo', surname: 'Montague')

--- a/spec/features/admin/members_spec.rb
+++ b/spec/features/admin/members_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'Admin managing members', type: :feature do
   let(:member) do
     Fabricate(:student, dietary_restrictions: %w[vegan other],

--- a/spec/features/admin/sponsor_spec.rb
+++ b/spec/features/admin/sponsor_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Admin::Sponsors', type: :feature do
   let(:manager) { Fabricate(:member) }
 

--- a/spec/features/admin/workshops_spec.rb
+++ b/spec/features/admin/workshops_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'An admin managing workshops', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:chapter) { Fabricate(:chapter) }

--- a/spec/features/chapter_spec.rb
+++ b/spec/features/chapter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'viewing a Chapter', type: :feature do
   context 'with non-active chapters' do
     let(:inactive_chapter) { Fabricate(:chapter, active: false) }

--- a/spec/features/coach_accepting_invitation_spec.rb
+++ b/spec/features/coach_accepting_invitation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'a Coach can', type: :feature do
   describe '#workshop' do
     let(:member) { Fabricate(:member) }

--- a/spec/features/internationalization_spec.rb
+++ b/spec/features/internationalization_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Internationalization', type: :feature do
   after do
     I18n.locale = :en

--- a/spec/features/listing_coaches_spec.rb
+++ b/spec/features/listing_coaches_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'when visiting the coaches page', type: :feature do
   scenario 'I can see the most active coaches' do
     # Use a past workshop date in the current year to ensure the coach is counted

--- a/spec/features/listing_events_spec.rb
+++ b/spec/features/listing_events_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'event listing', type: :feature do
   describe 'I can see upcoming events' do
     let!(:chapter) { Fabricate(:chapter, active: true) }

--- a/spec/features/manage_contact_preferences_spec.rb
+++ b/spec/features/manage_contact_preferences_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing contact preferences', type: :feature do
   context 'when a sponsor contact can manage their contact preferences' do
     let(:manager) { Fabricate(:member) }

--- a/spec/features/managing_workshop_attendance_spec.rb
+++ b/spec/features/managing_workshop_attendance_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing workshop attendance', type: :feature do
   let(:coach) { Fabricate(:coach) }
   let(:student) { Fabricate(:student) }

--- a/spec/features/member/login_spec.rb
+++ b/spec/features/member/login_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Member logging in', type: :feature do
   let(:member) { Fabricate(:member) }
 

--- a/spec/features/member_feedback_spec.rb
+++ b/spec/features/member_feedback_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'member feedback', type: :feature do
   let(:feedback_request) { Fabricate(:feedback_request) }
   let(:valid_token) { feedback_request.token }

--- a/spec/features/member_joining_spec.rb
+++ b/spec/features/member_joining_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'A new student signs up', type: :feature do
   before do
     mock_codebar_auth

--- a/spec/features/member_portal_spec.rb
+++ b/spec/features/member_portal_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Member portal', type: :feature do
   subject { page }
 

--- a/spec/features/member_updating_details_spec.rb
+++ b/spec/features/member_updating_details_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Update your details', type: :feature do
   before do
     mock_codebar_auth

--- a/spec/features/sponsors_spec.rb
+++ b/spec/features/sponsors_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Sponsors', type: :feature do
   context 'when viewing the listing' do
     scenario 'can see a listing of all non expired job posts' do

--- a/spec/features/subscribing_to_emails_spec.rb
+++ b/spec/features/subscribing_to_emails_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Managing subscriptions', type: :feature do
   let(:member) { Fabricate(:member) }
   let!(:group) { Fabricate(:group) }

--- a/spec/features/subscribing_to_newsletter_spec.rb
+++ b/spec/features/subscribing_to_newsletter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Subscribing to the newsletter', type: :feature do
   before do
     OmniAuth.config.mock_auth[:codebar] = OmniAuth::AuthHash.new(

--- a/spec/features/view_event_spec.rb
+++ b/spec/features/view_event_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'viewing an event', type: :feature do
   let(:closed_event) { Fabricate(:event, confirmation_required: true, surveys_required: true) }
   let(:open_event) { Fabricate(:event, confirmation_required: false, surveys_required: false) }

--- a/spec/features/viewing_a_meeting_spec.rb
+++ b/spec/features/viewing_a_meeting_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'viewing a meeting', type: :feature do
   let!(:meeting) { Fabricate(:meeting) }
 

--- a/spec/features/viewing_a_workshop_invitation_spec.rb
+++ b/spec/features/viewing_a_workshop_invitation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Viewing a workshop invitation', :wip, type: :feature do
   let(:invitation) { Fabricate(:workshop_invitation, workshop:) }
 

--- a/spec/features/viewing_a_workshop_spec.rb
+++ b/spec/features/viewing_a_workshop_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'Viewing a workshop page', type: :feature do
   context 'when a visitor' do
     before do

--- a/spec/features/viewing_pages_spec.rb
+++ b/spec/features/viewing_pages_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'A visitor to the website', type: :feature do
   scenario 'can access and view the cookie policy' do
     visit root_path

--- a/spec/features/visiting_homepage_spec.rb
+++ b/spec/features/visiting_homepage_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.feature 'when visiting the homepage', type: :feature do
   let!(:next_workshop) { Fabricate(:workshop) }
   let!(:events) { Fabricate.times(3, :event) }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ApplicationHelper do
   describe '#contact_email' do
     it "returns the workshop chapter's email" do

--- a/spec/helpers/email_header_helper_spec.rb
+++ b/spec/helpers/email_header_helper_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe EmailHeaderHelper, type: :helper do
   before do
     EmailHeaderHelper.module_eval { public :mail_to_member }

--- a/spec/lib/services/flodesk_spec.rb
+++ b/spec/lib/services/flodesk_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 require 'json'
 require 'flodesk'
 

--- a/spec/lib/services/mailing_list_spec.rb
+++ b/spec/lib/services/mailing_list_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 require 'json'
 require 'services/mailing_list'
 

--- a/spec/lib/tasks/delete_member_rake_spec.rb
+++ b/spec/lib/tasks/delete_member_rake_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'rake member:delete', type: :task do
   let!(:member) { Fabricate.create(:member) }
 

--- a/spec/lib/tasks/feedback_rake_spec.rb
+++ b/spec/lib/tasks/feedback_rake_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'rake feedback:request', type: :task do
   context 'when most recent workshop has attendances' do
     it 'preloads the Rails environment' do

--- a/spec/lib/tasks/mailing_list_rake_spec.rb
+++ b/spec/lib/tasks/mailing_list_rake_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'rake mailing_list:subscribe_active_members', type: :task do
   it 'preloads the Rails environment' do
     expect(task.prerequisites).to include 'environment'

--- a/spec/lib/tasks/reminders_meeting_rake_spec.rb
+++ b/spec/lib/tasks/reminders_meeting_rake_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'rake reminders:meeting', type: :task do
   it 'preloads the Rails environment' do
     expect(task.prerequisites).to include 'environment'

--- a/spec/lib/tasks/reminders_workshop_rake_spec.rb
+++ b/spec/lib/tasks/reminders_workshop_rake_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'rake reminders:workshop', type: :task do
   it 'preloads the Rails environment' do
     expect(task.prerequisites).to include 'environment'

--- a/spec/lib/verifier_spec.rb
+++ b/spec/lib/verifier_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 require 'verifier'
 
 RSpec.describe Verifier do

--- a/spec/mailers/event_invitation_mailer_spec.rb
+++ b/spec/mailers/event_invitation_mailer_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe EventInvitationMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:event) { Fabricate(:event, date_and_time: Time.zone.local(2017, 11, 12, 10, 0), name: 'Test event') }

--- a/spec/mailers/feedback_request_mailer_spec.rb
+++ b/spec/mailers/feedback_request_mailer_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe FeedbackRequestMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/meeting_invitation_mailer_spec.rb
+++ b/spec/mailers/meeting_invitation_mailer_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MeetingInvitationMailer do
   let(:meeting) { Fabricate(:meeting) }
   let(:member) { Fabricate(:member) }

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MemberMailer do
   let(:member) { Fabricate(:member) }
 

--- a/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/virtual_workshop_invitation_mailer_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe VirtualWorkshopInvitationMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop) }

--- a/spec/mailers/workshop_invitation_mailer_spec.rb
+++ b/spec/mailers/workshop_invitation_mailer_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopInvitationMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:workshop) { Fabricate(:workshop, title: 'HTML & CSS') }

--- a/spec/models/attendance_warning_spec.rb
+++ b/spec/models/attendance_warning_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe AttendanceWarning do
   describe '#create' do
     let(:member) { Fabricate(:member) }

--- a/spec/models/ban_spec.rb
+++ b/spec/models/ban_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Ban do
   context 'with validates' do
     it { is_expected.to validate_presence_of(:expires_at) }

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Chapter do
   it { is_expected.to validate_presence_of(:city) }
   it { is_expected.to validate_length_of(:description).is_at_most(280) }

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Listable do
   subject(:workshop) { Fabricate(:workshop) }
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Contact do
   subject(:contact) { Fabricate.build(:contact) }
 

--- a/spec/models/eligibility_inquiry_spec.rb
+++ b/spec/models/eligibility_inquiry_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe EligibilityInquiry do
   describe '#create' do
     let(:member) { Fabricate(:member) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Event do
   subject(:event) { Fabricate(:event) }
 

--- a/spec/models/feedback_request_spec.rb
+++ b/spec/models/feedback_request_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe FeedbackRequest do
   subject { Fabricate(:feedback_request) }
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feedback do
   subject(:feedback) { Fabricate.build(:feedback) }
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Group do
   subject(:group) { Fabricate.build(:group) }
 

--- a/spec/models/invitation_log_spec.rb
+++ b/spec/models/invitation_log_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe InvitationLog do
   describe 'associations' do
     it { is_expected.to belong_to(:loggable) }

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Invitation do
   it_behaves_like InvitationConcerns, :invitation, :event
 

--- a/spec/models/meeting_invitation_spec.rb
+++ b/spec/models/meeting_invitation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MeetingInvitation do
   it_behaves_like InvitationConcerns, :meeting_invitation, :meeting
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Meeting do
   include_examples 'Invitable', :meeting_invitation, :meeting
   include_examples DateTimeConcerns, :meeting

--- a/spec/models/member_note_spec.rb
+++ b/spec/models/member_note_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MemberNote do
   context 'with mandatory attributes' do
     it 'Requires a note' do

--- a/spec/models/member_permissions_spec.rb
+++ b/spec/models/member_permissions_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Member do
   subject(:member) { Fabricate(:member) }
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Member do
   let(:member) { Fabricate(:member) }
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Role do
   context 'with scopes' do
     let(:student_role) { Fabricate(:student_role) }

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Sponsor do
   subject(:sponsor) { Fabricate.build(:sponsor) }
 

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Tutorial do
   subject(:tutorial) { Fabricate.build(:tutorial) }
 

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WaitingList do
   let(:workshop) { Fabricate(:workshop) }
 

--- a/spec/models/workshop_invitation_spec.rb
+++ b/spec/models/workshop_invitation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopInvitation do
   subject(:workshop_invitation) { Fabricate(:workshop_invitation) }
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Workshop do
   subject(:workshop) { Fabricate(:workshop) }
 

--- a/spec/models/workshop_sponsor_spec.rb
+++ b/spec/models/workshop_sponsor_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopSponsor do
   subject(:workshop_sponsor) { Fabricate.build(:workshop_sponsor) }
 

--- a/spec/policies/admin_portal_policy_spec.rb
+++ b/spec/policies/admin_portal_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe AdminPortalPolicy do
   subject(:policy) { described_class.new(user, :admin_portal) }
 

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ApplicationPolicy do
   subject(:policy) { described_class.new(user, record) }
 

--- a/spec/policies/chapter_policy_spec.rb
+++ b/spec/policies/chapter_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ChapterPolicy do
   subject(:policy) { described_class.new(user, chapter) }
 

--- a/spec/policies/contact_policy_spec.rb
+++ b/spec/policies/contact_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ContactPolicy do
   subject(:policy) { described_class.new(user, contact) }
 

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe EventPolicy do
   subject(:policy) { described_class.new(user, event) }
 

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GroupPolicy do
   subject(:policy) { described_class.new(user, group) }
 

--- a/spec/policies/member_note_policy_spec.rb
+++ b/spec/policies/member_note_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MemberNotePolicy do
   subject(:policy) { described_class.new(user, member_note) }
 

--- a/spec/policies/organiser_policy_spec.rb
+++ b/spec/policies/organiser_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe OrganiserPolicy do
   subject(:policy) { described_class.new(user, organiser) }
 

--- a/spec/policies/sponsor_policy_spec.rb
+++ b/spec/policies/sponsor_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe SponsorPolicy do
   subject(:policy) { described_class.new(user, sponsor) }
 

--- a/spec/policies/testimonial_policy_spec.rb
+++ b/spec/policies/testimonial_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe TestimonialPolicy do
   subject(:policy) { described_class.new(user, testimonial) }
 

--- a/spec/policies/workshop_policy_spec.rb
+++ b/spec/policies/workshop_policy_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopPolicy do
   subject(:policy) { described_class.new(user, workshop) }
 

--- a/spec/presenters/address_presenter_spec.rb
+++ b/spec/presenters/address_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe AddressPresenter do
   let(:address) { Fabricate.build(:address) }
   let(:presenter) { described_class.new(address) }

--- a/spec/presenters/chapter_presenter_spec.rb
+++ b/spec/presenters/chapter_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ChapterPresenter do
   let(:chapter) { Fabricate(:chapter_without_organisers) }
   let(:presenter) { described_class.new(chapter) }

--- a/spec/presenters/contact_presenter_spec.rb
+++ b/spec/presenters/contact_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ContactPresenter do
   let(:contact_presenter) { described_class.new(contact) }
   let(:contact) { Fabricate(:contact) }

--- a/spec/presenters/event_presenter_spec.rb
+++ b/spec/presenters/event_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe EventPresenter do
   let(:workshop) { Fabricate(:workshop) }
   let(:event) { described_class.new(workshop) }

--- a/spec/presenters/how_you_found_us_presenter_spec.rb
+++ b/spec/presenters/how_you_found_us_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe HowYouFoundUsPresenter do
   def add_member(group, how)
     member = Fabricate(:member, how_you_found_us: how)

--- a/spec/presenters/invitation_presenter_spec.rb
+++ b/spec/presenters/invitation_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe InvitationPresenter do
   let(:invitation) { Fabricate(:student_workshop_invitation) }
   let(:invitation_presenter) { described_class.new(invitation) }

--- a/spec/presenters/meeting_presenter_spec.rb
+++ b/spec/presenters/meeting_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MeetingPresenter do
   let(:meeting) { Fabricate(:meeting) }
   let(:event) { described_class.new(meeting) }

--- a/spec/presenters/member_presenter_spec.rb
+++ b/spec/presenters/member_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MemberPresenter do
   let(:member) { Fabricate(:member, skill_list: 'java, ruby') }
   let(:member_presenter) { described_class.new(member) }

--- a/spec/presenters/sponsor_presenter_spec.rb
+++ b/spec/presenters/sponsor_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe SponsorPresenter do
   let(:sponsor_presenter) { described_class.new(sponsor) }
   let(:sponsor) { Fabricate(:sponsor, contacts:) }

--- a/spec/presenters/virtual_workshop_presenter_spec.rb
+++ b/spec/presenters/virtual_workshop_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe VirtualWorkshopPresenter do
   def double_workshop(attending_coaches:, attending_students:)
     instance_double(Workshop, coach_spaces: 3, student_spaces: 5, chapter:,

--- a/spec/presenters/workshop_presenter_spec.rb
+++ b/spec/presenters/workshop_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopPresenter do
   let(:chapter) { Fabricate(:chapter) }
   let(:host) { Fabricate(:sponsor, seats: 5, number_of_coaches: 15) }

--- a/spec/queriers/admin_workshop_attendee_flags_spec.rb
+++ b/spec/queriers/admin_workshop_attendee_flags_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe AdminWorkshopAttendeeFlags do
   subject(:flags) { described_class.for_members([member.id])[member.id] }
 

--- a/spec/queries/dashboard_query_spec.rb
+++ b/spec/queries/dashboard_query_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe DashboardQuery do
   describe '.upcoming_events' do
     it 'returns an empty hash when there are no upcoming events' do

--- a/spec/queries/sponsors_search_spec.rb
+++ b/spec/queries/sponsors_search_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe SponsorsSearch do
   describe 'initialization' do
     it 'configures its properties from the param hash' do

--- a/spec/serializers/workshop_calendar_spec.rb
+++ b/spec/serializers/workshop_calendar_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe WorkshopCalendar do
   let(:invitation_url) { Faker::Internet.url }
 

--- a/spec/services/auditor_spec.rb
+++ b/spec/services/auditor_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'Auditor::Audit' do
   let(:sponsor) { Fabricate.build(:sponsor) }
   let(:member) { Fabricate(:member) }

--- a/spec/services/chapter_creation_service_spec.rb
+++ b/spec/services/chapter_creation_service_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ChapterCreationService do
   let(:valid_params) do
     {

--- a/spec/services/invitation_manager_logging_spec.rb
+++ b/spec/services/invitation_manager_logging_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe InvitationManager, :invitation_logging do
   subject(:manager) { described_class.new }
 

--- a/spec/services/invitation_manager_spec.rb
+++ b/spec/services/invitation_manager_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe InvitationManager do
   subject(:manager) { described_class.new }
 

--- a/spec/services/three_month_email_service_spec.rb
+++ b/spec/services/three_month_email_service_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ThreeMonthEmailService, type: :service do
   describe '#send_chaser' do
     subject(:call) { described_class.send_chaser }


### PR DESCRIPTION
## Summary

Adds `require 'rails_helper'` to the 135 spec files that were missing it. Single-file runs previously depended on an implicit load chain: `.rspec` requires `spec_helper`, and `spec/spec_helper.rb` requires `config/environment`. That line could disappear during a refactor and break every spec run individually.

- 135 of 160 spec files affected, mostly under `spec/models/`, `spec/services/`, and `spec/presenters/`
- Change is mechanical: prepend `require 'rails_helper'` plus a blank line, nothing else

Suggested by @olleolleolle in a review comment on #2846. Fixes #2858.

## Review notes

- Diff is wide but uniform — spot-checking any file shows the full change
- Files that already had the require line are untouched
