### PR TITLE
Fix flaky add-all-chapters feature spec

### DIFF
--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Managing events', type: :feature do
 
     find_by_id('event_chapter_ids_chosen').click
     find('.add-all-chapters', text: 'Add to all').click
-    expect(page).to have_no_css('#event_chapter_ids_chosen.chosen-with-drop')
+    expect(page).to have_css('.search-choice', count: Chapter.count)
 
     click_on 'Save'
 


### PR DESCRIPTION
## Summary

Fixes a flaky JavaScript feature spec. `spec/features/admin/manage_event_spec.rb` ("adding all chapters to an event with one click") asserted that the Chosen dropdown closes after clicking "Add to all". That assertion races with Chosen's focus handling and failed in CI (run 34354614220, Group 5), then passed on re-run of the identical commit.

The re-open comes from Chosen's own `input_focus` handler: for multiple selects it schedules `container_mousedown()` 50ms after a focus event on the search field while the dropdown is inactive. That re-opens the dropdown after the add-all click handler's `chosen:close`, and nothing closes it again. All chapters were already selected at that point, and the Save button sits below the dropdown, so the close assertion guarded nothing the scenario depends on.

- Replace the negative `have_no_css` dropdown-closed assertion with a positive one: all chapters render as selected choices
- Selection outcome stays covered; Save and flash assertions unchanged

<details>
<summary>Failure from CI</summary>

```
1) Managing events adding all chapters to an event with one click
   Failure/Error: expect(page).to have_no_css('#event_chapter_ids_chosen.chosen-with-drop')
     expected not to find visible css "#event_chapter_ids_chosen.chosen-with-drop",
     found 1 match: "iste9\net10\nlibero11\nconsequatur12\nAdd to all\niste9\n..."
   # ./spec/features/admin/manage_event_spec.rb:28
```

Note the found match shows all four chapters already selected while the dropdown was open.
</details>
