### PR TITLE
Pin json gem to ~> 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,11 @@ gem 'jwt'
 # vips backend is never loaded.
 gem 'image_processing'
 gem 'mini_magick'
+# json 3.0 breaks ActiveSupport::JSON.decode: json 3.0 made JSON.parse
+# keyword-only, so Rails' JSON.parse(json, options) positional-hash call
+# raises ArgumentError and every session-cookie read fails. Pinned until
+# Rails supports json 3.x (https://github.com/codebar/planner/pull/2864).
+gem 'json', '~> 2.3'
 gem 'mutex_m' # LOCKED: Added because of activesupport 7.0
 gem 'nokogiri'
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -662,6 +662,7 @@ DEPENDENCIES
   image_processing
   irb
   jquery-rails
+  json (~> 2.3)
   jwt
   launchy
   letter_opener


### PR DESCRIPTION
# Pin json gem to ~> 2.3

## Why

Dependabot group PR codebar/planner#2864 is red across all six test groups. The PR body lists four gems (haml, image_processing, bullet, webmock), but the lockfile diff contains a fifth, unadvertised change: `json` 2.21.2 → 3.0.2, a major release pulled in transitively by rubocop's `json >= 2.3` constraint.

json 3.0 (released 2026-09-07) made `JSON.parse` keyword-only and now raises on options it doesn't recognise instead of ignoring them. Rails 8.1's `ActiveSupport::JSON.decode` calls `::JSON.parse(json, options)` with a positional hash. Ruby 4.0 cannot promote an empty positional hash to keywords, so json 3.0.2 raises:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
  json-3.0.2/lib/json/common.rb:296 in 'JSON.parse'
  activesupport-8.1.3.1 .../messages/metadata.rb:129 deserialize_from_json
  actionpack-8.1.3.1 .../cookie_store.rb ... get_cookie
```

Every request that reads the encrypted session cookie crashes, which is why the failure signature (`session.key?` in `ApplicationController#current_user`) appears in nearly every feature and controller spec.

## The fix

Pin `json ~> 2.3` in the Gemfile. The lockfile resolves back to json 2.21.2 and Dependabot will stop bumping it in the ruby-deps group.

## Verification

- Reproduced the CI failures locally on the #2864 branch (`spec/features/member_joining_spec.rb`: 4/4 failing with the same `ArgumentError`).
- With the pin added (and #2864's four bumps still applied), those specs pass again, plus all 203 controller/request specs.
- On this branch: `member_joining_spec.rb` 4 examples, 0 failures.

Once Rails supports json 3.x, drop the pin.
