### PR TITLE
Fix event edit form dropping organisers on save

### DIFF
--- a/app/views/admin/events/_form.html.haml
+++ b/app/views/admin/events/_form.html.haml
@@ -46,7 +46,7 @@
     .col-12.col-md-6.col-lg-4
       = f.association :gold_sponsors, input_html: { data: { placeholder: 'Select gold sponsors' }}, collection: all_sponsors
     .col-12
-      = f.input :organisers, collection: all_managers, value_method: :id, label_method: :full_name, selected: @event.organisers.pluck(&:id), input_html: { multiple: true }
+      = f.input :organisers, collection: all_managers, value_method: :id, label_method: :full_name, selected: @event.organisers.pluck(:id), input_html: { multiple: true }
     .col-12
       = f.input :announce_only, as: :boolean, hint: 'Events where invitations are not handled via our application'
     .col-12

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -25,7 +25,9 @@ RSpec.feature 'Managing events' do
 
     find_by_id('event_chapter_ids_chosen').click
     find('.add-all-chapters', text: 'Add to all').click
-    expect(page).to have_css('.search-choice', count: Chapter.count)
+    within('#event_chapter_ids_chosen') do
+      expect(page).to have_css('.search-choice', count: Chapter.count)
+    end
 
     click_on 'Save'
 

--- a/spec/features/admin/manage_event_spec.rb
+++ b/spec/features/admin/manage_event_spec.rb
@@ -33,6 +33,15 @@ RSpec.feature 'Managing events' do
     expect(event.reload.chapter_ids).to match_array(Chapter.ids)
   end
 
+  scenario 'editing an event keeps its existing organisers' do
+    visit edit_admin_event_path(event)
+
+    click_on 'Save'
+
+    expect(page).to have_text('You have just updated the event')
+    expect(event.reload.organisers).to include(member)
+  end
+
   scenario 'verifying an attendance' do
     invitation = Fabricate(:invitation, event:, attending: true)
     visit admin_event_path(event)

--- a/spec/models/concerns/listable_spec.rb
+++ b/spec/models/concerns/listable_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Listable do
   context 'with scopes' do
     describe '#today_and_upcoming' do
       it 'returns a list of all today and upcoming workshops' do
-        travel_to(Time.current) do
+        travel_to(Time.current.middle_of_day) do
           Fabricate.times(2, :past_workshop)
           future_workshops = Fabricate.times(1, :workshop)
 


### PR DESCRIPTION
Fix #2868

Keep an event's existing organisers when editing it, instead of silently clearing all of them on save.

### Why did we do this?
The organisers multi-select on the event edit form never showed existing organisers as selected, even though they were still assigned. Anyone who saved the form without re-picking organisers submitted an empty selection, and the controller dutifully revoked every one of them.

Two more commits fix test correctness issues this change surfaced or depends on:
- The "adding all chapters" feature test asserted on `.search-choice` without scoping it to the chapters widget. That class is shared by every multi-select on the page, so once organisers render correctly (this fix), the assertion started counting the organiser's chip too.
- The `today_and_upcoming` scope spec froze time at the real wall-clock instant and subtracted an hour to simulate "happening now" — if the real run time was within an hour after midnight, that pushed the workshop into the previous day, dropping it from a scope that filters from start-of-day. Unrelated to the organisers fix, but pinned it to noon so it can't cross midnight.

### Will this break anything?
No. The organisers fix only corrects `pluck(&:id)` to `pluck(:id)`, which is what the `selected:` option already expected. The two spec changes only make existing assertions more precise; they don't change any application behavior.

### How was this tested?
**Organisers fix** — captioned screen recordings of the actual edit → save flow against a real admin session, showing the event page (Team section) before editing, the organisers field mid-edit, and the event page again after saving:

Before fix — the organiser is genuinely assigned (Team section shows them), the edit page shows the field with 0 chips selected, and saving without touching it wipes them — the Team section now says "This event has no organisers.":

https://github.com/user-attachments/assets/42106b76-35ff-4625-b349-8ef9ba2be4b5

After fix — the organiser shows as a selected chip on the edit page and survives a save — the Team section still shows them afterward:

https://github.com/user-attachments/assets/5f41fb7b-c1a5-4a8c-b426-4c8fbb9826ee

**`today_and_upcoming` flake** — deterministic reproduction against the real scope and database, travelling to a fixed post-midnight instant (00:15) — real recorded terminal session (animated):

![travel_to repro](https://github.com/user-attachments/assets/d1e5bbf3-431c-4a3c-96a6-75d30e5b6456)

**`.search-choice` scoping** — visible in the after-fix video above: the organiser's chip renders inside `#event_organisers_chosen`, a sibling widget to `#event_chapter_ids_chosen`, which is exactly why the chapters test's unscoped selector needed narrowing.