### PR TITLE
Update CONTRIBUTING setup and test commands to match current README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,26 +8,24 @@
     cd planner
     ```
 
-3. Setup & start the application.
+3. Setup & start the application. See the [Quick start](https://github.com/codebar/planner#quick-start) section of the README for full setup instructions (mise, PostgreSQL, ImageMagick). Once set up:
 
     ```
-    bundle
-    rake db:create db:migrate db:seed
-    rails server
+    bundle exec rails server
     ```
 
 4. Have a look around to get a feel for the app.
 5. Run the tests. We only take pull requests with passing tests, and it's great to confirm that you have a clean slate.
 
     ```
-    rake
+    bundle exec rspec
     ```
 
 6. Add a test for your change - unless you are refactoring or adjusting styles and documentation. If you are adding any functionality or fixing a bug, we need a test!
 7. Implement your change and ensure all the tests pass.
 8. Run Rubocop to ensure you are complying with the Ruby style guide. Refer to (https://rubocop.readthedocs.io/en/latest/) for cops/violation details.
     ```
-    rubocop
+    bundle exec rubocop
     ```
 9. Commit, with a meaningful & descriptive message - this is very important!
 


### PR DESCRIPTION
CONTRIBUTING.md's setup and test/lint commands are inconsistent with what the rest of the repo (README, Makefile, AGENTS.md) actually documents and uses today.

### Why did we do this?
Verified each command directly against this repo before changing anything:
- Step 3's `rake db:create db:migrate db:seed` and bare `rails server` still work once the native toolchain (mise, PostgreSQL, ImageMagick) is installed — but CONTRIBUTING.md never mentions installing that toolchain at all, unlike the README's own "Quick start", which walks through it. A contributor following only this file would hit `pg` gem compile errors with no explanation of why.
- Step 5's bare `rake` does still run the full RSpec suite (confirmed locally) — but serially, with no way to target files, and it's not what the project's own Makefile/README/AGENTS.md document or use (`bundle exec rspec`, `bundle exec parallel_rspec`).
- Step 8's bare `rubocop` happened to work in this session's environment because gems ended up resolvable outside Bundler — not something to rely on across different Ruby version managers. `bundle exec rubocop` is what the rest of the repo's docs consistently use.

None of these commands were actually broken; they were just out of step with the setup this repo has already standardized on elsewhere, which risks confusing a new contributor who reads this file expecting it to be the current source of truth.

### Will this break anything?
No, this only touches documentation.

### How was this tested?
Ran the corrected commands directly in this repo — real recorded terminal sessions (animated):

`bundle exec rubocop`:

![rubocop](https://github.com/user-attachments/assets/bc010ae2-8c55-407b-9b12-a6f1ac18b13a)

`bundle exec rspec` (shown against one fast spec file for a readable capture; the full suite was also run and passes aside from pre-existing, unrelated local-environment gaps):

![rspec](https://github.com/user-attachments/assets/ca1185ec-6ce4-443a-89f7-cb2740897f5f)

For setup, pointed at the README's own "Quick start" section instead of duplicating it here, so the two docs can't independently drift out of sync again.